### PR TITLE
Fix #5960: [java] Add details to the error message for some rules

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
@@ -43,7 +43,7 @@ public class FinalFieldCouldBeStaticRule extends AbstractJavaRulechainRule {
             for (ASTVariableId field : node) {
                 ASTExpression init = field.getInitializer();
                 if (init != null && isAllowedExpression(init) && !isUsedForSynchronization(field)) {
-                    asCtx(data).addViolation(field);
+                    asCtx(data).addViolation(field, field.getName());
                 }
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
@@ -78,8 +79,12 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
         if (parent instanceof ASTIfStatement && !getProperty(ALLOW_IF_DESCRIPTOR)
             || parent instanceof ASTWhileStatement && !getProperty(ALLOW_WHILE_DESCRIPTOR)
             || parent instanceof ASTForStatement && ((ASTForStatement) parent).getCondition() == toplevel && !getProperty(ALLOW_FOR_DESCRIPTOR)) {
-
-            ctx.addViolation(impureExpr);
+            JavaNode firstChild = impureExpr.getChild(0);
+            if (firstChild instanceof ASTVariableAccess) {
+                ctx.addViolation(impureExpr, ((ASTVariableAccess) firstChild).getName());
+            } else {
+                ctx.addViolationWithMessage(impureExpr, "Avoid assignments in operands");
+            }
         }
     }
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -242,7 +242,7 @@ public class Foo {
     <rule name="AvoidThrowingRawExceptionTypes"
           language="java"
           since="1.8"
-          message="Avoid throwing raw exception types."
+          message="Avoid throwing raw exception type {0}."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoidthrowingrawexceptiontypes">
         <description>
@@ -282,7 +282,7 @@ public class Foo {
     <rule name="AvoidUncheckedExceptionsInSignatures"
           since="6.13.0"
           language="java"
-          message="A method or constructor should not explicitly declare unchecked exceptions in its ''throws'' clause"
+          message="A method or constructor should not explicitly declare unchecked exception {0} in its ''throws'' clause"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoiduncheckedexceptionsinsignatures">
         <description>
@@ -716,7 +716,7 @@ public class Foo {
     <rule name="FinalFieldCouldBeStatic"
           language="java"
           since="1.1"
-          message="This final field could be made static"
+          message="The final field {0} could be made static"
           class="net.sourceforge.pmd.lang.java.rule.design.FinalFieldCouldBeStaticRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#finalfieldcouldbestatic">
         <description>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -12,7 +12,7 @@ Rules to detect constructs that are either broken, extremely confusing or prone 
     <rule name="AssignmentInOperand"
           language="java"
           since="1.03"
-          message="Avoid assignments in operands"
+          message="Avoid assignment to {0} in operand"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AssignmentInOperandRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#assignmentinoperand">
         <description>
@@ -494,7 +494,7 @@ try {  // Prefer this:
     <rule name="AvoidLiteralsInIfCondition"
           language="java"
           since="4.2.6"
-          message="Avoid using literals in if statements"
+          message="Avoid using literals such as {0} in if statements"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidliteralsinifcondition">
         <description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
@@ -85,4 +85,21 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Distinct error messages for the same line</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,4</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid throwing raw exception type Error.</message>
+            <message>Avoid throwing raw exception type RuntimeException.</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public void bar(boolean flag) {
+        throw flag ? new Error() : new RuntimeException();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidUncheckedExceptionsInSignatures.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidUncheckedExceptionsInSignatures.xml
@@ -133,4 +133,19 @@ public interface Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Distinct error messages for the same line</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,2</expected-linenumbers>
+        <expected-messages>
+            <message>A method or constructor should not explicitly declare unchecked exception IllegalArgumentException in its 'throws' clause</message>
+            <message>A method or constructor should not explicitly declare unchecked exception NullPointerException in its 'throws' clause</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void foo() throws IllegalArgumentException, NullPointerException {}
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -408,4 +408,17 @@ class MyConstants {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>Distinct error messages for the same line</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>The final field FOO could be made static</message>
+            <message>The final field BAR could be made static</message>
+        </expected-messages>
+        <code><![CDATA[
+class MyConstants {
+    private final int FOO=2, BAR=3;
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
@@ -169,4 +169,23 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Distinct error messages for the same line</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Avoid assignment to x in operand</message>
+            <message>Avoid assignment to y in operand</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        int x = 0;
+        int y = 0;
+        if (x++ > (y = 5)) {
+            x = 2;
+        }
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
@@ -176,4 +176,22 @@ public class AvoidLiteralsInIfCondition {
         <expected-linenumbers>4,5,8,9,9</expected-linenumbers>
         <code-ref id="code-for-4514"/>
     </test-code>
+
+    <test-code>
+        <description>Distinct error messages for the same line</description>
+        <rule-property name="ignoreExpressions">false</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,3</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid using literals such as 7 in if statements</message>
+            <message>Avoid using literals such as "baz" in if statements</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public void bar(int a) {
+        if (a < 7 && a > "baz".length()) {}
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Add a reference to the error message for 5 rules that may realistically report multiple violations for the same line of code:
* AssignmentInOperand
* AvoidLiteralsInIfCondition
* AvoidThrowingRawExceptionTypes
* AvoidUncheckedExceptionsInSignatures
* FinalFieldCouldBeStatic

## Related issues

- Fix #5960 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

