### PR TITLE
Fix UseUtilityClassRule to use the message provided in design.xml

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -76,10 +76,8 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             && !hasLombokPrivateCtor(klass);
 
 
-        String message;
         if (hasAnyMethods && hasNonPrivateCtor) {
-            message = "This utility class has a non-private constructor";
-            asCtx(data).addViolationWithMessage(klass, message);
+            asCtx(data).addViolation(klass);
         }
         return null;
     }

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1452,7 +1452,7 @@ public class MyClass {
     <rule name="UseUtilityClass"
           language="java"
           since="0.3"
-          message="All methods are static.  Consider using a utility class instead. Alternatively, you could add a private constructor or make the class abstract to silence this warning."
+          message="This utility class has a non-private constructor"
           class="net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#useutilityclass">
         <description>


### PR DESCRIPTION
## Describe the PR

Fix UseUtilityClassRule to use the message provided in design.xml

I replaced the message in design.xml with the one that was in UseUtilityClassRule.java to not change user-visible behavior.

That being said, I think both versions of the message don't quite hit the spot. Would anyone object if I changed the message to "All methods are static. Consider adding a private no-args constructor to prevent instantiation."?

## Related issues

- Fix #5023

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

