### PR TITLE
Fix #972: [java] Add a new rule TypeParameterNamingConventions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsRule.java
@@ -1,0 +1,45 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.java.ast.ASTTypeParameter;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
+
+/**
+ * Configurable naming conventions for type parameters.
+ */
+public class TypeParameterNamingConventionsRule extends AbstractNamingConventionRule<ASTTypeParameter> {
+
+    private final PropertyDescriptor<Pattern> typeParameterRegex = defaultProp("typeParameterName", "type parameter").build();
+
+    public TypeParameterNamingConventionsRule() {
+        super(ASTTypeParameter.class);
+        definePropertyDescriptor(typeParameterRegex);
+    }
+
+    @Override
+    public Object visit(ASTTypeParameter node, Object data) {
+        checkMatches(node, typeParameterRegex, data);
+        return data;
+    }
+
+    @Override
+    String defaultConvention() {
+        return "[A-Z]";
+    }
+
+    @Override
+    String nameExtractor(ASTTypeParameter node) {
+        return node.getName();
+    }
+
+    @Override
+    String kindDisplayName(ASTTypeParameter node, PropertyDescriptor<Pattern> descriptor) {
+        return "type parameter";
+    }
+}

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -708,7 +708,7 @@ public class Foo {
         <description>
 Names for references to generic values should be limited to a single uppercase letter.
 
-**Deprecated:** This rule has been replaced by {% rule TypeParameterNamingConventions %}, which provides more comprehensive and configurable naming conventions for type parameters.
+**Deprecated:** This rule is deprecated since PMD 7.17.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule TypeParameterNamingConventions %}, which provides more comprehensive and configurable naming conventions for type parameters.
         </description>
         <priority>4</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -708,7 +708,7 @@ public class Foo {
         <description>
 Names for references to generic values should be limited to a single uppercase letter.
 
-**Deprecated:** This rule has been replaced by TypeParameterNamingConventions, which provides more comprehensive and configurable naming conventions for type parameters.
+**Deprecated:** This rule has been replaced by {% rule TypeParameterNamingConventions %}, which provides more comprehensive and configurable naming conventions for type parameters.
         </description>
         <priority>4</priority>
         <properties>
@@ -1209,7 +1209,7 @@ public class Foo {
 
     <rule name="TypeParameterNamingConventions"
           language="java"
-          since="7.16.0"
+          since="7.17.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.TypeParameterNamingConventionsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#typeparameternamingconventions">

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -701,11 +701,14 @@ public class Foo {
     <rule name="GenericsNaming"
           language="java"
           since="4.2.6"
+          deprecated="true"
           message="Generics names should be a one letter long and upper case."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#genericsnaming">
         <description>
 Names for references to generic values should be limited to a single uppercase letter.
+
+**Deprecated:** This rule has been replaced by TypeParameterNamingConventions, which provides more comprehensive and configurable naming conventions for type parameters.
         </description>
         <priority>4</priority>
         <properties>
@@ -1199,6 +1202,45 @@ public class ClassInDefaultPackage {
             <![CDATA[
 public class Foo {
     private int num = 1000000; // should be 1_000_000
+}
+]]>
+        </example>
+    </rule>
+
+    <rule name="TypeParameterNamingConventions"
+          language="java"
+          since="7.16.0"
+          message="The {0} name ''{1}'' doesn''t match ''{2}''"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.TypeParameterNamingConventionsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#typeparameternamingconventions">
+        <description>
+            Configurable naming conventions for type parameters in generic types and methods.
+            This rule reports type parameter declarations which do not match the configured regex.
+            Type parameters can appear on classes, interfaces, enums, records, and methods.
+
+            By default, this rule uses the standard Java naming convention (single uppercase letter).
+        </description>
+        <priority>4</priority>
+        <example>
+<![CDATA[
+// Generic types - valid
+public interface Repository<T> { }
+public class Cache<K, V> { }
+
+// Generic types - invalid
+public interface Repository<type> { }      // lowercase
+public class Cache<KEY, VALUE> { }         // multiple letters
+
+// Generic methods - valid
+public class Util {
+    public static <T> T identity(T value) { return value; }
+    public <T, R> R transform(T input, Function<T, R> mapper) { }
+}
+
+// Generic methods - invalid
+public class Util {
+    public static <element> element get(element value) { }  // lowercase
+    public <INPUT, OUTPUT> OUTPUT convert(INPUT in) { }     // multiple letters
 }
 ]]>
         </example>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -66,7 +66,6 @@
     <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
     <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
     <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
-    <!--<rule ref="category/java/codestyle.xml/GenericsNaming"/>-->
     <rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference"/>
     <!-- <rule ref="category/java/codestyle.xml/LinguisticNaming" /> -->
     <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -66,7 +66,7 @@
     <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
     <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
     <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
+    <!--<rule ref="category/java/codestyle.xml/GenericsNaming"/>-->
     <rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference"/>
     <!-- <rule ref="category/java/codestyle.xml/LinguisticNaming" /> -->
     <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
@@ -76,6 +76,7 @@
     <!-- <rule ref="category/java/codestyle.xml/ShortClassName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/ShortMethodName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/ShortVariable" /> -->
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
 
     <!-- <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention" /> -->
     <!-- <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention" /> -->

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class TypeParameterNamingConventionsTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/TypeParameterNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/TypeParameterNamingConventions.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>1 upper case/single letter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface Foo <B extends Number>
+{
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>2 upper case/single letter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface Foo <B extends Number, C extends Comparable<C>>
+{
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>1 lower case/single letter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>The type parameter name 'b' doesn't match '[A-Z]'</message>
+        </expected-messages>
+        <code><![CDATA[
+public interface Foo <b extends Number>
+{
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>1 upper case/multiple letter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>The type parameter name 'CBA' doesn't match '[A-Z]'</message>
+        </expected-messages>
+        <code><![CDATA[
+public interface Foo <CBA extends Foo<CBA>>
+{
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>1 upper case/multiple letter - custom pattern</description>
+        <rule-property name="typeParameterNamePattern">[A-Z]+</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface Foo <CBA extends Foo<CBA>>
+{
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic method - single uppercase letter (valid)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public <T> T getValue(T input) {
+        return input;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic method - multiple type parameters (valid)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public <T, U> T transform(T input, U other) {
+        return input;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic method - lowercase letter (invalid)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>The type parameter name 't' doesn't match '[A-Z]'</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public <t> t getValue(t input) {
+        return input;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic method - multiple letters (invalid)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>The type parameter name 'TYPE' doesn't match '[A-Z]'</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public <TYPE> TYPE getValue(TYPE input) {
+        return input;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic method - mixed valid and invalid</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>The type parameter name 'invalid' doesn't match '[A-Z]'</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public <T, invalid> T transform(T input, invalid other) {
+        return input;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Generic static method - valid</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static <T extends Comparable<T>> T max(T a, T b) {
+        return a.compareTo(b) > 0 ? a : b;
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

Add a new rule TypeParameterNamingConventions, Deprecate GenericsNaming

The old rule wasn't configurable, the new one is.
The name of the new rule is in line with the existing rules ClassNamingConventions, FormalParameterNamingConventions, LocalVariableNamingConventions, and MethodNamingConventions.

## Related issues

- Fix #972

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

