### PR TITLE
Issue 5569 java excessive public count should report number of public things

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
@@ -33,7 +33,7 @@ public class ExcessiveImportsRule extends AbstractJavaCounterCheckRule<ASTCompil
      */
     @Override
     protected boolean isViolation(ASTCompilationUnit node, int reportLevel) {
-        return false;
+        return super.isViolation(node, reportLevel);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
@@ -28,8 +28,16 @@ public class ExcessiveImportsRule extends AbstractJavaCounterCheckRule<ASTCompil
         return 30;
     }
 
+    /**
+     * @deprecated since 7.17.0
+     */
     @Override
     protected boolean isViolation(ASTCompilationUnit node, int reportLevel) {
-        return node.children(ASTImportDeclaration.class).count() >= reportLevel;
+        return false;
+    }
+
+    @Override
+    protected int getMetric(ASTCompilationUnit node) {
+        return node.children(ASTImportDeclaration.class).count();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -42,7 +42,7 @@ public class ExcessiveParameterListRule extends AbstractJavaCounterCheckRule<AST
      */
     @Override
     protected boolean isViolation(ASTFormalParameters node, int reportLevel) {
-        return false;
+        return super.isViolation(node, reportLevel);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -49,9 +49,4 @@ public class ExcessiveParameterListRule extends AbstractJavaCounterCheckRule<AST
     protected int getMetric(ASTFormalParameters node) {
         return node.size();
     }
-
-    @Override
-    protected boolean checkViolation(int metric, int threshold) {
-        return metric > threshold;
-    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -37,8 +37,21 @@ public class ExcessiveParameterListRule extends AbstractJavaCounterCheckRule<AST
                 && ((ASTConstructorDeclaration) parent).getVisibility() == Visibility.V_PRIVATE;
     }
 
+    /**
+     * @deprecated since 7.17.0
+     */
     @Override
     protected boolean isViolation(ASTFormalParameters node, int reportLevel) {
-        return node.size() > reportLevel;
+        return false;
+    }
+
+    @Override
+    protected int getMetric(ASTFormalParameters node) {
+        return node.size();
+    }
+
+    @Override
+    protected boolean checkViolation(int metric, int threshold) {
+        return metric > threshold;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
@@ -39,15 +39,21 @@ public class ExcessivePublicCountRule extends AbstractJavaCounterCheckRule<ASTTy
         return 45;
     }
 
+    /**
+     * @deprecated since 7.17.0
+     */
     @Override
     protected boolean isViolation(ASTTypeDeclaration node, int reportLevel) {
-        long publicCount = node.getDeclarations()
-                               .filterIs(ModifierOwner.class)
-                               .filter(it -> it.hasModifiers(PUBLIC))
-                               // filter out constants
-                               .filter(it -> !(it instanceof ASTFieldDeclaration && it.hasModifiers(STATIC, FINAL)))
-                               .count();
+        return false;
+    }
 
-        return publicCount >= reportLevel;
+    @Override
+    protected int getMetric(ASTTypeDeclaration node) {
+        return node.getDeclarations()
+                   .filterIs(ModifierOwner.class)
+                   .filter(it -> it.hasModifiers(PUBLIC))
+                   // filter out constants
+                   .filter(it -> !(it instanceof ASTFieldDeclaration && it.hasModifiers(STATIC, FINAL)))
+                   .count();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
@@ -44,7 +44,7 @@ public class ExcessivePublicCountRule extends AbstractJavaCounterCheckRule<ASTTy
      */
     @Override
     protected boolean isViolation(ASTTypeDeclaration node, int reportLevel) {
-        return false;
+        return super.isViolation(node, reportLevel);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -46,7 +46,10 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
     /**
      * @deprecated since 7.17.0
      */
-    protected abstract boolean isViolation(T node, int reportLevel);
+    protected boolean isViolation(T node, int reportLevel) {
+        int metric = getMetric(node);
+        return checkViolation(metric, reportLevel);
+    }
 
     protected abstract int getMetric(T node);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -48,14 +48,10 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
      */
     protected boolean isViolation(T node, int reportLevel) {
         int metric = getMetric(node);
-        return checkViolation(metric, reportLevel);
+        return metric >= reportLevel;
     }
 
     protected abstract int getMetric(T node);
-
-    protected boolean checkViolation(int metric, int threshold) {
-        return metric >= threshold;
-    }
 
     @Override
     public Object visitJavaNode(JavaNode node, Object data) {
@@ -65,7 +61,8 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
 
         if (!isIgnored(t)) {
             int metric = getMetric(t);
-            if (checkViolation(metric, getProperty(reportLevel))) {
+            int threshold = getProperty(reportLevel);
+            if (metric >= threshold) {
                 asCtx(data).addViolation(node, metric);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -42,8 +42,17 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
         return false;
     }
 
+
+    /**
+     * @deprecated since 7.17.0
+     */
     protected abstract boolean isViolation(T node, int reportLevel);
 
+    protected abstract int getMetric(T node);
+
+    protected boolean checkViolation(int metric, int threshold) {
+        return metric >= threshold;
+    }
 
     @Override
     public Object visitJavaNode(JavaNode node, Object data) {
@@ -52,8 +61,9 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
         // since we only visit this node, it's ok
 
         if (!isIgnored(t)) {
-            if (isViolation(t, getProperty(reportLevel))) {
-                asCtx(data).addViolation(node);
+            int metric = getMetric(t);
+            if (checkViolation(metric, getProperty(reportLevel))) {
+                asCtx(data).addViolation(node, metric);
             }
         }
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -623,7 +623,7 @@ public void bar() {
     <rule name="ExcessiveImports"
           language="java"
           since="1.04"
-          message="A high number of imports can indicate a high degree of coupling within an object."
+          message="A high number of imports ({0}) can indicate a high degree of coupling within an object."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveImportsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessiveimports">
         <description>
@@ -647,7 +647,7 @@ public class Foo {
     <rule name="ExcessiveParameterList"
           language="java"
           since="0.9"
-          message="Avoid long parameter lists."
+          message="Avoid long parameter lists ({0} parameters)."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveParameterListRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessiveparameterlist">
         <description>
@@ -675,7 +675,7 @@ public void addPerson(      // preferred approach
     <rule name="ExcessivePublicCount"
           language="java"
           since="1.04"
-          message="This class has a bunch of public methods and attributes"
+          message="This class has {0} public methods and attributes"
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessivePublicCountRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessivepubliccount">
         <description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveImports.xml
@@ -26,4 +26,20 @@ import java.util.Vector;
 public class Foo{}
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Verify message includes import count</description>
+        <rule-property name="minimum">3</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>A high number of imports (4) can indicate a high degree of coupling within an object.</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.util.Vector;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+public class Foo{}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveParameterList.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveParameterList.xml
@@ -53,4 +53,18 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Verify message includes parameter count</description>
+        <rule-property name="minimum">9</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Avoid long parameter lists (10 parameters).</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int p01, int p02, int p03, int p04, int p05, int p06, int p07, int p08, int p09, int p10 ) { }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessivePublicCount.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessivePublicCount.xml
@@ -91,4 +91,14 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Verify message includes actual count</description>
+        <rule-property name="minimum">2</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>This class has 3 public methods and attributes</message>
+        </expected-messages>
+        <code-ref id="id-3-public-methods"/>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This is the pmd-apex part of #6011
This PR changes ExcessiveClassLength/ExcessiveParameterList in pmd-apex to include the number of lines/parameters in the message. Plus some tests where the count was already there, but there were no tests for the message.

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)