### PR TITLE
chore: Fix JUnit warning about invalid test factory

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -54,6 +54,7 @@ It is shipped with the new module `pmd-css`.
 * [#5859](https://github.com/pmd/pmd/pull/5859): Fix #5858: \[java] Fix false positive in FinalFieldCouldBeStatic for array initializers - [Zbynek Konecny](https://github.com/zbynek) (@zbynek)
 * [#5876](https://github.com/pmd/pmd/pull/5876): chore: license header cleanup - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#5883](https://github.com/pmd/pmd/pull/5883): Fix #2862: \[java] Add rules discouraging the use of java.util.Calendar and java.util.Date - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#5894](https://github.com/pmd/pmd/pull/5894): chore: Fix JUnit warning about invalid test factory - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#5895](https://github.com/pmd/pmd/pull/5895): Fix #5597: Move dogfood profile to separate settings.xml - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#5914](https://github.com/pmd/pmd/pull/5914): Fix #5892: \[java] ShortVariable FP for java 22 Unnamed Variable - [Lukas Gräf](https://github.com/lukasgraef) (@lukasgraef)
 

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.annotation.InternalApi
 import org.junit.jupiter.api.Test
 
 /**
- * This is to trick Intellij into making subclasses executable (because of @TestFactory).
+ * This is to trick Intellij into making subclasses executable (because of @Test).
  * But Junit does not use it because of the unsatisfiable condition. This comes from
  * Kotest, but was removed in 4.2.0 without explanation.
  */

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
@@ -5,8 +5,8 @@
 package net.sourceforge.pmd.lang.test.ast
 
 
-import org.junit.jupiter.api.TestFactory
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import net.sourceforge.pmd.annotation.InternalApi
+import org.junit.jupiter.api.Test
 
 /**
  * This is to trick Intellij into making subclasses executable (because of @TestFactory).
@@ -14,8 +14,12 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty
  * Kotest, but was removed in 4.2.0 without explanation.
  */
 interface IntelliMarker {
-    @EnabledIfSystemProperty(named = "wibble", matches = "wobble")
-    @TestFactory
+    @Deprecated("This is not an API")
     fun primer() {
+    }
+
+    @Test
+    @InternalApi
+    fun dummyTestForIntelliJIntegration() {
     }
 }


### PR DESCRIPTION
## Describe the PR

This fixes the following warnings during build (they appeared at some point after a junit upgrade):

```
2025-07-08T17:55:43.6126480Z Jul 08, 2025 5:55:43 PM org.junit.platform.launcher.core.DiscoveryIssueNotifier logIssues
2025-07-08T17:55:43.6127957Z WARNING: TestEngine with ID 'junit-jupiter' encountered 2 non-critical issues during test discovery:
2025-07-08T17:55:43.6129584Z 
2025-07-08T17:55:43.6131442Z (1) [WARNING] @TestFactory method 'public void net.sourceforge.pmd.lang.java.types.SubtypingTest.primer()' must return a single org.junit.jupiter.api.DynamicNode or a Stream, Collection, Iterable, Iterator, Iterator provider, or array of org.junit.jupiter.api.DynamicNode. It will not be executed.
2025-07-08T17:55:43.6133978Z     Source: MethodSource [className = 'net.sourceforge.pmd.lang.java.types.SubtypingTest', methodName = 'primer', methodParameterTypes = '']
2025-07-08T17:55:43.6135380Z             at net.sourceforge.pmd.lang.java.types.SubtypingTest.primer(SourceFile:0)
2025-07-08T17:55:43.6135899Z 
...
```

It seems, that we still need this IntelliMarker, as without it, gutter icons in IntelliJ IDEA won't show up. Also not with the kotest intellij plugin.


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

