### PR TITLE
[apex] ExcessiveClassLength/ExcessiveParameterList include the metric in the message

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -206,7 +206,7 @@ public class Foo {
     <rule name="ExcessiveClassLength"
           language="apex"
           since="5.5.0"
-          message="Avoid really long classes."
+          message="Avoid really long classes ({0} lines)."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveClassLengthRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#excessiveclasslength">
         <description>
@@ -238,7 +238,7 @@ public class Foo {
     <rule name="ExcessiveParameterList"
           language="apex"
           since="5.5.0"
-          message="Avoid long parameter lists."
+          message="Avoid long parameter lists ({0} parameters)."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveParameterListRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#excessiveparameterlist">
         <description>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveClassLength.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveClassLength.xml
@@ -42,6 +42,16 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Verify message includes line count</description>
+        <rule-property name="minimum">10</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Avoid really long classes (13 lines).</message>
+        </expected-messages>
+        <code-ref id="long"/>
+    </test-code>
+
+    <test-code>
         <description>long class - changed minimum</description>
         <rule-property name="minimum">2000</rule-property>
         <expected-problems>0</expected-problems>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveParameterList.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveParameterList.xml
@@ -29,6 +29,21 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Verify message includes parameter count</description>
+        <rule-property name="minimum">9</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Avoid long parameter lists (10 parameters).</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public void foo(Integer p01, Integer p02, Integer p03, Integer p04, Integer p05, Integer p06, Integer p07, Integer p08, Integer p09, Integer p10 ) { }
+    public void bar(Integer p01, Integer p02, Integer p03, Integer p04, Integer p05 ) { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
        <description>#1396 Public method with javadoc</description>
        <expected-problems>0</expected-problems>
        <code><![CDATA[

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssConstructorCount.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssConstructorCount.xml
@@ -74,6 +74,16 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Verify message includes NCSS count</description>
+        <rule-property name="minimum">13</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The constructor has an NCSS line count of 13</message>
+        </expected-messages>
+        <code-ref id="long-constructor"/>
+    </test-code>
+
+    <test-code>
         <description>long method - changed minimum</description>
         <!-- obtained this value by using NCSS directly -->
         <rule-property name="minimum">14</rule-property>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssTypeCount.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssTypeCount.xml
@@ -74,6 +74,16 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Verify message includes NCSS count</description>
+        <rule-property name="minimum">13</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The type has an NCSS line count of 14</message>
+        </expected-messages>
+        <code-ref id="long-method"/>
+    </test-code>
+
+    <test-code>
         <description>long method - changed minimum</description>
         <!-- validated this number against NCSS -->
         <rule-property name="minimum">15</rule-property>


### PR DESCRIPTION
## Describe the PR

This is the pmd-apex part of #6011
This PR changes ExcessiveClassLength/ExcessiveParameterList in pmd-apex to include the number of lines/parameters in the message. Plus some tests where the count was already there, but there were no tests for the message.

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)