### PR TITLE
Fix #5875: [java] PoC: Automated fixing of issues

### DIFF
--- a/docs/pages/pmd/devdocs/contributing/contributing.md
+++ b/docs/pages/pmd/devdocs/contributing/contributing.md
@@ -81,6 +81,19 @@ There are various channels, on which you can ask questions:
 
 *   Ask your question our [PMD Guru at Gurubase](https://gurubase.io/g/pmd).
 
+## 🚀 Code Transformation & Automated Rewriting
+*(Advanced Refactoring, Modernization, and Bulk Code Changes)*
+
+#### 🔧 Automated rewriting of source code to
+- **Refactor** safely (e.g., rename methods, migrate APIs)
+- **Modernize** (e.g., Java 8 → Java 17 features)
+- **Fix anti-patterns** (e.g., replace `Vector` with `ArrayList`)
+- **Enforce conventions** (e.g., JUnit's naming rules)
+
+The build system incorporates [Moderne](https://moderne.io/) rewrite capabilities for automated code transformations. These modifications are environment-driven enlisted in the [junitbuild.java-library-conventions.gradle.kts](gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts)
+
+You can use `mvn rewrite:run` to apply the change or just activate this automatically by setting the env variable `rewriteDogFood=true`.
+
 ## Code Style
 
 PMD uses [Checkstyle](https://checkstyle.org/) to enforce a common code style.
@@ -88,6 +101,8 @@ PMD uses [Checkstyle](https://checkstyle.org/) to enforce a common code style.
 See [pmd-checkstyle-config.xml](https://github.com/pmd/build-tools/blob/main/src/main/resources/net/sourceforge/pmd/pmd-checkstyle-config.xml) for the configuration and
 [the eclipse configuration files](https://github.com/pmd/build-tools/tree/main/eclipse) that can
 be imported into a fresh workspace.
+
+Rewrite will automatically apply all rules, by using the CodeCleanup recipe like in this [showcase](https://docs.openrewrite.org/running-recipes/popular-recipe-guides/automatically-fix-checkstyle-violations). 
 
 ## Add yourself as contributor
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -31,7 +31,7 @@ class SuppressWarningsTest extends ApexParserTestBase {
 
         @Override
         public Object visit(ASTUserClass clazz, Object ctx) {
-            if (clazz.getSimpleName().equalsIgnoreCase("bar")) {
+            if ("bar".equalsIgnoreCase(clazz.getSimpleName())) {
                 asCtx(ctx).addViolation(clazz);
             }
             return super.visit(clazz, ctx);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
@@ -236,7 +236,7 @@ class NodeStreamBlanketTest<T extends Node> {
                 stream.precedingSiblings(),
                 stream.descendantsOrSelf(),
                 stream.children(),
-                stream.children().filter(c -> c.getImage().equals("0")),
+                stream.children().filter(c -> "0".equals(c.getImage())),
                 stream.children(DummyNode.class)
             )
         ).flatMap(

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
@@ -207,7 +207,7 @@ class LatticeRelationTest {
     void testTransitiveSucc() {
 
         LatticeRelation<String, String, Set<String>> lattice =
-            stringLattice(s -> s.equals("c") || s.equals("bc"));
+            stringLattice(s -> "c".equals(s) || "bc".equals(s));
 
         lattice.put("abc", "val");
         lattice.put("bc", "v2");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
@@ -149,7 +149,7 @@ class IteratorUtilTest {
     void testFlatmapIsLazy() {
         Iterator<String> iter = iterOf("a", "b");
         Function<String, Iterator<String>> fun = s -> {
-            if (s.equals("a")) {
+            if ("a".equals(s)) {
                 return iterOf("a");
             } else {
                 throw new AssertionError("This statement shouldn't be reached");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -130,7 +130,7 @@ class XmlTreeRendererTest {
         XmlRenderingConfig strategy = new XmlRenderingConfig() {
             @Override
             public boolean takeAttribute(Node node, Attribute attribute) {
-                return attribute.getName().equals("ohio");
+                return "ohio".equals(attribute.getName());
             }
         }.lineSeparator("\n");
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
@@ -84,13 +84,13 @@ public class TypeAnnotTestUtil {
     @SuppressWarnings("unchecked")
     public static <A extends Annotation> A createAnnotationInstance(Class<A> annotationClass, Map<String, Object> attributes) {
         return (A) Proxy.newProxyInstance(annotationClass.getClassLoader(), new Class[] { annotationClass }, (proxy, method, args) -> {
-            if (method.getName().equals("annotationType") && args == null) {
+            if ("annotationType".equals(method.getName()) && args == null) {
                 return annotationClass;
-            } else if (method.getName().equals("toString") && args == null) {
+            } else if ("toString".equals(method.getName()) && args == null) {
                 return AnnotationUtils.toString((Annotation) proxy);
-            } else if (method.getName().equals("hashCode") && args == null) {
+            } else if ("hashCode".equals(method.getName()) && args == null) {
                 return AnnotationUtils.hashCode((Annotation) proxy);
-            } else if (method.getName().equals("equals") && args.length == 1) {
+            } else if ("equals".equals(method.getName()) && args.length == 1) {
                 if (args[0] instanceof Annotation) {
                     return AnnotationUtils.equals((Annotation) proxy, (Annotation) args[0]);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
         <junit5.version>5.13.3</junit5.version>
         <junit5.platform.version>1.13.3</junit5.platform.version>
         <dokka.version>2.0.0</dokka.version>
+        <rewrite.version>6.12.1</rewrite.version>
+        <rewrite.static.analysis.version>2.12.0</rewrite.static.analysis.version>
 
         <javacc.version>5.0</javacc.version>
         <surefire.version>3.5.3</surefire.version>
@@ -477,6 +479,45 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>${rewrite.version}</version>
+                    <configuration>
+                        <exclusions>
+                            <exclusion>**Chars.java</exclusion> <!-- // @SuppressWarnings("PMD.MissingOverride") -->
+                            <exclusion>**Dummy**.java</exclusion>
+                            <exclusion>**FooRule.java</exclusion>
+                            <exclusion>**jdkversiontests**</exclusion>
+                            <exclusion>**missingoverride**</exclusion>
+                            <exclusion>**private_method_in_inner_class_interface*.java</exclusion>
+                            <exclusion>**testdata**</exclusion>
+                            <exclusion>**unnecessaryimport**</exclusion>
+                            <exclusion>**uselessoverridingmethod**</exclusion>
+                        </exclusions>
+                        <activeRecipes>
+                            <recipe>org.openrewrite.staticanalysis.EqualsAvoidsNull</recipe>
+                            <recipe>org.openrewrite.staticanalysis.ModifierOrder</recipe>
+                        </activeRecipes>
+                        <failOnDryRunResults>true</failOnDryRunResults>
+                        <rewriteSkip>${rewrite.skip}</rewriteSkip>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>dryRun</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-static-analysis</artifactId>
+                            <version>${rewrite.static.analysis.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${checkstyle.plugin.version}</version>
@@ -756,6 +797,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!-- configuration is in plugin management section -->
+            </plugin>
+            <plugin>
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1285,6 +1330,7 @@
             <activation>
                 <property>
                     <name>dogfoodStagingRepo</name>
+                    <value>true</value>
                 </property>
             </activation>
             <build>
@@ -1306,6 +1352,32 @@
                     <snapshots><enabled>true</enabled></snapshots>
                 </pluginRepository>
             </pluginRepositories>
+        </profile>
+
+        <profile>
+            <id>rewriteDogFood</id>
+            <activation>
+                <property>
+                    <name>rewriteDogFood</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openrewrite.maven</groupId>
+                        <artifactId>rewrite-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
## Fix #5875: [java] PoC: Automated fixing of issues

trying to apply:

> To clarify somewhat how I sort your arguments:
> 
> * Desirable things:
>   
>   * Less configuration for new users
>   * More conventional code style (debatable: our code style is not eccentric by any means)
>   * Automated fixing of issues within the IDE
>   * Automated fixing of issues on the command line (debatable: I just want to use the IDE format command)
> * Undesirable things:
>   
>   * Proliferation of tools
>   * Forcing people to run the maven build before push

we call very fast maven goal `run/dryRun` not the expensive `build`.

For simple integration it would be nice if the run goal is executed locally depending on some env-var to configure. 

like `rewriteDogFood` to apply it out of the box.

> * Immaterial things:
>   
>   * Making it easy to change the code style. Once we decide on one, we don't need to follow fashion trends.
>   * Getting rid of Checkstyle just because you perceive it as "old".
>   * Making vim users happy.
>   * Convention over configuration at all cost. Developer tools like IDEs need to be configured to behave how we agree they should, and this configuration must be part of your proposal.



## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- https://github.com/pmd/pmd/discussions/5875
  - https://github.com/pmd/pmd/discussions/5875#discussioncomment-13744680

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

