### PR TITLE
[java] Fix #4911: AvoidRethrowingException consider supertypes in following catches

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionRule.java
@@ -1,0 +1,53 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design;
+
+import java.util.List;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCatchClause;
+import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+/**
+ * Avoid rethrowing exceptions unless there's a subsequent catch clause
+ * that handles a superclass of the exception being rethrown.
+ */
+public class AvoidRethrowingExceptionRule extends AbstractJavaRulechainRule {
+
+    public AvoidRethrowingExceptionRule() {
+        super(ASTTryStatement.class);
+    }
+
+    @Override
+    public Object visit(ASTTryStatement tryStmt, Object data) {
+        List<ASTCatchClause> catchClauses = tryStmt.getCatchClauses().toList();
+        
+        for (int i = 0; i < catchClauses.size(); i++) {
+            ASTCatchClause currentCatch = catchClauses.get(i);
+            
+            if (!JavaAstUtils.isJustRethrowException(currentCatch)) {
+                continue;
+            }
+
+            List<ASTCatchClause> subsequentCatches = catchClauses.subList(i + 1, catchClauses.size());
+            if (!hasSubsequentSuperclassCatch(currentCatch, subsequentCatches)) {
+                asCtx(data).addViolation(currentCatch);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if any subsequent catch clause handles a superclass of the exception being rethrown.
+     */
+    private boolean hasSubsequentSuperclassCatch(ASTCatchClause currentCatch, List<ASTCatchClause> subsequentCatches) {
+        return currentCatch.getParameter().getAllExceptionTypes()
+                .any(currentType -> subsequentCatches.stream()
+                        .anyMatch(subsequentCatch -> subsequentCatch.getParameter().getAllExceptionTypes()
+                                .any(subsequentType -> currentType.getTypeMirror().isSubtypeOf(subsequentType.getTypeMirror()))));
+    }
+}

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -122,23 +122,12 @@ public class Foo {
           language="java"
           since="3.8"
           message="A catch statement that catches an exception only to rethrow it should be avoided."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.design.AvoidRethrowingExceptionRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoidrethrowingexception">
         <description>
 Catch blocks that merely rethrow a caught exception only add to code size and runtime complexity.
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//CatchClause[
-  CatchParameter/VariableId/@Name
-= Block[@Size = 1]/ThrowStatement/VariableAccess/@Name]
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 public void bar() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidRethrowingException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidRethrowingException.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>failure case</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void bar() {
@@ -62,6 +63,48 @@ public class Foo {
             } catch (IllegalArgumentException oe) {
                 throw se;
             }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>#4911 AvoidRethrowingException should allow rethrowing exception subclasses</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.nio.file.NoSuchFileException;
+import java.io.IOException;
+
+public class Repro {
+    void foo() {
+        try {
+            Files.delete("example.txt");
+        } catch (NoSuchFileException e) {
+            // Unrecoverable error
+            throw e;
+        } catch (IOException e) {
+            // Potentially recoverable error. Sleep and try again...
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>catch followed by an unrelated catch</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.file.NoSuchFileException;
+
+public class Foo {
+    void foo() {
+        try {
+            Files.delete("example.txt");
+        } catch (NoSuchFileException e) {
+            throw e;
+        } catch (IllegalStateException e) {
         }
     }
 }


### PR DESCRIPTION
## Describe the PR

AvoidRethrowingException now doesn't complain, when the catch clause in question is followed by a catch clause that catches a superclass.

Rewrite from xpath to java, since xpath doesn't handle inheritance. (Did I understand that correctly?)

## Related issues

- Fix #4911

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

