### PR TITLE
Fix #4916: [java] UseExplicitTypes cases where 'var' should be unobjectionable

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -2008,12 +2008,14 @@ See also [Local Variable Type Inference Style Guidelines](https://openjdk.org/pr
         <properties>
             <property name="allowLiterals" type="Boolean" value="false" description="Allow when variables are directly initialized with literals"/>
             <property name="allowCtors" type="Boolean" value="false" description="Allow when variables are directly initialized with a constructor call"/>
+            <property name="allowCasts" type="Boolean" value="false" description="Allow when variables are directly initialized with a the result of a cast"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
 //LocalVariableDeclaration[@TypeInferred = true()]
     [not(VariableDeclarator[*[pmd-java:nodeIs("Literal")]]) or $allowLiterals = false()]
     [not(VariableDeclarator[ConstructorCall]) or $allowCtors = false()]
+    [not(VariableDeclarator[CastExpression]) or $allowCasts = false()]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -2009,6 +2009,7 @@ See also [Local Variable Type Inference Style Guidelines](https://openjdk.org/pr
             <property name="allowLiterals" type="Boolean" value="false" description="Allow when variables are directly initialized with literals"/>
             <property name="allowCtors" type="Boolean" value="false" description="Allow when variables are directly initialized with a constructor call"/>
             <property name="allowCasts" type="Boolean" value="false" description="Allow when variables are directly initialized with a the result of a cast"/>
+            <property name="allowLoopVariable" type="Boolean" value="false" description="Allow when variables are used as loop variables in enhanced for loops"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -2016,6 +2017,7 @@ See also [Local Variable Type Inference Style Guidelines](https://openjdk.org/pr
     [not(VariableDeclarator[*[pmd-java:nodeIs("Literal")]]) or $allowLiterals = false()]
     [not(VariableDeclarator[ConstructorCall]) or $allowCtors = false()]
     [not(VariableDeclarator[CastExpression]) or $allowCasts = false()]
+    [not(parent::ForeachStatement) or $allowLoopVariable = false()]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseExplicitTypes.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseExplicitTypes.xml
@@ -14,7 +14,9 @@ public class Foo {
         String s2 = "a"; // no violation - explicit type
         var f = getFoo(); // line 8 - violation
         var f = new Foo(); // line 9 - violation - ctor call
-        Function<Integer, Integer> quadrat = (var x) -> x*x;
+        Function<Integer, Integer> square = (var x) -> x*x;
+
+        var f = (Integer)getFoo(); // line 12 - violation - cast
     }
 
     private String getFoo() {
@@ -25,24 +27,32 @@ public class Foo {
     
     <test-code>
         <description>No vars anywhere</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>5,6,8,9</expected-linenumbers>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>5,6,8,9,12</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 
     <test-code>
         <description>Allow literals</description>
         <rule-property name="allowLiterals">true</rule-property>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>8,9</expected-linenumbers>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>8,9,12</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 
     <test-code>
         <description>Allow constructor calls</description>
         <rule-property name="allowCtors">true</rule-property>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>5,6,8</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>5,6,8,12</expected-linenumbers>
+        <code-ref id="basic-sample"/>
+    </test-code>
+
+    <test-code>
+        <description>Allow casts</description>
+        <rule-property name="allowCasts">true</rule-property>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>5,6,8,9</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseExplicitTypes.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseExplicitTypes.xml
@@ -6,17 +6,24 @@
 
     <code-fragment id="basic-sample"><![CDATA[
 import java.util.function.Function;
+import java.util.List;
+import java.util.Arrays;
 
 public class Foo {
     public void bar() {
-        var s = "a"; // line 5 - violation - literal
-        var i = 1;   // line 6 - violation - literal
+        var s = "a"; // line 7 - violation - literal
+        var i = 1;   // line 8 - violation - literal
         String s2 = "a"; // no violation - explicit type
-        var f = getFoo(); // line 8 - violation
-        var f = new Foo(); // line 9 - violation - ctor call
+        var f = getFoo(); // line 10 - violation
+        var f = new Foo(); // line 11 - violation - ctor call
         Function<Integer, Integer> square = (var x) -> x*x;
 
-        var f = (Integer)getFoo(); // line 12 - violation - cast
+        var f = (Integer)getFoo(); // line 14 - violation - cast
+        
+        List<String> strings = Arrays.asList("a", "b", "c");
+        for (var str : strings) { // line 17 - violation - enhanced for loop
+            System.out.println(str);
+        }
     }
 
     private String getFoo() {
@@ -27,32 +34,40 @@ public class Foo {
     
     <test-code>
         <description>No vars anywhere</description>
-        <expected-problems>5</expected-problems>
-        <expected-linenumbers>5,6,8,9,12</expected-linenumbers>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>7,8,10,11,14,17</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 
     <test-code>
         <description>Allow literals</description>
         <rule-property name="allowLiterals">true</rule-property>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>8,9,12</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>10,11,14,17</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 
     <test-code>
         <description>Allow constructor calls</description>
         <rule-property name="allowCtors">true</rule-property>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>5,6,8,12</expected-linenumbers>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>7,8,10,14,17</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 
     <test-code>
         <description>Allow casts</description>
         <rule-property name="allowCasts">true</rule-property>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>5,6,8,9</expected-linenumbers>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>7,8,10,11,17</expected-linenumbers>
+        <code-ref id="basic-sample"/>
+    </test-code>
+
+    <test-code>
+        <description>Allow loop variables</description>
+        <rule-property name="allowLoopVariable">true</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>7,8,10,11,14</expected-linenumbers>
         <code-ref id="basic-sample"/>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Adds two more options to UseExplicitTypes: allowCasts and allowLoopVariable

## Related issues

- Fix #4916 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

