### PR TITLE
Fix #5974: [java] NPE in CloseResourceRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -53,6 +53,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.reporting.RuleContext;
@@ -678,6 +679,11 @@ public class CloseResourceRule extends AbstractJavaRule {
     }
 
     private String getResourceTypeName(ASTVariableId varId, TypeNode type) {
+        if (type == null) {
+            final JTypeMirror typeMirror = varId.getTypeMirror();
+            return typeMirror.getSymbol() != null ? typeMirror.getSymbol().getSimpleName() : typeMirror.toString();
+        }
+
         if (type instanceof ASTType) {
             return PrettyPrintingUtil.prettyPrintType((ASTType) type);
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2090,16 +2090,18 @@ public class DefaultFileSystemUsage {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Ensure that resources like this Closeable object are closed after use</message>
+            <message>Ensure that resources like this FileInputStream object are closed after use</message>
         </expected-messages>
         <code><![CDATA[
-import java.io.Closeable;
+import java.io.FileInputStream;
 import java.util.List;
 
 public class Foo {
-    public void bar(List<Closeable> connections) {
-        for (final var c: connections) {
-            c.close();
+    public void bar(List<FileInputStream> streams) {
+        for (final var stream: streams) {
+            try {
+                int c = stream.in();
+            } catch (IOException ignored) {}
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2085,4 +2085,24 @@ public class DefaultFileSystemUsage {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#5974: NPE with var in for-each loop</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Ensure that resources like this Closeable object are closed after use</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.io.Closeable;
+import java.util.List;
+
+public class Foo {
+    public void bar(List<Closeable> connections) {
+        for (final var c: connections) {
+            c.close();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix NPE that occurs when reporting a violation for a `var` variable within a for-each loop.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5974 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

