### PR TITLE
Fix #5915: Fix AssignmentInOperandRule to also work an do-while loops and switch statements.

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -7,10 +7,12 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
@@ -30,6 +32,11 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
             .desc("Allow assignment within the conditional expression of an if statement")
             .defaultValue(false).build();
 
+    private static final PropertyDescriptor<Boolean> ALLOW_SWITCH_DESCRIPTOR =
+            booleanProperty("allowSwitch")
+                    .desc("Allow assignment within the conditional expression of a switch statement")
+                    .defaultValue(false).build();
+
     private static final PropertyDescriptor<Boolean> ALLOW_FOR_DESCRIPTOR =
         booleanProperty("allowFor")
             .desc("Allow assignment within the conditional expression of a for statement")
@@ -38,6 +45,11 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
     private static final PropertyDescriptor<Boolean> ALLOW_WHILE_DESCRIPTOR =
             booleanProperty("allowWhile")
                     .desc("Allow assignment within the conditional expression of a while statement")
+                    .defaultValue(false).build();
+
+    private static final PropertyDescriptor<Boolean> ALLOW_DO_WHILE_DESCRIPTOR =
+            booleanProperty("allowDoWhile")
+                    .desc("Allow assignment within the conditional expression of a do-while statement")
                     .defaultValue(false).build();
 
     private static final PropertyDescriptor<Boolean> ALLOW_INCREMENT_DECREMENT_DESCRIPTOR =
@@ -52,6 +64,8 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
         definePropertyDescriptor(ALLOW_FOR_DESCRIPTOR);
         definePropertyDescriptor(ALLOW_WHILE_DESCRIPTOR);
         definePropertyDescriptor(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR);
+        definePropertyDescriptor(ALLOW_DO_WHILE_DESCRIPTOR);
+        definePropertyDescriptor(ALLOW_SWITCH_DESCRIPTOR);
     }
 
     @Override
@@ -77,6 +91,8 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
         }
         if (parent instanceof ASTIfStatement && !getProperty(ALLOW_IF_DESCRIPTOR)
             || parent instanceof ASTWhileStatement && !getProperty(ALLOW_WHILE_DESCRIPTOR)
+            || parent instanceof ASTDoStatement && !getProperty(ALLOW_DO_WHILE_DESCRIPTOR)
+            || parent instanceof ASTSwitchStatement && !getProperty(ALLOW_SWITCH_DESCRIPTOR)
             || parent instanceof ASTForStatement && ((ASTForStatement) parent).getCondition() == toplevel && !getProperty(ALLOW_FOR_DESCRIPTOR)) {
 
             ctx.addViolation(impureExpr);
@@ -85,7 +101,8 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
 
     public boolean allowsAllAssignments() {
         return getProperty(ALLOW_IF_DESCRIPTOR) && getProperty(ALLOW_FOR_DESCRIPTOR)
-                && getProperty(ALLOW_WHILE_DESCRIPTOR) && getProperty(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR);
+                && getProperty(ALLOW_WHILE_DESCRIPTOR) && getProperty(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR)
+                && getProperty(ALLOW_DO_WHILE_DESCRIPTOR) && getProperty(ALLOW_SWITCH_DESCRIPTOR);
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
@@ -106,6 +106,46 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>assignment in do-while conditional expression</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumber>6</expected-linenumber>
+        <expected-message>Avoid assignments in operands</expected-message>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        int x = 2;
+        do {
+            System.out.println("loop");
+        } while ((x = getX()) > 0);
+    }
+    private int getX() {return 1;}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>assignment in switch expression</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumber>4</expected-linenumber>
+        <expected-message>Avoid assignments in operands</expected-message>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        int x = 2;
+        switch ((x = getValue())) {
+            case 1:
+                System.out.println("one");
+                break;
+            default:
+                break;
+        }
+    }
+    private int getValue() {return 5;}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>assignment in while conditional expression, allowed</description>
         <rule-property name="allowWhile">true</rule-property>
         <expected-problems>0</expected-problems>
@@ -150,6 +190,44 @@ public class Foo {
             int x = i;
         }
     }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>assignment in do-while conditional expression, allowed</description>
+        <rule-property name="allowDoWhile">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        int x = 2;
+        do {
+            System.out.println("loop");
+        } while ((x = getX()) > 0);
+    }
+    private int getX() {return 1;}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>assignment in switch expression, allowed</description>
+        <rule-property name="allowSwitch">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        int x = 2;
+        switch ((x = getValue())) {
+            case 1:
+                System.out.println("one");
+                break;
+            default:
+                break;
+        }
+    }
+    private int getValue() {return 5;}
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This PR fixes the AssignmentInOperandRule so that is works in all cases of assignment inside control statement.
Adds two new properties to the rule: allowDoWhile and allowSwitch.

## Related issues

- Fix #5915 
- Does NOT Fix #3434. There's already an old PR #5014 for that.

## Ready?

- [X] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

