### PR TITLE
chore: Fix LiteralsFirstInComparison violations in test code

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
@@ -21,7 +21,7 @@ public class FooRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass c, Object ctx) {
-        if (c.getSimpleName().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getSimpleName())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);
@@ -29,7 +29,7 @@ public class FooRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTVariableDeclaration c, Object ctx) {
-        if (c.getImage().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getImage())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);
@@ -37,7 +37,7 @@ public class FooRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTField c, Object ctx) {
-        if (c.getImage().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getImage())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);
@@ -45,7 +45,7 @@ public class FooRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTParameter c, Object ctx) {
-        if (c.getImage().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getImage())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -31,7 +31,7 @@ class SuppressWarningsTest extends ApexParserTestBase {
 
         @Override
         public Object visit(ASTUserClass clazz, Object ctx) {
-            if (clazz.getSimpleName().equalsIgnoreCase("bar")) {
+            if ("bar".equalsIgnoreCase(clazz.getSimpleName())) {
                 asCtx(ctx).addViolation(clazz);
             }
             return super.visit(clazz, ctx);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -160,7 +160,9 @@ class AbstractRuleTest {
     @Test
     void testEquals4() {
         MyRule myRule = new MyRule();
-        assertFalse(myRule.equals("MyRule"), "A rule cannot be equal to an object of another class");
+        @SuppressWarnings("PMD.LiteralsFirstInComparisons") // we really want to call equals on MyRule
+        boolean result = myRule.equals("MyRule");
+        assertFalse(result, "A rule cannot be equal to an object of another class");
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -104,7 +104,7 @@ public class DummyLanguageModule extends SimpleLanguageModuleBase implements Cpd
         @Override
         public Parser getParser() {
             return task -> {
-                if (task.getLanguageVersion().getVersion().equals(PARSER_THROWS)) {
+                if (PARSER_THROWS.equals(task.getLanguageVersion().getVersion())) {
                     throw new ParseException("ohio");
                 }
                 return readLispNode(task);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
@@ -236,7 +236,7 @@ class NodeStreamBlanketTest<T extends Node> {
                 stream.precedingSiblings(),
                 stream.descendantsOrSelf(),
                 stream.children(),
-                stream.children().filter(c -> c.getImage().equals("0")),
+                stream.children().filter(c -> "0".equals(c.getImage())),
                 stream.children(DummyNode.class)
             )
         ).flatMap(

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetTest.java
@@ -215,7 +215,9 @@ class RuleSetTest {
                 .withName("basic rules")
                 .withDescription("desc")
                 .build();
-        assertFalse(s.equals("basic rules"), "A ruleset cannot be equals to another kind of object");
+        @SuppressWarnings("PMD.LiteralsFirstInComparisons") // we really want to call equals on RuleSet
+        boolean result = s.equals("basic rules");
+        assertFalse(result, "A ruleset cannot be equals to another kind of object");
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
@@ -207,7 +207,7 @@ class LatticeRelationTest {
     void testTransitiveSucc() {
 
         LatticeRelation<String, String, Set<String>> lattice =
-            stringLattice(s -> s.equals("c") || s.equals("bc"));
+            stringLattice(s -> "c".equals(s) || "bc".equals(s));
 
         lattice.put("abc", "val");
         lattice.put("bc", "v2");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
@@ -149,7 +149,7 @@ class IteratorUtilTest {
     void testFlatmapIsLazy() {
         Iterator<String> iter = iterOf("a", "b");
         Function<String, Iterator<String>> fun = s -> {
-            if (s.equals("a")) {
+            if ("a".equals(s)) {
                 return iterOf("a");
             } else {
                 throw new AssertionError("This statement shouldn't be reached");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -130,7 +130,7 @@ class XmlTreeRendererTest {
         XmlRenderingConfig strategy = new XmlRenderingConfig() {
             @Override
             public boolean takeAttribute(Node node, Attribute attribute) {
-                return attribute.getName().equals("ohio");
+                return "ohio".equals(attribute.getName());
             }
         }.lineSeparator("\n");
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
@@ -20,7 +20,7 @@ public class FooRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTClassDeclaration c, Object ctx) {
-        if (c.getSimpleName().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getSimpleName())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);
@@ -28,7 +28,7 @@ public class FooRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTVariableId c, Object ctx) {
-        if (c.getName().equalsIgnoreCase("Foo")) {
+        if ("Foo".equalsIgnoreCase(c.getName())) {
             asCtx(ctx).addViolation(c);
         }
         return super.visit(c, ctx);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
@@ -84,13 +84,13 @@ public class TypeAnnotTestUtil {
     @SuppressWarnings("unchecked")
     public static <A extends Annotation> A createAnnotationInstance(Class<A> annotationClass, Map<String, Object> attributes) {
         return (A) Proxy.newProxyInstance(annotationClass.getClassLoader(), new Class[] { annotationClass }, (proxy, method, args) -> {
-            if (method.getName().equals("annotationType") && args == null) {
+            if ("annotationType".equals(method.getName()) && args == null) {
                 return annotationClass;
-            } else if (method.getName().equals("toString") && args == null) {
+            } else if ("toString".equals(method.getName()) && args == null) {
                 return AnnotationUtils.toString((Annotation) proxy);
-            } else if (method.getName().equals("hashCode") && args == null) {
+            } else if ("hashCode".equals(method.getName()) && args == null) {
                 return AnnotationUtils.hashCode((Annotation) proxy);
-            } else if (method.getName().equals("equals") && args.length == 1) {
+            } else if ("equals".equals(method.getName()) && args.length == 1) {
                 if (args[0] instanceof Annotation) {
                     return AnnotationUtils.equals((Annotation) proxy, (Annotation) args[0]);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -555,10 +555,6 @@
                                 <rulesets>
                                     <ruleset>/net/sourceforge/pmd/pmd-dogfood-config.xml</ruleset>
                                 </rulesets>
-                                <excludeRoots>
-                                    <excludeRoot>target/generated-sources/javacc</excludeRoot>
-                                    <excludeRoot>target/generated-sources/antlr4</excludeRoot>
-                                </excludeRoots>
                             </configuration>
                         </execution>
                         <execution>
@@ -585,6 +581,10 @@
                         <failurePriority>2</failurePriority>
                         <failOnViolation>true</failOnViolation>
                         <printFailingErrors>true</printFailingErrors>
+                        <excludeRoots>
+                            <excludeRoot>target/generated-sources/javacc</excludeRoot>
+                            <excludeRoot>target/generated-sources/antlr4</excludeRoot>
+                        </excludeRoots>
                         <!-- Skip the default pmd executions, which is triggered by pmd:check and avoid
                              unnecessary pmd analysis of the main code.
                              We use executions pmd-main and pmd-test instead and explicitly run pmd:pmd. -->


### PR DESCRIPTION
## Describe the PR

This fixes violations of LiteralsFirstInComparisons in test code, so that we can enable this rule as well.

This PR should be merged prior to updating build-tools (where the dogfood ruleset is located).

## Related issues

- See also Pankratz76/pmd#4

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

