### PR TITLE
[docs] Update suppression docs to reflect PMD 7 changes

### DIFF
--- a/docs/pages/pmd/userdocs/suppressing_warnings.md
+++ b/docs/pages/pmd/userdocs/suppressing_warnings.md
@@ -169,7 +169,7 @@ For example, to suppress reporting specifically named parameters which
 are unused:
 
 ```xml
-<rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter">
+<rule ref="category/java/unusedcode.xml/UnusedFormalParameter">
   <properties>
     <property name="violationSuppressRegex" value=".*'mySpecialParameterName'.*"/>
   </properties>
@@ -198,9 +198,9 @@ The XPath version used by those queries is XPath 3.1 since PMD 7. Before then XP
 For example, to suppress reporting specifically "String" parameters which are unused:
 
 ```xml
-<rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter">
+<rule ref="category/java/unusedcode.xml/UnusedFormalParameter">
   <properties>
-    <property name="violationSuppressXPath" value=".[typeIs('java.lang.String')]"/>
+    <property name="violationSuppressXPath" value=".[pmd-java:typeIs('java.lang.String')]"/>
   </properties>
 </rule>
 ```

--- a/docs/pages/pmd/userdocs/suppressing_warnings.md
+++ b/docs/pages/pmd/userdocs/suppressing_warnings.md
@@ -117,7 +117,7 @@ public class Foo {
     }
 }
 
-$ pmd check -d Foo.java -f text -R java-unusedcode --suppress-marker TURN_OFF_WARNINGS
+$ pmd check -d Foo.java -f text -R java-bestpractices --suppress-marker TURN_OFF_WARNINGS
 No problems found!
 UnusedLocalVariable rule violation suppressed by //NOPMD in /home/tom/pmd/pmd/bin/Foo.java
 ```
@@ -169,7 +169,7 @@ For example, to suppress reporting specifically named parameters which
 are unused:
 
 ```xml
-<rule ref="category/java/unusedcode.xml/UnusedFormalParameter">
+<rule ref="category/java/bestpractices.xml/UnusedFormalParameter">
   <properties>
     <property name="violationSuppressRegex" value=".*'mySpecialParameterName'.*"/>
   </properties>
@@ -198,7 +198,7 @@ The XPath version used by those queries is XPath 3.1 since PMD 7. Before then XP
 For example, to suppress reporting specifically "String" parameters which are unused:
 
 ```xml
-<rule ref="category/java/unusedcode.xml/UnusedFormalParameter">
+<rule ref="category/java/bestpractices.xml/UnusedFormalParameter">
   <properties>
     <property name="violationSuppressXPath" value=".[pmd-java:typeIs('java.lang.String')]"/>
   </properties>


### PR DESCRIPTION
## Describe the PR

The rulesets have been renamed in PMD 6 and `typeIs` requires a prefix since PMD 7.

## Related issues

None.

## Ready?

Documentation change only -- no tests added.

