### PR TITLE
[test] Fix QuickstartRulesetTests to detect deprecated rules again

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/QuickstartRulesetTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/QuickstartRulesetTest.java
@@ -4,35 +4,23 @@
 
 package net.sourceforge.pmd.lang.apex;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import net.sourceforge.pmd.lang.rule.RuleSet;
-import net.sourceforge.pmd.lang.rule.RuleSetLoader;
+import net.sourceforge.pmd.test.RuleSetAssertions;
 import net.sourceforge.pmd.test.lang.rule.AbstractRuleSetFactoryTest;
-
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 
 class QuickstartRulesetTest {
     private static final String QUICKSTART_RULESET = "rulesets/apex/quickstart.xml";
 
     @Test
     void loadQuickstartRuleset() throws Exception {
-        String log = SystemLambda.tapSystemErr(() -> {
-            RuleSet ruleset = rulesetLoader().loadFromResource(QUICKSTART_RULESET);
-            assertNotNull(ruleset);
-        });
-        assertTrue(log.isEmpty(), "No Logging expected");
+        RuleSetAssertions.assertNoWarnings(QUICKSTART_RULESET);
     }
 
     @Test
     void correctEncoding() throws Exception {
         assertTrue(AbstractRuleSetFactoryTest.hasCorrectEncoding(QUICKSTART_RULESET));
-    }
-
-    private RuleSetLoader rulesetLoader() {
-        return new RuleSetLoader();
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
@@ -4,28 +4,19 @@
 
 package net.sourceforge.pmd.lang.java;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-import net.sourceforge.pmd.lang.rule.RuleSet;
-import net.sourceforge.pmd.lang.rule.RuleSetLoader;
+import net.sourceforge.pmd.test.RuleSetAssertions;
 import net.sourceforge.pmd.test.lang.rule.AbstractRuleSetFactoryTest;
-
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 
 class QuickstartRulesetTest {
     private static final String QUICKSTART_RULESET = "rulesets/java/quickstart.xml";
 
     @Test
-    void noDeprecations() throws Exception {
-        RuleSetLoader ruleSetLoader = new RuleSetLoader();
-        String errorOutput = SystemLambda.tapSystemErr(() -> {
-            RuleSet quickstart = ruleSetLoader.loadFromResource(QUICKSTART_RULESET);
-            assertFalse(quickstart.getRules().isEmpty());
-        });
-        assertTrue(errorOutput.isEmpty());
+    void noDeprecations() {
+        RuleSetAssertions.assertNoWarnings(QUICKSTART_RULESET);
     }
 
     @Test

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleSetAssertions.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleSetAssertions.java
@@ -1,0 +1,55 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.slf4j.event.Level;
+
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.lang.rule.RuleSet;
+import net.sourceforge.pmd.lang.rule.RuleSetLoader;
+import net.sourceforge.pmd.util.log.internal.MessageReporterBase;
+
+public final class RuleSetAssertions {
+    private RuleSetAssertions() {
+    }
+
+    public static void assertNoWarnings(String rulesetFilename) {
+        class Reporter extends MessageReporterBase {
+            private int warnings = 0;
+
+            Reporter() {
+                setLevel(Level.WARN);
+            }
+
+            @Override
+            protected void logImpl(Level level, String message) {
+                if (level == Level.WARN) {
+                    warnings++;
+                }
+                System.out.println(message);
+            }
+
+            public int numWarnings() {
+                return warnings;
+            }
+        }
+
+        Reporter reporter = new Reporter();
+        PMDConfiguration pmdConfig = new PMDConfiguration();
+        pmdConfig.setReporter(reporter);
+        RuleSetLoader ruleSetLoader = RuleSetLoader.fromPmdConfig(pmdConfig).warnDeprecated(true);
+
+        RuleSet ruleSet = ruleSetLoader.loadFromResource(rulesetFilename);
+        assertAll(
+                () -> assertEquals(0, reporter.numErrors(), "errors while loading ruleset " + rulesetFilename),
+                () -> assertEquals(0, reporter.numWarnings(), "warnings while loading ruleset " + rulesetFilename),
+                () -> assertFalse(ruleSet.getRules().isEmpty(), "ruleset " + rulesetFilename + " was empty")
+        );
+    }
+}

--- a/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleSetAssertionsTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleSetAssertionsTest.java
@@ -1,0 +1,26 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.opentest4j.MultipleFailuresError;
+
+class RuleSetAssertionsTest {
+    @Test
+    void canDetectDeprecatedRuleReferences() {
+        MultipleFailuresError error = assertThrows(MultipleFailuresError.class, () -> RuleSetAssertions.assertNoWarnings("net/sourceforge/pmd/test/ruleset-with-deprecated-rule-ref.xml"));
+        assertEquals(1, error.getFailures().size());
+        assertTrue(error.getFailures().get(0).getMessage().startsWith("warnings while loading"));
+    }
+
+    @Test
+    void rulesetWithoutWarning() {
+        RuleSetAssertions.assertNoWarnings("net/sourceforge/pmd/test/ruleset-without-warnings.xml");
+    }
+}

--- a/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-with-deprecated-rule-ref.xml
+++ b/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-with-deprecated-rule-ref.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+    <rule ref="net/sourceforge/pmd/test/ruleset-with-deprecated-rule.xml/SampleXPathRule" />
+
+</ruleset>

--- a/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-with-deprecated-rule.xml
+++ b/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-with-deprecated-rule.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+    <rule name="SampleXPathRule"
+          language="dummy"
+          since="1.1"
+          deprecated="true"
+          message="Test Rule"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/dummy/basic.xml#SampleXPathRule">
+        <description>Test</description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value><![CDATA[
+//dummyRootNode
+                ]]></value>
+            </property>
+        </properties>
+        <example> </example>
+    </rule>
+
+</ruleset>

--- a/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-without-warnings.xml
+++ b/pmd-test/src/test/resources/net/sourceforge/pmd/test/ruleset-without-warnings.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+    <rule name="SampleXPathRule"
+          language="dummy"
+          since="1.1"
+          message="Test Rule"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/dummy/basic.xml#SampleXPathRule">
+        <description>Test</description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value><![CDATA[
+//dummyRootNode
+                ]]></value>
+            </property>
+        </properties>
+        <example> </example>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
## Describe the PR

The tests to verify Quickstart rulesets didn't detect anymore, when deprecated rules were part of them.

> Interesting. I would have expected QuickstartRulesetTest::noDeprecations to fail.
> https://github.com/pmd/pmd/pull/5922#issuecomment-3092537771 by @UncleOwen 

## Related issues

- Refs #5922

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

