### PR TITLE
Fix #5960: [java] AddEmptyString: Improve report location

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
@@ -28,22 +28,23 @@ public class AddEmptyStringRule extends AbstractJavaRulechainRule {
             return null;
         }
         JavaNode parent = node.getParent();
-        checkExpr(data, parent);
+        checkExpr(data, parent, node);
         if (parent instanceof ASTVariableDeclarator) {
             ASTVariableId varId = ((ASTVariableDeclarator) parent).getVarId();
             if (varId.hasModifiers(JModifier.FINAL)) {
                 for (ASTNamedReferenceExpr usage : varId.getLocalUsages()) {
-                    checkExpr(data, usage.getParent());
+                    checkExpr(data, usage.getParent(), usage);
                 }
             }
         }
         return null;
     }
 
-    private void checkExpr(Object data, JavaNode parent) {
+    private void checkExpr(Object data, JavaNode parent, JavaNode emptyStringNode) {
         if (JavaAstUtils.isInfixExprWithOperator(parent, BinaryOp.ADD)
             && parent.ancestors(ASTAnnotation.class).isEmpty()) {
-            asCtx(data).addViolation(parent);
+            asCtx(data).addViolationWithPosition(parent, parent.getAstInfo(),
+                emptyStringNode.getReportLocation(), getMessage());
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AddEmptyString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AddEmptyString.xml
@@ -119,4 +119,18 @@ class Main {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Message location for multiline expression</description>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>2,3,3,4,5</expected-linenumbers>
+        <code><![CDATA[
+class Main {
+    final String outerString1 = ""
+            + "" + ""
+            + ""
+            + "";
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Expressions that add strings together may span multiple lines, the violation should be reported at the line where the violating string is located.

## Related issues

- Fix #5960 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

