### PR TITLE
Fix #3434: [java] False negatives in AssignmentInOperand rule

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -333,4 +333,14 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
         return rule;
     }
+
+    @Override
+    @SuppressWarnings("PMD.UselessOverridingMethod")
+    public String dysfunctionReason() {
+        // This method is overridden to let subclasses remove their implementation
+        // of dysfunctionReason in a binary compatible way. For this to
+        // work one implementation has to be in a superclass, however this
+        // method only has a default implementation in the interface.
+        return super.dysfunctionReason();
+    }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
@@ -21,11 +21,17 @@ public final class AssertionUtil {
 
     private static final boolean ASSERT_ENABLED;
 
+    private static boolean areAssertsEnabled() {
+        try {
+            assert false;
+            return false;
+        } catch (AssertionError e) {
+            return true;
+        }
+    }
+
     static {
-        boolean assertEnabled = false;
-        //noinspection AssertWithSideEffects
-        assert assertEnabled = true; // SUPPRESS CHECKSTYLE now
-        ASSERT_ENABLED = assertEnabled;
+        ASSERT_ENABLED = areAssertsEnabled();
     }
 
     private AssertionUtil() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
@@ -554,7 +554,9 @@ public final class CollectionUtil {
 
         return Collector.of(
             Holder::new,
-            (h, t) -> h.set = h.set.plus(t),
+            (h, t) -> {
+                h.set = h.set.plus(t);
+            },
             (left, right) -> {
                 left.set = left.set.plusAll(right.set);
                 return left;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTStatementExpressionList;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
@@ -20,7 +21,6 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
-import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
@@ -86,35 +86,38 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
     private void checkAssignment(ASTExpression impureExpr, RuleContext ctx) {
         ASTExpression toplevel = JavaAstUtils.getTopLevelExpr(impureExpr);
         JavaNode parent = toplevel.getParent();
-        if (parent instanceof ASTExpressionStatement) {
+
+        if (toplevel == impureExpr
+            && (parent instanceof ASTExpressionStatement
+            || parent instanceof ASTStatementExpressionList)
+        ) {
             // that's ok
             return;
         }
-        if (parent instanceof ASTIfStatement && !getProperty(ALLOW_IF_DESCRIPTOR)
-            || parent instanceof ASTWhileStatement && !getProperty(ALLOW_WHILE_DESCRIPTOR)
-            || parent instanceof ASTDoStatement && !getProperty(ALLOW_DO_WHILE_DESCRIPTOR)
-            || parent instanceof ASTSwitchStatement && !getProperty(ALLOW_SWITCH_DESCRIPTOR)
-            || parent instanceof ASTForStatement && ((ASTForStatement) parent).getCondition() == toplevel && !getProperty(ALLOW_FOR_DESCRIPTOR)) {
-            JavaNode firstChild = impureExpr.getChild(0);
-            if (firstChild instanceof ASTVariableAccess) {
-                ctx.addViolation(impureExpr, ((ASTVariableAccess) firstChild).getName());
-            } else {
-                ctx.addViolationWithMessage(impureExpr, "Avoid assignments in operands");
-            }
+        if (parent instanceof ASTIfStatement && getProperty(ALLOW_IF_DESCRIPTOR)
+            || parent instanceof ASTWhileStatement && getProperty(ALLOW_WHILE_DESCRIPTOR)
+            || parent instanceof ASTDoStatement && getProperty(ALLOW_DO_WHILE_DESCRIPTOR)
+            || parent instanceof ASTSwitchStatement && getProperty(ALLOW_SWITCH_DESCRIPTOR)
+            || parent instanceof ASTForStatement && ((ASTForStatement) parent).getCondition() == toplevel && getProperty(ALLOW_FOR_DESCRIPTOR)
+        ) {
+            return;
+        }
+        JavaNode firstChild = impureExpr.getChild(0);
+        if (firstChild instanceof ASTVariableAccess) {
+            ctx.addViolation(impureExpr, ((ASTVariableAccess) firstChild).getName());
+        } else {
+            ctx.addViolationWithMessage(impureExpr, "Avoid assignments in operands");
         }
     }
 
+    /**
+     * @deprecated Since 7.17.0. This method is an implementation detail and will be internalized.
+     */
+    @Deprecated
     public boolean allowsAllAssignments() {
         return getProperty(ALLOW_IF_DESCRIPTOR) && getProperty(ALLOW_FOR_DESCRIPTOR)
                 && getProperty(ALLOW_WHILE_DESCRIPTOR) && getProperty(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR)
                 && getProperty(ALLOW_DO_WHILE_DESCRIPTOR) && getProperty(ALLOW_SWITCH_DESCRIPTOR);
     }
 
-    /**
-     * @see PropertySource#dysfunctionReason()
-     */
-    @Override
-    public String dysfunctionReason() {
-        return allowsAllAssignments() ? "All assignment types allowed, no checks performed" : null;
-    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
@@ -247,6 +247,7 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>Distinct error messages for the same line</description>
         <expected-problems>2</expected-problems>
@@ -265,5 +266,35 @@ public class Foo {
     }
 }
 ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3434 Assignments in other contexts</description>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>4,5,9,12,13,16,17,20</expected-linenumbers>
+        <code><![CDATA[
+            class AssignmentInOperand{
+                void test(){
+                    // case1
+                    keys.contains(k = random.nextLong());
+                    Character.isJavaIdentifierPart(text.charAt(--j));
+
+                    // case2
+                    addNextStaticMember = ((staticMember.getNextStaticMember() != null) ? true : false) ;
+                    ((null == theClassMethods) ? (theClassMethods = theClass.getMethods()) : theClassMethods);
+
+                    // case3
+                    Character.isWhitespace(segment.array[offset++]);
+                    subPropMatches[i++];
+
+                    // case4
+                    (is = ia.getNext(null)).isPresent();
+                    (destFile = new File (dest, srcFO.getNameExt ())).exists();
+
+                    // case5
+                    new File(location, projectName = projectNamePrefix + "_" + num).exists();
+                }
+            }
+        ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

I took @oowekyala's code from #5014, made it apply to the current version of the rule, and fixed all the dogfood issues.
While at it, I fixed some XML issues in AssignmentInOperand.xml

## Related issues

- Fix #3434 
- Closes #5014 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

