### PR TITLE
Fix #5881: AvoidLosingException - Consider nested method calls

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#5874](https://github.com/pmd/pmd/issues/5874): \[java] Update java regression tests with Java 25 language features
 * java-codestyle
   * [#972](https://github.com/pmd/pmd/issues/972): \[java] Improve naming conventions rules
+* java-errorprone
+  * [#5881](https://github.com/pmd/pmd/issues/5881): \[java] AvoidLosingExceptionInformation does not trigger when inside if-else
 
 ### 🚨 API Changes
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -587,7 +587,7 @@ only add to code size.  Either remove the invocation, or use the return result.
             <property name="xpath">
                 <value>
 <![CDATA[
-//CatchClause/Block/ExpressionStatement/MethodCall[
+//CatchClause/Block//ExpressionStatement/MethodCall[
     pmd-java:matchesSig("java.lang.Throwable#getMessage()")
     or pmd-java:matchesSig("java.lang.Throwable#getLocalizedMessage()")
     or pmd-java:matchesSig("java.lang.Throwable#getCause()")

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLosingExceptionInformation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLosingExceptionInformation.xml
@@ -103,4 +103,25 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5881 [java] AvoidLosingExceptionInformation does not trigger when inside if-else</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,9</expected-linenumbers>
+        <code><![CDATA[
+class AvoidLosingExceptionInformation {
+    public void showBug() {
+        try {
+            throw new Exception("This is a test exception");
+        } catch (Exception se) {
+            if (true) {
+                se.getMessage();    // should raise flag
+            } else {
+                se.getLocalizedMessage();    // should raise flag
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Couldn't keep it back to try to fix this (if the fix is really that simply). Even though, the rule will be deprecated with #5907 , this fix would allow us to close the issue.

## Related issues

- Fix #5881

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

