### PR TITLE
chore: license header cleanup

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/RuleSetWrapper.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/RuleSetWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/SourceLanguage.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/SourceLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageHandler.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageModule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageProcessor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AssignmentOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AssignmentOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BinaryOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BinaryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BooleanOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BooleanOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PostfixOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PostfixOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PrefixOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PrefixOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AbstractAvoidNodeInLoopsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AbstractAvoidNodeInLoopsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/LanguageVersionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/QuickstartRulesetTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/QuickstartRulesetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/RuleSetFactoryTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnumTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnumTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterfaceTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTriggerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTriggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCompilerSoqlTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCompilerSoqlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCompilerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexCompilerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexLexerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParsingHelper.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/AllMetricsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/AllMetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/CognitiveComplexityTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/CognitiveComplexityTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/CycloTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/CycloTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/WmcTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/internal/WmcTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestMethodShouldHaveIsTestAnnotationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestMethodShouldHaveIsTestAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ForLoopsMustUseBracesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ForLoopsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/IfElseStmtsMustUseBracesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/IfElseStmtsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/IfStmtsMustUseBracesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/IfStmtsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/OneDeclarationPerLineTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/OneDeclarationPerLineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/WhileLoopsMustUseBracesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/WhileLoopsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidDirectAccessTriggerMapTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidDirectAccessTriggerMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyCatchBlockTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyCatchBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyStatementBlockTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyStatementBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyTryOrFinallyBlockTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyTryOrFinallyBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyWhileStmtTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyWhileStmtTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TestMethodsMustBeInTestClassesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TestMethodsMustBeInTestClassesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/EagerlyLoadedDescribeSObjectResultTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/EagerlyLoadedDescribeSObjectResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/me/tongfei/progressbar/PmdProgressBarFriend.java
+++ b/pmd-cli/src/main/java/me/tongfei/progressbar/PmdProgressBarFriend.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/PmdCli.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/PmdCli.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractAnalysisPmdSubcommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractAnalysisPmdSubcommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractPmdSubcommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractPmdSubcommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdGuiCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdGuiCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/DesignerCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/DesignerCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdRootCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdRootCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/TreeExportCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/TreeExportCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/mixins/internal/EncodingMixin.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/mixins/internal/EncodingMixin.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/CpdLanguageTypeSupport.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/CpdLanguageTypeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/LanguageTypeSupport.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/LanguageTypeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/NumThreadsConverter.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/NumThreadsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/PmdLanguageTypeSupport.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/PmdLanguageTypeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/PmdLanguageVersionTypeSupport.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/PmdLanguageVersionTypeSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/CliExitCode.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/CliExitCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/BaseCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/BaseCliTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/CpdCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/CpdCliTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/BaseCommandTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/BaseCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/CpdCommandTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/CpdCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/PmdCommandTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/internal/PmdCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/resources/net/sourceforge/pmd/cli/cpd/files/dup1.java
+++ b/pmd-cli/src/test/resources/net/sourceforge/pmd/cli/cpd/files/dup1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/resources/net/sourceforge/pmd/cli/cpd/files/dup2.java
+++ b/pmd-cli/src/test/resources/net/sourceforge/pmd/cli/cpd/files/dup2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/cpd/CocoCpdLexer.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/cpd/CocoCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/InternalApi.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/InternalApi.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AbstractAnalysisCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/CachedRuleMapper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/CachedRuleMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/CachedRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/CachedRuleViolation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ChecksumAware.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ChecksumAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathEntryFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathEntryFingerprinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopFingerprinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyCpdLexer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDNullListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDNullListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVWithLinecountPerFileRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVWithLinecountPerFileRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdLexer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Match.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Match.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchAlgorithm.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchAlgorithm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchCollector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLOldRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLOldRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/CpdLexerBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/CpdLexerBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/JavaccCpdLexer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/JavaccCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ShortFilenameUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ShortFilenameUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractPmdLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractPmdLanguageVersionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageFilenameFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageFilenameFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionDiscoverer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionDiscoverer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/TokenManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/TokenManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/ParseException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/ParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/RootNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/RootNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/SuppressionCommentImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/SuppressionCommentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeParserAdapter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeParserAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BasePmdDialectLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BasePmdDialectLanguageVersionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/LanguageMetricsProvider.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/LanguageMetricsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/Metric.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/Metric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricOption.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricOptions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKey.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RulePriority.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RulePriority.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/impl/UnnecessaryPmdSuppressionRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/impl/UnnecessaryPmdSuppressionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReferenceId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReferenceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleSets.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/XPathRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/XPathRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractNameDeclaration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractNameDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Applier.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Applier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ImageFinderFunction.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ImageFinderFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameDeclaration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameOccurrence.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameOccurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Scope.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Scope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ScopedNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ScopedNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyDescriptor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/PropertyTypeId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/PropertyTypeId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractAccumulatingRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractAccumulatingRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/ColumnDescriptor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/ColumnDescriptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmacsRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmacsRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmptyRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmptyRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/IDEAJRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/IDEAJRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SummaryHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SummaryHTMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextPadRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextPadRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ParametricRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ParametricRuleViolation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleViolation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBMSMetadata.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBMSMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBURI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBURI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/ResourceResolver.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/ResourceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/ResourceLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/FileSelectorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/FileSelectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetSchemaTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetSchemaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleWithProperties.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleWithProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/FileAnalysisCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/AnyCpdLexerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/AnyCpdLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDFilelistTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDFilelistTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CSVRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MatchTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MatchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/TokenEntryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/TokenEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/CpdOnlyDummyLanguage.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/CpdOnlyDummyLanguage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/Dummy2LanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/Dummy2LanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageDialectModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageDialectModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageNoCapabilities.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageNoCapabilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageRegistryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageVersionDiscovererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageVersionDiscovererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/BoundaryTraversalTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/BoundaryTraversalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileCollectorZipTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileCollectorZipTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBaseTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleReferenceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetWriterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReferenceIdTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/RuleSetReferenceIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/symboltable/ApplierTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/symboltable/ApplierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/IDEAJRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/IDEAJRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/RenderersTests.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/RenderersTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextColorRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextColorRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XSLTRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XSLTRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleContextTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleViolationComparatorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleViolationComparatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleViolationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/RuleViolationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBMSMetadataTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBMSMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBURITest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBURITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/ResourceLoaderTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/ResourceLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/ResourceResolverTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/ResourceResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/cpd/files/dup1.txt
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/cpd/files/dup1.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/cpd/files/dup2.txt
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/cpd/files/dup2.txt
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/CpdExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/CpdExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/ExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/ExecutionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/PMDExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/SourceDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/SourceDistributionIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/ZipFileExtractor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/ZipFileExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/DeadLinksChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/DeadLinksChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/DefaultFileWriter.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/DefaultFileWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/EscapeUtils.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/EscapeUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/FileWriter.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/FileWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/GenerateRuleDocsCmd.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/GenerateRuleDocsCmd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleSetUtils.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleSetUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/SidebarGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/EscapeUtilsTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/EscapeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/MockedFileWriter.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/MockedFileWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleDocGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleSetResolverTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleSetResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/SidebarGeneratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/cpd/GherkinCpdLexer.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/cpd/GherkinCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/RuleSetFactoryTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/HtmlParsingHelper.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/HtmlParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/AvoidInlineStylesTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/AvoidInlineStylesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAmbiguousName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAmbiguousName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationMemberList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationMemberList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnonymousClassDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnonymousClassDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArgumentList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArgumentList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAccess.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAllocation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAllocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimExpr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimensions.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayInitializer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayTypeDim.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayTypeDim.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssertStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssertStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBodyDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBodyDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBreakStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBreakStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCastExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCastExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchClause.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTContinueStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTContinueStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTDefaultValue.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTDefaultValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTDoStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTDoStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEmptyStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEmptyStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExplicitConstructorInvocation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExplicitConstructorInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExtendsList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExtendsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldAccess.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFinallyClause.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFinallyClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForInit.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForInit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForUpdate.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForUpdate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForeachStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForeachStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTIfStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTIfStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImplementsList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImplementsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInitializer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLabeledStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLabeledStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValue.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValueArrayInitializer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValueArrayInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleExportsDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleExportsDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleOpensDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleOpensDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleProvidesDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleProvidesDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleRequiresDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleRequiresDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleUsesDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModuleUsesDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPermitsList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPermitsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimaryExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResourceList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResourceList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReturnStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReturnStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatementExpressionList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatementExpressionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSuperExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSuperExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchArrowBranch.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchArrowBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchArrowRHS.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchArrowRHS.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchBranch.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchFallthroughBranch.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchFallthroughBranch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabel.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSynchronizedStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSynchronizedStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThisExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThisExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThrowStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThrowStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTopLevelDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTopLevelDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArguments.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArguments.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableAccess.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVoidType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVoidType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWhileStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWhileStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWildcardType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWildcardType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTYieldStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTYieldStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractExecutableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractExecutableDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaPattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaPattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaTypeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaTypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractPackageNameModuleDirective.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractPackageNameModuleDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeBodyDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeBodyDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Annotatable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Annotatable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AssignmentOp.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AssignmentOp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/BinaryOp.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/BinaryOp.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaVisitorBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaVisitorBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocComment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ReturnScopeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ReturnScopeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/javadoc/JavadocTag.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/javadoc/JavadocTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CognitiveComplexityVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CognitiveComplexityVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NPathMetricCalculator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NPathMetricCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitAssertionsShouldIncludeMessageRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestContainsTooManyAssertsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestContainsTooManyAssertsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GodClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GodClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ExcludeLinesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ExcludeLinesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaParsingHelper.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/LanguageVersionDiscovererTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/LanguageVersionDiscovererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/LanguageVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/PMDCoverageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/PMDTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ReportTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ReportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/RuleSetFactoryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteralTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteralTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTClassTypeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTClassTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTInitializerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTInitializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabelTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTVariableIdTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTVariableIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/AllJavaAstTreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/AllJavaAstTreeDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/EncodingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/EncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java10Test.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java10Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java8Test.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java8Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java8TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java8TreeDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java9TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java9TreeDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/TextBlockEscapeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/TextBlockEscapeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/testdata/InterfaceWithNestedClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/testdata/InterfaceWithNestedClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/internal/JavaViolationDecoratorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/internal/JavaViolationDecoratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsProviderTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/MetricsMemoizationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/MetricsMemoizationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AllMetricsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AllMetricsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AtfdTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AtfdTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CfoTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CfoTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CognitiveComplexityTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CognitiveComplexityTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CycloTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/CycloTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/LocTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/LocTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NPathTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NPathTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NcssTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NcssTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NoamTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NoamTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NopaTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/NopaTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/TccTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/TccTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/WmcTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/WmcTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/WocTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/WocTestRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/GetterDetection.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/GetterDetection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/MetricsVisitorTestData.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/MetricsVisitorTestData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/SetterDetection.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/testdata/SetterDetection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidMessageDigestFieldTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidMessageDigestFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidPrintStackTraceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidPrintStackTraceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidStringBufferFieldTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidStringBufferFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ConstantsInInterfaceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ConstantsInInterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/DefaultLabelNotLastInSwitchTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/DefaultLabelNotLastInSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopVariableCountTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopVariableCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4SuitesShouldUseSuiteAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4SuitesShouldUseSuiteAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/NonExhaustiveSwitchTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/NonExhaustiveSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OneDeclarationPerLineTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OneDeclarationPerLineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceEnumerationWithIteratorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceEnumerationWithIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceHashtableWithMapTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceHashtableWithMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceVectorWithListTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ReplaceVectorWithListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SystemPrintlnTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SystemPrintlnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseAfterAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseAfterAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseBeforeAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseBeforeAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseTestAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldUseTestAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseVarargsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseVarargsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/WhileLoopWithLiteralBooleanTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/WhileLoopWithLiteralBooleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbsClassWithInterface.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbsClassWithInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AmbiguousOverload.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AmbiguousOverload.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CloneableInterface.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CloneableInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CloneableInterfaceOverride.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CloneableInterfaceOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassArrayParams.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassArrayParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassTransitive.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassTransitive.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CovariantReturnType.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CovariantReturnType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithAnonClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithAnonClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithInterfaces.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithInterfaces.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericInterfaceWithOverloads.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericInterfaceWithOverloads.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericWithOverloadsImpl.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericWithOverloadsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/HierarchyWithSeveralBridges.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/HierarchyWithSeveralBridges.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithNoSuperClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithNoSuperClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/Option.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/Option.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/OptionTestCaseOneParam.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/OptionTestCaseOneParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/RunnableImpl.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/RunnableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassPrivateNoOverride.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassPrivateNoOverride.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithGenericMethod.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithGenericMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithStatic.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithStatic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SuperclassWithPrivate.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SuperclassWithPrivate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SuperclassWithStatic.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SuperclassWithStatic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/ClassWithPublicEnum.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/ClassWithPublicEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/DashboardGraphInnateFilter.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/DashboardGraphInnateFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/DashboardInnateFilter.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/DashboardInnateFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidDollarSignsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidDollarSignsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidProtectedFieldInFinalClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidProtectedFieldInFinalClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidProtectedMethodInFinalClassNotExtendingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidProtectedMethodInFinalClassNotExtendingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidUsingNativeCodeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/AvoidUsingNativeCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/BooleanGetMethodNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/BooleanGetMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CallSuperInConstructorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CallSuperInConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ControlStatementBracesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ControlStatementBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyMethodInAbstractClassShouldBeAbstractTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyMethodInAbstractClassShouldBeAbstractTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ExtendsObjectTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ExtendsObjectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ForLoopShouldBeWhileLoopTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ForLoopShouldBeWhileLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/GenericsNamingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/GenericsNamingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalHomeNamingConventionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalHomeNamingConventionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalInterfaceSessionNamingConventionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalInterfaceSessionNamingConventionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LongVariableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LongVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MDBAndSessionBeanNamingConventionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MDBAndSessionBeanNamingConventionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/NoPackageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/NoPackageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/PackageCaseTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/PackageCaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/RemoteInterfaceNamingConventionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/RemoteInterfaceNamingConventionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/RemoteSessionInterfaceNamingConventionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/RemoteSessionInterfaceNamingConventionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortClassNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortClassNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortMethodNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortVariableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ShortVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/TooManyStaticImportsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/TooManyStaticImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryAnnotationValueElementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryAnnotationValueElementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessarySemicolonTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessarySemicolonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseShortArrayInitializerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseShortArrayInitializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseUnderscoresInNumericLiteralsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseUnderscoresInNumericLiteralsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessQualifiedThisTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessQualifiedThisTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/commentdefaultaccessmodifier/OnlyForTesting.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/commentdefaultaccessmodifier/OnlyForTesting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AbstractClassWithoutAnyMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AbstractClassWithoutAnyMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidCatchingGenericExceptionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidCatchingGenericExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNewInstanceOfSameExceptionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNewInstanceOfSameExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingRawExceptionTypesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingRawExceptionTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidUncheckedExceptionsInSignaturesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/AvoidUncheckedExceptionsInSignaturesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CollapsibleIfStatementsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CollapsibleIfStatementsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DataClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DataClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DoNotExtendJavaLangErrorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DoNotExtendJavaLangErrorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/GodClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/GodClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LogicInversionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LogicInversionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/MutableStaticStateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/MutableStaticStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifiedTernaryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifiedTernaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanExpressionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanExpressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/TooManyMethodsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/TooManyMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UseObjectForClearerAPITest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UseObjectForClearerAPITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/donotextendjavalangerror/Error.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/donotextendjavalangerror/Error.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/signaturedeclarethrowsexception/MyTestCase.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/signaturedeclarethrowsexception/MyTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/UncommentedEmptyConstructorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/UncommentedEmptyConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/UncommentedEmptyMethodBodyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/UncommentedEmptyMethodBodyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAssertAsIdentifierTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAssertAsIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCallingFinalizeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCallingFinalizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingNPETest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingNPETest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingThrowableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingThrowableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDecimalLiteralsInBigDecimalConstructorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDecimalLiteralsInBigDecimalConstructorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidEnumAsIdentifierTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidEnumAsIdentifierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingMethodNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidInstanceofChecksInCatchClauseTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidInstanceofChecksInCatchClauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidLiteralsInIfConditionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidLiteralsInIfConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidLosingExceptionInformationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidLosingExceptionInformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidMultipleUnaryOperatorsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidMultipleUnaryOperatorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CallSuperFirstTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CallSuperFirstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CallSuperLastTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CallSuperLastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ClassCastExceptionWithToArrayTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ClassCastExceptionWithToArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustBePublicTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustBePublicTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodReturnTypeMustMatchClassNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodReturnTypeMustMatchClassNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ComparisonWithNaNTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ComparisonWithNaNTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotCallGarbageCollectionExplicitlyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotCallGarbageCollectionExplicitlyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotExtendJavaLangThrowableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotExtendJavaLangThrowableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotHardCodeSDCardTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotHardCodeSDCardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotThrowExceptionInFinallyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotThrowExceptionInFinallyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontImportSunTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontImportSunTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontUseFloatTypeForLoopIndicesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontUseFloatTypeForLoopIndicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EmptyCatchBlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EmptyCatchBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EmptyFinalizerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EmptyFinalizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EqualsNullTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/EqualsNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeDoesNotCallSuperFinalizeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeDoesNotCallSuperFinalizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeOnlyCallsSuperFinalizeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeOnlyCallsSuperFinalizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeOverloadedTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeOverloadedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeShouldBeProtectedTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/FinalizeShouldBeProtectedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/InstantiationToGetClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/InstantiationToGetClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JumbledIncrementerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JumbledIncrementerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MethodWithSameNameAsEnclosingClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MethodWithSameNameAsEnclosingClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MisplacedNullCheckTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MisplacedNullCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDBase.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingStaticMethodInNonInstantiatableClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingStaticMethodInNonInstantiatableClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MyInterface.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MyInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonCaseLabelInSwitchTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonCaseLabelInSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonStaticInitializerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonStaticInitializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperLoggerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperLoggerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnFromFinallyBlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnFromFinallyBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SimpleDateFormatNeedsLocaleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SimpleDateFormatNeedsLocaleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/StaticEJBFieldShouldBeFinalTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/StaticEJBFieldShouldBeFinalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/StringBufferInstantiationWithCharTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/StringBufferInstantiationWithCharTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousEqualsMethodNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousEqualsMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousHashcodeMethodNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousHashcodeMethodNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnconditionalIfStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnconditionalIfStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryBooleanAssertionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryBooleanAssertionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryConversionTemporaryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryConversionTemporaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedNullCheckInEqualsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedNullCheckInEqualsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseCorrectExceptionLoggingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseCorrectExceptionLoggingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseEqualsToCompareStringsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseEqualsToCompareStringsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseLocaleWithCaseConversionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseLocaleWithCaseConversionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseProperClassLoaderTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UseProperClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/CustomStringWriter.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/CustomStringWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedAtMethodLevelTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedAtMethodLevelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidThreadGroupTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidThreadGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidUsingVolatileTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidUsingVolatileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoNotUseThreadsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoNotUseThreadsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DontCallThreadRunTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DontCallThreadRunTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UseConcurrentHashMapTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UseConcurrentHashMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UseNotifyAllInsteadOfNotifyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/UseNotifyAllInsteadOfNotifyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidArrayLoopsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidArrayLoopsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidCalendarDateCreationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidCalendarDateCreationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidFileStreamTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidFileStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/OptimizableToArrayCallTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/OptimizableToArrayCallTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/TooFewBranchesForSwitchTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/TooFewBranchesForSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseArrayListInsteadOfVectorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseArrayListInsteadOfVectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseArraysAsListTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseArraysAsListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ast/FullTypeAnnotations.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ast/FullTypeAnnotations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/cli/EmptyIfStatement.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/cli/EmptyIfStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases17.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases17.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases18.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases18.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/private_method_in_inner_class_interface1.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/private_method_in_inner_class_interface1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/private_method_in_inner_class_interface2.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/private_method_in_inner_class_interface2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/cpd/testdata/StringTemplateReduction2.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/cpd/testdata/StringTemplateReduction2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptLanguageModule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/cpd/TypeScriptCpdLexer.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/cpd/TypeScriptCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/LanguageVersionTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/PMDTaskTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/PMDTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ReportTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ReportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/RuleSetFactoryTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNodeTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatementTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTestBase.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/JsParsingHelper.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/JsParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/AvoidWithStatementTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/AvoidWithStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/GlobalVariableTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/GlobalVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ScopeForInVariableTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ScopeForInVariableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/UseBaseWithParseIntTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/UseBaseWithParseIntTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/AssignmentInOperandTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/AssignmentInOperandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/ForLoopsMustUseBracesTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/ForLoopsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/IfElseStmtsMustUseBracesTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/IfElseStmtsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/IfStmtsMustUseBracesTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/IfStmtsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/NoElseReturnTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/NoElseReturnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryParenthesesTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryParenthesesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnreachableCodeTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnreachableCodeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/WhileLoopsMustUseBracesTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/WhileLoopsMustUseBracesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/AvoidTrailingCommaTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/AvoidTrailingCommaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/EqualComparisonTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/EqualComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/InaccurateNumericLiteralTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/InaccurateNumericLiteralTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/typescript/cpd/TypeScriptCpdLexerTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/typescript/cpd/TypeScriptCpdLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/JspParserTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/JspParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/LanguageVersionTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/RuleSetFactoryTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNodesTst.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNodesTst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspPageStyleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspPageStyleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspParsingHelper.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/OpenTagRegisterTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/OpenTagRegisterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/DontNestJsfInJstlIterationTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/DontNestJsfInJstlIterationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoClassAttributeTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoClassAttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoHtmlCommentsTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoHtmlCommentsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoJspForwardTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/bestpractices/NoJspForwardTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineScriptTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineScriptTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoLongScriptsTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoLongScriptsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoScriptletsTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/design/NoScriptletsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/errorprone/JspEncodingTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/errorprone/JspEncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/security/IframeMissingSrcAttributeTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/security/IframeMissingSrcAttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/cpd/JuliaCpdLexer.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/cpd/JuliaCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/AbstractKotlinRule.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/AbstractKotlinRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinHandler.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinLanguageModule.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/KotlinLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/UnicodeClasses.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/UnicodeClasses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/FunctionNameTooShortTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/FunctionNameTooShortTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaHandler.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaLanguageModule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTClassDefinition.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTClassDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTComponentReference.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTComponentReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTDerClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTDerClassSpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTElementList.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTElementList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTEnumerationShortClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTEnumerationShortClassSpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTExtendingLongClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTExtendingLongClassSpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMultipleDefinitionImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMultipleDefinitionImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTName.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRenamingImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRenamingImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleLongClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleLongClassSpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleShortClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleShortClassSpecifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSingleDefinitionImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSingleDefinitionImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStoredDefinition.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStoredDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTUnqualifiedImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTUnqualifiedImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTWithinClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTWithinClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaClassSpecifierNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaClassSpecifierNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/Helper.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/Helper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/InternalApiBridge.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaClassSpecifierNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaClassSpecifierNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaImportClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ResolvableModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ResolvableModelicaNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/Visibility.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/Visibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/AbstractModelicaDeclaration.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/AbstractModelicaDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/AbstractModelicaScope.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/AbstractModelicaScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/CompositeName.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/CompositeName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/InternalApiBridge.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaBuiltinType.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaBuiltinType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassDeclaration.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassScope.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassSpecialization.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassSpecialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassType.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaClassType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaComponentDeclaration.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaComponentDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaDeclaration.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaScope.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaSourceFileScope.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaSourceFileScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaType.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ResolutionResult.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ResolutionResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ResolvableEntity.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ResolvableEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/RootScope.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/RootScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ScopeAndDeclarationFinder.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ScopeAndDeclarationFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/SubcomponentResolver.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/SubcomponentResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/ResolutionContext.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/ResolutionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/ResolutionState.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/ResolutionState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/Watchdog.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/internal/Watchdog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/LanguageVersionTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/ModelicaParserTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/ModelicaParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/ModelicaParsingHelper.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/ModelicaParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/RuleSetFactoryTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaResolverTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ClassStartNameEqualsEndNameTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ClassStartNameEqualsEndNameTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLLanguageModule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveMethodLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveMethodLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveObjectLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveObjectLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageBodyLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageBodyLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageSpecificationLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageSpecificationLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveTypeLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveTypeLengthRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ClassNameDeclaration.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ClassNameDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodNameDeclaration.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodNameDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/NameFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/NameFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/OccurrenceFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/OccurrenceFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/PLSQLNameOccurrence.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/PLSQLNameOccurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/Search.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/Search.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/SourceFileScope.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/SourceFileScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/SymbolFacade.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/SymbolFacade.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/VariableNameDeclaration.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/VariableNameDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/LanguageVersionDiscovererTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/LanguageVersionDiscovererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/LanguageVersionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLXPathRuleTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLXPathRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/RuleSetFactoryTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTComparisonConditionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTComparisonConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundConditionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundConditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AllPlsqlAstTreeDumpTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AllPlsqlAstTreeDumpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlockTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CreateTableTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CreateTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorAttributesTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorAttributesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorForLoopTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorForLoopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorWithWithTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CursorWithWithTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/DeleteStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/DeleteStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateBulkCollectTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateBulkCollectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/FunctionsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/FunctionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/IfStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/IfStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/InOutNoCopyTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/InOutNoCopyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/InsertIntoClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/InsertIntoClauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/JoinClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/JoinClauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/LexicalParametersTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/LexicalParametersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/OrderByExpressionsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/OrderByExpressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroupTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/RecordTypeTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/RecordTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectForUpdateTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectForUpdateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchicalTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchicalTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoWithGroupByTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoWithGroupByTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectUnionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectUnionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivisionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivisionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TableCollectionExpressionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TableCollectionExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/UpdateStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/UpdateStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WithClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WithClauseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/bestpractices/TomKytesDespairTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/bestpractices/TomKytesDespairTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/ForLoopNamingTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/ForLoopNamingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/MisplacedPragmaTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/MisplacedPragmaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveMethodLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveMethodLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveObjectLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveObjectLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageBodyLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageBodyLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageSpecificationLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessivePackageSpecificationLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveTypeLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveTypeLengthTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssMethodCountTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssMethodCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyMethodsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToDateToCharTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToDateToCharTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToDateWithoutDateFormatTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToDateWithoutDateFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToTimestampWithoutDateFormatTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/errorprone/ToTimestampWithoutDateFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/cpd/ScalaCpdLexer.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/cpd/ScalaCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/cpd/ScalaTokenAdapter.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/cpd/ScalaTokenAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/LanguageVersionTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/RulesetFactoryTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/RulesetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/cpd/ScalaCpdLexerTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/cpd/ScalaCpdLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftHandler.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftLanguageModule.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionRule.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/RuleSetFactoryTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/ProhibitedInterfaceBuilderTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/ProhibitedInterfaceBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/errorprone/ForceCastTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/errorprone/ForceCastTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/errorprone/ForceTryTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/rule/errorprone/ForceTryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/AbstractAntTestHelper.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/AbstractAntTestHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/AbstractLanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/PmdRuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/PmdRuleTst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleTst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/SimpleAggregatorTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/SimpleAggregatorTst.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleTstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/cpd/TSqlCpdLexer.java
+++ b/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/cpd/TSqlCpdLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-tsql/src/test/java/net/sourceforge/pmd/lang/tsql/cpd/TSqlCpdLexerTest.java
+++ b/pmd-tsql/src/test/java/net/sourceforge/pmd/lang/tsql/cpd/TSqlCpdLexerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/DataType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/InternalApiBridge.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/DataTypeTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/DataTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/LanguageVersionDiscovererTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/LanguageVersionDiscovererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/LanguageVersionTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/RuleSetFactoryTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/VFTestUtils.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/VFTestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpressionTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVfTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/OpenTagRegisterTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/OpenTagRegisterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfDocStyleTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfDocStyleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfPageStyleTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfPageStyleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfParsingHelper.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfParsingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlXssStyleTagUrlPatternMatchingTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlXssStyleTagUrlPatternMatchingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlParser.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/antlr4/XMLLexer.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/antlr4/XMLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNode.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/pom/PomDialectModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/pom/PomDialectModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/pom/PomLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/pom/PomLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/wsdl/WsdlDialectModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/wsdl/WsdlDialectModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/wsdl/WsdlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/wsdl/WsdlLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/xsl/XslDialectModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/xsl/XslDialectModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/xsl/XslLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/xsl/XslLanguageModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/LanguageVersionTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/PMDTaskTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/PMDTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/RuleSetFactoryTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/InvalidDependencyTypesTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/InvalidDependencyTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/ProjectVersionAsDependencyVersionTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/ProjectVersionAsDependencyVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/bestpractices/MissingEncodingTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/bestpractices/MissingEncodingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/errorprone/MistypedCDATASectionTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/errorprone/MistypedCDATASectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/xsl/rule/codestyle/UseConcatOnceTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/xsl/rule/codestyle/UseConcatOnceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/xsl/rule/performance/AvoidAxisNavigationTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/xsl/rule/performance/AvoidAxisNavigationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 


### PR DESCRIPTION
## Describe the PR

Unifies the license headers in each file. With https://github.com/pmd/build-tools/pull/81 the license header must be exactly correct.

## Related issues

- See discussion: https://github.com/pmd/pmd/discussions/5875#discussioncomment-13659777


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

