### PR TITLE
Fix #2862: [java] Add rules discouraging the use of java.util.Calendar and java.util.Date

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2438,8 +2438,9 @@ public class Foo {
 
     <rule name="ReplaceJavaUtilCalendar"
           language="java"
-          since="7.16"
+          since="7.16.0"
           message="Usage of java.util.Calendar should be replaced with classes from java.time"
+          minimumLanguageVersion="1.8"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautilcalendar">
         <description>
@@ -2490,15 +2491,16 @@ public class Foo {
 
     <rule name="ReplaceJavaUtilDate"
           language="java"
-          since="7.16"
+          since="7.16.0"
           message="Usage of java.util.Date should be replaced with classes from java.time"
+          minimumLanguageVersion="1.8"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautildate">
         <description>
 The legacy java.util.Date class is mutable, not thread-safe, and has a confusing API. Many of its methods 
 are deprecated, it doesn't handle timezones properly, and it represents both date and time even when only 
 one is needed. The constructor parameters are particularly error-prone: year is "years since 1900" and 
-month is 0-based (January = 0). The modern java.time API provides better type safety, immutability, and clearer semantics.
+month is 0-based (January = 0). The modern java.time API (introduced in Java 8) provides better type safety, immutability, and clearer semantics.
 
 Use LocalDate (date only), LocalTime (time only), LocalDateTime (date and time), Instant (timestamp), 
 or ZonedDateTime (date-time with timezone) from java.time package instead.

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2436,6 +2436,67 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="ReplaceJavaUtilCalendar"
+          language="java"
+          since="7.16"
+          message="Usage of java.util.Calendar should be replaced with classes from java.time"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautilcalendar">
+        <description>
+            Using java.util.Calendar leads to bugs. Use java.time instead.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value><![CDATA[
+                //ClassType[pmd-java:typeIs('java.util.Calendar')]
+                ]]></value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class Foo {
+    void bar() {
+        Calendar c = new GregorianCalendar();
+    }
+}
+]]>
+        </example>
+    </rule>
+
+    <rule name="ReplaceJavaUtilDate"
+          language="java"
+          since="7.16"
+          message="Usage of java.util.Date should be replaced with classes from java.time"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautildate">
+        <description>
+            Using java.util.Date leads to bugs. Use java.time instead.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value><![CDATA[
+                //ClassType[pmd-java:typeIs('java.util.Date')]
+                ]]></value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+import java.util.Date;
+
+public class Foo {
+    void bar() {
+        Date d = new Date();
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="ReturnEmptyCollectionRatherThanNull"
           language="java"
           since="6.37.0"

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2443,7 +2443,11 @@ public class Foo {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautilcalendar">
         <description>
-            Using java.util.Calendar leads to bugs. Use java.time instead.
+The legacy java.util.Calendar API is error-prone, mutable, and not thread-safe. It has confusing month indexing 
+(January = 0), inconsistent field semantics, and verbose usage patterns. The modern java.time API (introduced in Java 8) 
+provides immutable, thread-safe alternatives with clear, intuitive methods.
+
+Use LocalDate (for date-only operations), LocalDateTime (for date and time), or ZonedDateTime (when timezone is important) from java.time package instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -2457,10 +2461,27 @@ public class Foo {
             <![CDATA[
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Foo {
-    void bar() {
-        Calendar c = new GregorianCalendar();
+    void problematic() {
+        // Problematic - using legacy Calendar API
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 15); // Month indexing is confusing (0-based)
+        cal.add(Calendar.DAY_OF_MONTH, 7);
+        
+        Calendar specific = new GregorianCalendar(2024, 0, 15); // Also problematic
+    }
+    
+    void preferred() {
+        // Preferred - using modern java.time API
+        LocalDate date = LocalDate.of(2024, 1, 15); // Month indexing is intuitive (1-based)
+        LocalDate weekLater = date.plusDays(7);
+        
+        LocalDateTime dateTime = LocalDateTime.now();
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
     }
 }
 ]]>
@@ -2474,7 +2495,13 @@ public class Foo {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#replacejavautildate">
         <description>
-            Using java.util.Date leads to bugs. Use java.time instead.
+The legacy java.util.Date class is mutable, not thread-safe, and has a confusing API. Many of its methods 
+are deprecated, it doesn't handle timezones properly, and it represents both date and time even when only 
+one is needed. The constructor parameters are particularly error-prone: year is "years since 1900" and 
+month is 0-based (January = 0). The modern java.time API provides better type safety, immutability, and clearer semantics.
+
+Use LocalDate (date only), LocalTime (time only), LocalDateTime (date and time), Instant (timestamp), 
+or ZonedDateTime (date-time with timezone) from java.time package instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -2487,10 +2514,32 @@ public class Foo {
         <example>
             <![CDATA[
 import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Foo {
-    void bar() {
-        Date d = new Date();
+    void problematic() {
+        // Problematic - using legacy Date API
+        Date now = new Date();
+        Date epoch = new Date(0L);
+        Date custom = new Date(124, 0, 15); // Deprecated constructor: year=1900+124=2024, month=0=January
+        
+        // Mutable operations are error-prone
+        now.setTime(System.currentTimeMillis());
+    }
+    
+    void preferred() {
+        // Preferred - using modern java.time API
+        Instant now = Instant.now(); // For timestamps
+        LocalDate today = LocalDate.now(); // For date only
+        LocalDateTime dateTime = LocalDateTime.now(); // For date and time
+        ZonedDateTime zonedDateTime = ZonedDateTime.now(); // With timezone
+        
+        // Immutable operations are safer
+        LocalDate tomorrow = today.plusDays(1);
+        LocalDateTime nextHour = dateTime.plusHours(1);
     }
 }
 ]]>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2454,7 +2454,10 @@ Use LocalDate (for date-only operations), LocalDateTime (for date and time), or 
         <properties>
             <property name="xpath">
                 <value><![CDATA[
-                //ClassType[pmd-java:typeIs('java.util.Calendar')]
+                //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
+                //FormalParameter[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
+                //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
+                //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Calendar')]]
                 ]]></value>
             </property>
         </properties>
@@ -2509,7 +2512,10 @@ or ZonedDateTime (date-time with timezone) from java.time package instead.
         <properties>
             <property name="xpath">
                 <value><![CDATA[
-                //ClassType[pmd-java:typeIs('java.util.Date')]
+                //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
+                //FormalParameter[ClassType[pmd-java:typeIs('java.util.Date')]] |
+                //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
+                //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Date')]]
                 ]]></value>
             </property>
         </properties>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.test.PmdRuleTst;
 
-public class ReplaceJavaUtilCalendarTest extends PmdRuleTst {
+class ReplaceJavaUtilCalendarTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilCalendarTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class ReplaceJavaUtilCalendarTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.test.PmdRuleTst;
 
-public class ReplaceJavaUtilDateTest extends PmdRuleTst {
+class ReplaceJavaUtilDateTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReplaceJavaUtilDateTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class ReplaceJavaUtilDateTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
@@ -60,4 +60,24 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>don't trigger too many violations when one change fixes all</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+    void bar() {
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault()); // first violation
+        cal.setTimeInMillis(timeNow);
+        cal.set(Calendar.SECOND, 0); // second violation
+        cal.set(Calendar.MILLISECOND, 0); // third
+        cal.set(Calendar.HOUR_OF_DAY, mm); // fourth
+        cal.set(Calendar.MINUTE, mm); // fifth
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>bad, local variable of type java.util.Calendar</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
         <code><![CDATA[
 import java.util.Calendar;
 
@@ -21,6 +22,7 @@ public class Foo {
     <test-code>
         <description>bad, param of type java.util.Calendar</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.util.Calendar;
 
@@ -34,6 +36,7 @@ public class Foo {
     <test-code>
         <description>bad, creating object of type java.util.GregorianCalendar</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
         <code><![CDATA[
 import java.util.GregorianCalendar;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>bad, local variable of type java.util.Calendar</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+    void bar() {
+        Calendar c;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, param of type java.util.Calendar</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+    void bar(Calendar d) {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, creating object of type java.util.GregorianCalendar</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.GregorianCalendar;
+
+public class Foo {
+    void bar() {
+        new GregorianCalendar();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, not java.util.Calendar</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import foo.Calendar;
+
+public class Foo {
+    void bar(Calendar d) {
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>bad, local variable of type java.util.Date</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,5</expected-linenumbers>
         <code><![CDATA[
 import java.util.Date;
 
@@ -21,6 +22,7 @@ public class Foo {
     <test-code>
         <description>bad, param of type java.util.Date</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.util.Date;
 
@@ -34,6 +36,7 @@ public class Foo {
     <test-code>
         <description>bad, param of type java.sql.Date</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.sql.Date;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>bad, local variable of type java.util.Date</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    void bar() {
+        Date d = new Date();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, param of type java.util.Date</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    void bar(Date d) {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, param of type java.sql.Date</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.sql.Date;
+
+public class Foo {
+    void bar(Date d) {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, not java.util.Date</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import foo.Date;
+
+public class Foo {
+    void bar(Date d) {
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Add rules discouraging the use of java.util.Calendar and java.util.Date. Instead, one should use the classes in java.time.

## Related issues

- Fix #2862 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

