### PR TITLE
[test] Fix #6012: Alphabetically sort all default rules

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -264,27 +264,6 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="UnusedLocalVariable"
-          since="6.23.0"
-          language="apex"
-          message="Variable ''{0}'' defined but not used"
-          class="net.sourceforge.pmd.lang.apex.rule.bestpractices.UnusedLocalVariableRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#unusedlocalvariable">
-        <description>
-Detects when a local variable is declared and/or assigned but not used.
-        </description>
-        <example>
-<![CDATA[
-    public Boolean bar(String z) {
-        String x = 'some string'; // not used
-
-        String y = 'some other string'; // used in the next line
-        return z.equals(y);
-    }
-]]>
-        </example>
-    </rule>
-
     <rule name="QueueableWithoutFinalizer"
           since="7.8.0"
           language="apex"
@@ -292,13 +271,13 @@ Detects when a local variable is declared and/or assigned but not used.
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.QueueableWithoutFinalizerRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#queueablewithoutfinalizer">
         <description>
-Detects when the Queueable interface is used but a Finalizer is not attached.
-It is best practice to call the `System.attachFinalizer(Finalizer f)` method within the `execute` method of a class which implements the `Queueable` interface.
-Without attaching a Finalizer, there is no way of designing error recovery actions should the Queueable action fail.
+            Detects when the Queueable interface is used but a Finalizer is not attached.
+            It is best practice to call the `System.attachFinalizer(Finalizer f)` method within the `execute` method of a class which implements the `Queueable` interface.
+            Without attaching a Finalizer, there is no way of designing error recovery actions should the Queueable action fail.
         </description>
         <priority>5</priority>
         <example>
-<![CDATA[
+            <![CDATA[
 // Incorrect code, does not attach a finalizer.
 public class UserUpdater implements Queueable {
     public List<User> usersToUpdate;
@@ -333,6 +312,27 @@ public class UserUpdater implements Queueable, Finalizer {
         }
     }
 }
+]]>
+        </example>
+    </rule>
+
+    <rule name="UnusedLocalVariable"
+          since="6.23.0"
+          language="apex"
+          message="Variable ''{0}'' defined but not used"
+          class="net.sourceforge.pmd.lang.apex.rule.bestpractices.UnusedLocalVariableRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#unusedlocalvariable">
+        <description>
+Detects when a local variable is declared and/or assigned but not used.
+        </description>
+        <example>
+<![CDATA[
+    public Boolean bar(String z) {
+        String x = 'some string'; // not used
+
+        String y = 'some other string'; // used in the next line
+        return z.equals(y);
+    }
 ]]>
         </example>
     </rule>

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -70,76 +70,6 @@ public class fooClass { } // This will be reported unless you change the regex
         </example>
     </rule>
 
-    <rule name="IfElseStmtsMustUseBraces"
-          language="apex"
-          since="5.6.0"
-          message="Avoid using 'if...else' statements without curly braces"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#ifelsestmtsmustusebraces">
-        <description>
-Avoid using if..else statements without using surrounding braces. If the code formatting
-or indentation is lost then it becomes difficult to separate the code being controlled
-from the rest.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//IfBlockStatement/BlockStatement[@CurlyBrace= false()][count(child::*) > 0]
-|
-//IfElseBlockStatement/BlockStatement[@CurlyBrace= false()][count(child::*) > 0]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
-// this is OK
-if (foo) x++;
-
-// but this is not
-if (foo)
-    x = x+1;
-else
-    x = x-1;
-]]>
-        </example>
-    </rule>
-
-    <rule name="IfStmtsMustUseBraces"
-          language="apex"
-          since="5.6.0"
-          message="Avoid using if statements without curly braces"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#ifstmtsmustusebraces">
-        <description>
-Avoid using if statements without using braces to surround the code block. If the code
-formatting or indentation is lost then it becomes difficult to separate the code being
-controlled from the rest.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//IfBlockStatement/BlockStatement[@CurlyBrace= false()]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
- <![CDATA[
-if (foo)    // not recommended
-    x++;
-
-if (foo) {  // preferred approach
-    x++;
-}
-]]>
-        </example>
-    </rule>
-
     <rule name="FieldDeclarationsShouldBeAtStart"
           language="apex"
           since="6.23.0"
@@ -245,6 +175,76 @@ public class Foo {
     public bar(Integer methodParameter) { } // This is in camel case, so it's ok
 
     public baz(Integer METHOD_PARAMETER) { } // This will be reported unless you change the regex
+}
+]]>
+        </example>
+    </rule>
+
+    <rule name="IfElseStmtsMustUseBraces"
+          language="apex"
+          since="5.6.0"
+          message="Avoid using 'if...else' statements without curly braces"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#ifelsestmtsmustusebraces">
+        <description>
+            Avoid using if..else statements without using surrounding braces. If the code formatting
+            or indentation is lost then it becomes difficult to separate the code being controlled
+            from the rest.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//IfBlockStatement/BlockStatement[@CurlyBrace= false()][count(child::*) > 0]
+|
+//IfElseBlockStatement/BlockStatement[@CurlyBrace= false()][count(child::*) > 0]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+// this is OK
+if (foo) x++;
+
+// but this is not
+if (foo)
+    x = x+1;
+else
+    x = x-1;
+]]>
+        </example>
+    </rule>
+
+    <rule name="IfStmtsMustUseBraces"
+          language="apex"
+          since="5.6.0"
+          message="Avoid using if statements without curly braces"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#ifstmtsmustusebraces">
+        <description>
+            Avoid using if statements without using braces to surround the code block. If the code
+            formatting or indentation is lost then it becomes difficult to separate the code being
+            controlled from the rest.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//IfBlockStatement/BlockStatement[@CurlyBrace= false()]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+if (foo)    // not recommended
+    x++;
+
+if (foo) {  // preferred approach
+    x++;
 }
 ]]>
         </example>

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -9,33 +9,6 @@
 Rules that help you discover design issues.
     </description>
 
-    <rule name="AvoidDeeplyNestedIfStmts"
-          language="apex"
-          since="5.5.0"
-          message="Deeply nested if..then statements are hard to read"
-          class="net.sourceforge.pmd.lang.apex.rule.design.AvoidDeeplyNestedIfStmtsRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#avoiddeeplynestedifstmts">
-        <description>
-Avoid creating deeply nested if-then statements since they are harder to read and error-prone to maintain.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
-public class Foo {
-    public void bar(Integer x, Integer y, Integer z) {
-        if (x>y) {
-            if (y>z) {
-                if (z==x) {
-                    // !! too deep
-                }
-            }
-        }
-    }
-}
-]]>
-        </example>
-    </rule>
-
     <rule name="AvoidBooleanMethodParameters"
           language="apex"
           since="7.15.0"
@@ -87,53 +60,28 @@ public void disableStrictChecking() { ... }
         ]]></example>
     </rule>
 
-    <rule name="CyclomaticComplexity"
+    <rule name="AvoidDeeplyNestedIfStmts"
           language="apex"
-          message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
-          since="6.0.0"
-          class="net.sourceforge.pmd.lang.apex.rule.design.CyclomaticComplexityRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cyclomaticcomplexity">
+          since="5.5.0"
+          message="Deeply nested if..then statements are hard to read"
+          class="net.sourceforge.pmd.lang.apex.rule.design.AvoidDeeplyNestedIfStmtsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#avoiddeeplynestedifstmts">
         <description>
-The complexity of methods directly affects maintenance costs and readability. Concentrating too much decisional logic
-in a single method makes its behaviour hard to read and change.
-
-Cyclomatic complexity assesses the complexity of a method by counting the number of decision points in a method,
-plus one for the method entry. Decision points are places where the control flow jumps to another place in the
-program. As such, they include all control flow statements, such as 'if', 'while', 'for', and 'case'.
-
-Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
-high complexity, and 11+ is very high complexity. By default, this rule reports methods with a complexity >= 10.
-Additionally, classes with many methods of moderate complexity get reported as well once the total of their
-methods' complexities reaches 40, even if none of the methods was directly reported.
-
-Reported methods should be broken down into several smaller methods. Reported classes should probably be broken down
-into subcomponents.
+Avoid creating deeply nested if-then statements since they are harder to read and error-prone to maintain.
         </description>
         <priority>3</priority>
         <example>
 <![CDATA[
-public class Complicated {
-  public void example() { // This method has a cyclomatic complexity of 12
-    int x = 0, y = 1, z = 2, t = 2;
-    boolean a = false, b = true, c = false, d = true;
-    if (a && b || b && d) {
-      if (y == z) {
-        x = 2;
-      } else if (y == t && !d) {
-        x = 2;
-      } else {
-        x = 2;
-      }
-    } else if (c && d) {
-      while (z < y) {
-        x = 2;
-      }
-    } else {
-      for (int n = 0; n < t; n++) {
-        x = 2;
-      }
+public class Foo {
+    public void bar(Integer x, Integer y, Integer z) {
+        if (x>y) {
+            if (y>z) {
+                if (z==x) {
+                    // !! too deep
+                }
+            }
+        }
     }
-  }
 }
 ]]>
         </example>
@@ -198,6 +146,58 @@ public class Foo {
 
         update contactsToUpdate;
     }
+}
+]]>
+        </example>
+    </rule>
+
+    <rule name="CyclomaticComplexity"
+          language="apex"
+          message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
+          since="6.0.0"
+          class="net.sourceforge.pmd.lang.apex.rule.design.CyclomaticComplexityRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cyclomaticcomplexity">
+        <description>
+The complexity of methods directly affects maintenance costs and readability. Concentrating too much decisional logic
+in a single method makes its behaviour hard to read and change.
+
+Cyclomatic complexity assesses the complexity of a method by counting the number of decision points in a method,
+plus one for the method entry. Decision points are places where the control flow jumps to another place in the
+program. As such, they include all control flow statements, such as 'if', 'while', 'for', and 'case'.
+
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity. By default, this rule reports methods with a complexity >= 10.
+Additionally, classes with many methods of moderate complexity get reported as well once the total of their
+methods' complexities reaches 40, even if none of the methods was directly reported.
+
+Reported methods should be broken down into several smaller methods. Reported classes should probably be broken down
+into subcomponents.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+public class Complicated {
+  public void example() { // This method has a cyclomatic complexity of 12
+    int x = 0, y = 1, z = 2, t = 2;
+    boolean a = false, b = true, c = false, d = true;
+    if (a && b || b && d) {
+      if (y == z) {
+        x = 2;
+      } else if (y == t && !d) {
+        x = 2;
+      } else {
+        x = 2;
+      }
+    } else if (c && d) {
+      while (z < y) {
+        x = 2;
+      }
+    } else {
+      for (int n = 0; n < t; n++) {
+        x = 2;
+      }
+    }
+  }
 }
 ]]>
         </example>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -417,6 +417,53 @@ while (true) {  // preferred approach
         </example>
     </rule>
 
+    <rule name="EmptyControlStatement"
+          language="java"
+          since="6.46.0"
+          message="This control statement has an empty branch"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.EmptyControlStatementRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#emptycontrolstatement">
+        <!-- Note about naming: EmptyCodeBlock does not work because the rule flags `if(true);`  -->
+        <!-- EmptyControlStatement is weird because `{}` is not a control statement, and we also flag initializers. -->
+        <!-- EmptyStatement does not work because `;` is called an "empty statement" and is not flagged by this rule, rather, by UnnecessarySemicolon. -->
+        <!-- EmptyCodeConstruct would work but sounds a bit odd (right?). -->
+        <description><![CDATA[
+            Reports control statements whose body is empty, as well as empty initializers.
+
+            The checked code constructs are the following:
+            - bodies of `try` statements
+            - `finally` clauses of `try` statements
+            - `switch` statements
+            - `synchronized` statements
+            - `if` statements
+            - loop statements: `while`, `for`, `do .. while`
+            - initializers
+            - blocks used as statements (for scoping)
+
+            This rule replaces the rules EmptyFinallyBlock,
+            EmptyIfStmt, EmptyInitializer, EmptyStatementBlock,
+            EmptySwitchStatements, EmptySynchronizedBlock, EmptyTryBlock, and EmptyWhileStmt.
+
+            Notice that {% rule java/errorprone/EmptyCatchBlock %} is still an independent rule.
+
+            EmptyStatementNotInLoop is replaced by {% rule java/codestyle/UnnecessarySemicolon %}.
+        ]]></description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+class Foo {
+    {
+        if (true); // empty if statement
+        if (true) { // empty as well
+        }
+    }
+
+    {} // empty initializer
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="EmptyMethodInAbstractClassShouldBeAbstract"
           language="java"
           since="4.1"
@@ -454,53 +501,6 @@ public abstract class ShouldBeAbstract {
 
     public void couldBeAbstract() {
     }
-}
-]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyControlStatement"
-          language="java"
-          since="6.46.0"
-          message="This control statement has an empty branch"
-          class="net.sourceforge.pmd.lang.java.rule.codestyle.EmptyControlStatementRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#emptycontrolstatement">
-        <!-- Note about naming: EmptyCodeBlock does not work because the rule flags `if(true);`  -->
-        <!-- EmptyControlStatement is weird because `{}` is not a control statement, and we also flag initializers. -->
-        <!-- EmptyStatement does not work because `;` is called an "empty statement" and is not flagged by this rule, rather, by UnnecessarySemicolon. -->
-        <!-- EmptyCodeConstruct would work but sounds a bit odd (right?). -->
-        <description><![CDATA[
-            Reports control statements whose body is empty, as well as empty initializers.
-
-            The checked code constructs are the following:
-            - bodies of `try` statements
-            - `finally` clauses of `try` statements
-            - `switch` statements
-            - `synchronized` statements
-            - `if` statements
-            - loop statements: `while`, `for`, `do .. while`
-            - initializers
-            - blocks used as statements (for scoping)
-
-            This rule replaces the rules EmptyFinallyBlock, 
-            EmptyIfStmt, EmptyInitializer, EmptyStatementBlock, 
-            EmptySwitchStatements, EmptySynchronizedBlock, EmptyTryBlock, and EmptyWhileStmt.
-
-            Notice that {% rule java/errorprone/EmptyCatchBlock %} is still an independent rule.
-
-            EmptyStatementNotInLoop is replaced by {% rule java/codestyle/UnnecessarySemicolon %}.
-        ]]></description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
-class Foo {
-    {
-        if (true); // empty if statement
-        if (true) { // empty as well
-        }
-    }
-
-    {} // empty initializer
 }
 ]]>
         </example>
@@ -1200,97 +1200,6 @@ public class ClassInDefaultPackage {
         </example>
     </rule>
 
-    <rule name="UseUnderscoresInNumericLiterals"
-          language="java"
-          since="6.10.0"
-          minimumLanguageVersion="1.7"
-          message="Number {0} should separate every third digit with an underscore"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#useunderscoresinnumericliterals">
-        <description>
-            Since Java 1.7, numeric literals can use underscores to separate digits. This rule enforces that
-            numeric literals above a certain length use these underscores to increase readability.
-
-            The rule only supports decimal (base 10) literals for now. The acceptable length under which literals
-            are not required to have underscores is configurable via a property. Even under that length, underscores
-            that are misplaced (not making groups of 3 digits) are reported.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="acceptableDecimalLength" type="Integer" value="4" min="3" max="1000"
-                      description="Length under which literals in base 10 are not required to have underscores"/>
-            <property name="xpath">
-                <value>
-                    <![CDATA[
-//NumericLiteral
- (: Filter out literals in base other than 10 :)
- [@Base = 10]
- (: Filter out ignored field name :)
- [not(ancestor::VariableDeclarator[1][@Name = 'serialVersionUID'])]
- [
-   some $num in tokenize(@Image, "[dDfFlLeE+\-]")
-   satisfies not(
-                  ( contains($num, ".")
-                    and string-length(substring-before($num, ".")) <= $acceptableDecimalLength
-                    and string-length(substring-after($num, ".")) <= $acceptableDecimalLength
-                    or string-length($num) <= $acceptableDecimalLength
-                  )
-                  and not(contains($num,"_"))
-                  or matches($num, "^[0-9]{1,3}(_[0-9]{3})*(\.([0-9]{3}_)*[0-9]{1,3})?$")
-                )
- ]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-            <![CDATA[
-public class Foo {
-    private int num = 1000000; // should be 1_000_000
-}
-]]>
-        </example>
-    </rule>
-
-    <rule name="TypeParameterNamingConventions"
-          language="java"
-          since="7.17.0"
-          message="The {0} name ''{1}'' doesn''t match ''{2}''"
-          class="net.sourceforge.pmd.lang.java.rule.codestyle.TypeParameterNamingConventionsRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#typeparameternamingconventions">
-        <description>
-            Configurable naming conventions for type parameters in generic types and methods.
-            This rule reports type parameter declarations which do not match the configured regex.
-            Type parameters can appear on classes, interfaces, enums, records, and methods.
-
-            By default, this rule uses the standard Java naming convention (single uppercase letter).
-        </description>
-        <priority>4</priority>
-        <example>
-<![CDATA[
-// Generic types - valid
-public interface Repository<T> { }
-public class Cache<K, V> { }
-
-// Generic types - invalid
-public interface Repository<type> { }      // lowercase
-public class Cache<KEY, VALUE> { }         // multiple letters
-
-// Generic methods - valid
-public class Util {
-    public static <T> T identity(T value) { return value; }
-    public <T, R> R transform(T input, Function<T, R> mapper) { }
-}
-
-// Generic methods - invalid
-public class Util {
-    public static <element> element get(element value) { }  // lowercase
-    public <INPUT, OUTPUT> OUTPUT convert(INPUT in) { }     // multiple letters
-}
-]]>
-        </example>
-    </rule>
-
     <rule name="OnlyOneReturn"
           language="java"
           since="1.0"
@@ -1607,6 +1516,44 @@ import static Yoko; // Too much !
         </example>
     </rule>
 
+    <rule name="TypeParameterNamingConventions"
+          language="java"
+          since="7.17.0"
+          message="The {0} name ''{1}'' doesn''t match ''{2}''"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.TypeParameterNamingConventionsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#typeparameternamingconventions">
+        <description>
+            Configurable naming conventions for type parameters in generic types and methods.
+            This rule reports type parameter declarations which do not match the configured regex.
+            Type parameters can appear on classes, interfaces, enums, records, and methods.
+
+            By default, this rule uses the standard Java naming convention (single uppercase letter).
+        </description>
+        <priority>4</priority>
+        <example>
+            <![CDATA[
+// Generic types - valid
+public interface Repository<T> { }
+public class Cache<K, V> { }
+
+// Generic types - invalid
+public interface Repository<type> { }      // lowercase
+public class Cache<KEY, VALUE> { }         // multiple letters
+
+// Generic methods - valid
+public class Util {
+    public static <T> T identity(T value) { return value; }
+    public <T, R> R transform(T input, Function<T, R> mapper) { }
+}
+
+// Generic methods - invalid
+public class Util {
+    public static <element> element get(element value) { }  // lowercase
+    public <INPUT, OUTPUT> OUTPUT convert(INPUT in) { }     // multiple letters
+}
+]]>
+        </example>
+    </rule>
 
     <rule name="UnnecessaryAnnotationValueElement"
           language="java"
@@ -2193,6 +2140,58 @@ E.g. `int[] x = new int[] { 1, 2, 3 };` can be written as `int[] x = { 1, 2, 3 }
 <![CDATA[
 Foo[] x = new Foo[] { ... }; // Overly verbose
 Foo[] x = { ... }; //Equivalent to above line
+]]>
+        </example>
+    </rule>
+
+    <rule name="UseUnderscoresInNumericLiterals"
+          language="java"
+          since="6.10.0"
+          minimumLanguageVersion="1.7"
+          message="Number {0} should separate every third digit with an underscore"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#useunderscoresinnumericliterals">
+        <description>
+            Since Java 1.7, numeric literals can use underscores to separate digits. This rule enforces that
+            numeric literals above a certain length use these underscores to increase readability.
+
+            The rule only supports decimal (base 10) literals for now. The acceptable length under which literals
+            are not required to have underscores is configurable via a property. Even under that length, underscores
+            that are misplaced (not making groups of 3 digits) are reported.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="acceptableDecimalLength" type="Integer" value="4" min="3" max="1000"
+                      description="Length under which literals in base 10 are not required to have underscores"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//NumericLiteral
+ (: Filter out literals in base other than 10 :)
+ [@Base = 10]
+ (: Filter out ignored field name :)
+ [not(ancestor::VariableDeclarator[1][@Name = 'serialVersionUID'])]
+ [
+   some $num in tokenize(@Image, "[dDfFlLeE+\-]")
+   satisfies not(
+                  ( contains($num, ".")
+                    and string-length(substring-before($num, ".")) <= $acceptableDecimalLength
+                    and string-length(substring-after($num, ".")) <= $acceptableDecimalLength
+                    or string-length($num) <= $acceptableDecimalLength
+                  )
+                  and not(contains($num,"_"))
+                  or matches($num, "^[0-9]{1,3}(_[0-9]{3})*(\.([0-9]{3}_)*[0-9]{1,3})?$")
+                )
+ ]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class Foo {
+    private int num = 1000000; // should be 1_000_000
+}
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -319,6 +319,67 @@ public class Foo {  //Should be final
         </example>
     </rule>
 
+    <rule name="CognitiveComplexity"
+          language="java"
+          message="The {0} ''{1}'' has a cognitive complexity of {2}, current threshold is {3}"
+          since="6.35.0"
+          class="net.sourceforge.pmd.lang.java.rule.design.CognitiveComplexityRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#cognitivecomplexity">
+        <description><![CDATA[
+            Methods that are highly complex are difficult to read and more costly to maintain. If you include too much decisional
+            logic within a single method, you make its behavior hard to understand and more difficult to modify.
+
+            Cognitive complexity is a measure of how difficult it is for humans to read and understand a method. Code that contains
+            a break in the control flow is more complex, whereas the use of language shorthands doesn't increase the level of
+            complexity. Nested control flows can make a method more difficult to understand, with each additional nesting of the
+            control flow leading to an increase in cognitive complexity.
+
+            Information about Cognitive complexity can be found in the original paper here:
+            <https://www.sonarsource.com/docs/CognitiveComplexity.pdf>
+
+            By default, this rule reports methods with a complexity of 15 or more. Reported methods should be broken down into less
+            complex components.
+        ]]></description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+public class Foo {
+  // Has a cognitive complexity of 0
+  public void createAccount() {
+    Account account = new Account("PMD");
+    // save account
+  }
+
+  // Has a cognitive complexity of 1
+  public Boolean setPhoneNumberIfNotExisting(Account a, String phone) {
+    if (a.phone == null) {                          // +1
+      a.phone = phone;
+      return true;
+    }
+
+    return false;
+  }
+
+  // Has a cognitive complexity of 4
+  public void updateContacts(List<Contact> contacts) {
+    List<Contact> contactsToUpdate = new ArrayList<Contact>();
+
+    for (Contact contact : contacts) {                           // +1
+      if (contact.department.equals("Finance")) {                // +2 (nesting = 1)
+        contact.title = "Finance Specialist";
+        contactsToUpdate.add(contact);
+      } else if (contact.department.equals("Sales")) {           // +1
+        contact.title = "Sales Specialist";
+        contactsToUpdate.add(contact);
+      }
+    }
+    // save contacts
+  }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="CollapsibleIfStatements"
           language="java"
           since="3.1"
@@ -396,66 +457,6 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="CognitiveComplexity"
-        language="java"
-        message="The {0} ''{1}'' has a cognitive complexity of {2}, current threshold is {3}"
-        since="6.35.0"
-        class="net.sourceforge.pmd.lang.java.rule.design.CognitiveComplexityRule"
-        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#cognitivecomplexity">
-        <description><![CDATA[
-            Methods that are highly complex are difficult to read and more costly to maintain. If you include too much decisional
-            logic within a single method, you make its behavior hard to understand and more difficult to modify.
-
-            Cognitive complexity is a measure of how difficult it is for humans to read and understand a method. Code that contains
-            a break in the control flow is more complex, whereas the use of language shorthands doesn't increase the level of
-            complexity. Nested control flows can make a method more difficult to understand, with each additional nesting of the
-            control flow leading to an increase in cognitive complexity.
-
-            Information about Cognitive complexity can be found in the original paper here:
-            <https://www.sonarsource.com/docs/CognitiveComplexity.pdf>
-
-            By default, this rule reports methods with a complexity of 15 or more. Reported methods should be broken down into less
-            complex components.
-        ]]></description>
-        <priority>3</priority>
-        <example>
-            <![CDATA[
-public class Foo {
-  // Has a cognitive complexity of 0
-  public void createAccount() {
-    Account account = new Account("PMD");
-    // save account
-  }
-
-  // Has a cognitive complexity of 1
-  public Boolean setPhoneNumberIfNotExisting(Account a, String phone) {
-    if (a.phone == null) {                          // +1
-      a.phone = phone;
-      return true;
-    }
-
-    return false;
-  }
-
-  // Has a cognitive complexity of 4
-  public void updateContacts(List<Contact> contacts) {
-    List<Contact> contactsToUpdate = new ArrayList<Contact>();
-
-    for (Contact contact : contacts) {                           // +1
-      if (contact.department.equals("Finance")) {                // +2 (nesting = 1)
-        contact.title = "Finance Specialist";
-        contactsToUpdate.add(contact);
-      } else if (contact.department.equals("Sales")) {           // +1
-        contact.title = "Sales Specialist";
-        contactsToUpdate.add(contact);
-      }
-    }
-    // save contacts
-  }
-}
-]]>
-        </example>
-    </rule>
 
     <rule name="CyclomaticComplexity"
           language="java"
@@ -961,6 +962,43 @@ public class Bar {
         </example>
     </rule>
 
+    <rule name="MutableStaticState"
+          language="java"
+          since="6.35.0"
+          message="Do not use non-final non-private static fields"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#mutablestaticstate">
+        <description>
+            Non-private static fields should be made constants (or immutable references) by
+            declaring them final.
+
+            Non-private non-final static fields break encapsulation and can lead to hard to find
+            bugs, since these fields can be modified from anywhere within the program.
+            Callers can trivially access and modify non-private non-final static fields. Neither
+            accesses nor modifications can be guarded against, and newly set values cannot
+            be validated.
+
+            If you are using this rule, then you don't need this
+            rule {% rule java/errorprone/AssignmentToNonFinalStatic %}.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//FieldDeclaration[pmd-java:modifiers() = "static"][not(pmd-java:modifiers() = ("private", "final"))]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class Greeter { public static Foo foo = new Foo(); ... }       // avoid this
+public class Greeter { public static final Foo FOO = new Foo(); ... } // use this instead
+]]>
+        </example>
+    </rule>
+
     <rule name="NcssCount"
           language="java"
           message="The {0} ''{1}'' has a NCSS line count of {2}."
@@ -1458,43 +1496,6 @@ public class MaybeAUtility {
   public static void foo() {}
   public static void bar() {}
 }
-]]>
-        </example>
-    </rule>
-
-    <rule name="MutableStaticState"
-          language="java"
-          since="6.35.0"
-          message="Do not use non-final non-private static fields"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#mutablestaticstate">
-        <description>
-Non-private static fields should be made constants (or immutable references) by
-declaring them final.
-
-Non-private non-final static fields break encapsulation and can lead to hard to find
-bugs, since these fields can be modified from anywhere within the program.
-Callers can trivially access and modify non-private non-final static fields. Neither
-accesses nor modifications can be guarded against, and newly set values cannot
-be validated.
-
-If you are using this rule, then you don't need this
-rule {% rule java/errorprone/AssignmentToNonFinalStatic %}.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-                    <![CDATA[
-//FieldDeclaration[pmd-java:modifiers() = "static"][not(pmd-java:modifiers() = ("private", "final"))]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-            <![CDATA[
-public class Greeter { public static Foo foo = new Foo(); ... }       // avoid this
-public class Greeter { public static final Foo FOO = new Foo(); ... } // use this instead
 ]]>
         </example>
     </rule>

--- a/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
+++ b/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
@@ -8,6 +8,42 @@
 Rules which enforce generally accepted best practices.
     </description>
 
+    <rule name="AmbiguousResolution"
+          language="modelica"
+          message="Type resolution is ambiguous: {0}"
+          since="6.21.0"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_modelica_bestpractices.html#ambiguousresolution"
+          class="net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule">
+        <description>
+            There is multiple candidates for this type resolution. While generally this is not an error,
+            this may indicate a bug.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+package Test
+  package Inc1
+    model X
+    end X;
+    model Y
+    end Y;
+  end Inc1;
+  package Inc2
+    model Y
+    end Y;
+    model Z
+    end Z;
+  end Inc2;
+  model B
+    import Test.Inc1.*;
+    import Test.Inc2.*;
+    Y y; // Class Y is imported twice
+  end B;
+end Test;
+]]>
+        </example>
+    </rule>
+
     <rule name="ClassStartNameEqualsEndName"
           language="modelica"
           since="6.21.0"
@@ -73,39 +109,4 @@ end Example;
         </example>
     </rule>
 
-    <rule name="AmbiguousResolution"
-          language="modelica"
-          message="Type resolution is ambiguous: {0}"
-          since="6.21.0"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_modelica_bestpractices.html#ambiguousresolution"
-          class="net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule">
-        <description>
-            There is multiple candidates for this type resolution. While generally this is not an error,
-            this may indicate a bug.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
-package Test
-  package Inc1
-    model X
-    end X;
-    model Y
-    end Y;
-  end Inc1;
-  package Inc2
-    model Y
-    end Y;
-    model Z
-    end Z;
-  end Inc2;
-  model B
-    import Test.Inc1.*;
-    import Test.Inc2.*;
-    Y y; // Class Y is imported twice
-  end B;
-end Test;
-]]>
-        </example>
-    </rule>
 </ruleset>

--- a/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
@@ -92,49 +92,6 @@ END;
         ]]></example>
     </rule>
 
-    <rule name="MisplacedPragma"
-          language="plsql"
-          since="5.5.2"
-          message="Pragma should be used only inside the declaration block before 'BEGIN'."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_plsql_codestyle.html#misplacedpragma">
-        <description>
-Oracle states that the PRAQMA AUTONOMOUS_TRANSACTION must be in the declaration block,
-but the code does not complain, when being compiled on the 11g DB.
-https://docs.oracle.com/cd/B28359_01/appdev.111/b28370/static.htm#BABIIHBJ
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//ProgramUnit/Pragma
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
-create or replace package inline_pragma_error is
-
-end;
-/
-
-create or replace package body inline_pragma_error is
-  procedure do_transaction(p_input_token        in varchar(200)) is
-  PRAGMA AUTONOMOUS_TRANSACTION; /* this is correct place for PRAGMA */
-  begin
-    PRAGMA AUTONOMOUS_TRANSACTION; /* this is the wrong place for PRAGMA -> violation */
-    /* do something */
-    COMMIT;
-   end do_transaction;
-
-end inline_pragma_error;
-/
-]]>
-        </example>
-    </rule>
-
     <rule name="ForLoopNaming"
           language="plsql"
           since="6.7.0"
@@ -142,13 +99,13 @@ end inline_pragma_error;
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_plsql_codestyle.html#forloopnaming">
         <description>
-In case you have loops please name the loop variables more meaningful.
+            In case you have loops please name the loop variables more meaningful.
         </description>
         <priority>3</priority>
         <properties>
             <property name="xpath">
                 <value>
-<![CDATA[
+                    <![CDATA[
 //CursorForLoopStatement[
     $allowSimpleLoops = false() or
     (Statement//CursorForLoopStatement or ancestor::CursorForLoopStatement)
@@ -168,7 +125,7 @@ In case you have loops please name the loop variables more meaningful.
             <property name="indexPattern" type="Regex" description="The pattern used for the index loop variable" value="[a-zA-Z_0-9]{5,}" />
         </properties>
         <example>
-<![CDATA[
+            <![CDATA[
 -- good example
 BEGIN
 FOR company IN (SELECT * FROM companies) LOOP
@@ -208,6 +165,49 @@ This rule checks for long lines. Please note that comments are not ignored.
 This rule is the PMD equivalent of checkstyle's [LineLength](http://checkstyle.sourceforge.net/config_sizes.html#LineLength) check.
         </description>
         <priority>3</priority>
+    </rule>
+
+    <rule name="MisplacedPragma"
+          language="plsql"
+          since="5.5.2"
+          message="Pragma should be used only inside the declaration block before 'BEGIN'."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_plsql_codestyle.html#misplacedpragma">
+        <description>
+            Oracle states that the PRAQMA AUTONOMOUS_TRANSACTION must be in the declaration block,
+            but the code does not complain, when being compiled on the 11g DB.
+            https://docs.oracle.com/cd/B28359_01/appdev.111/b28370/static.htm#BABIIHBJ
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//ProgramUnit/Pragma
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+create or replace package inline_pragma_error is
+
+end;
+/
+
+create or replace package body inline_pragma_error is
+  procedure do_transaction(p_input_token        in varchar(200)) is
+  PRAGMA AUTONOMOUS_TRANSACTION; /* this is correct place for PRAGMA */
+  begin
+    PRAGMA AUTONOMOUS_TRANSACTION; /* this is the wrong place for PRAGMA -> violation */
+    /* do something */
+    COMMIT;
+   end do_transaction;
+
+end inline_pragma_error;
+/
+]]>
+        </example>
     </rule>
 
 </ruleset>

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/RulesetFactoryTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/RulesetFactoryTest.java
@@ -4,11 +4,25 @@
 
 package net.sourceforge.pmd.lang.scala;
 
-import net.sourceforge.pmd.test.lang.rule.AbstractRuleSetFactoryTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
 
 /**
- * Test scala rulesets
+ * Test scala rulesets.
  */
-class RulesetFactoryTest extends AbstractRuleSetFactoryTest {
+class RulesetFactoryTest {
+
     // no rulesets yet
+    @Test
+    void nothingToTest() throws IOException {
+        Properties props = new Properties();
+        props.load(RulesetFactoryTest.class.getClassLoader()
+            .getResourceAsStream("category/scala/categories.properties"));
+        assertEquals("", props.get("rulesets.filenames"),
+            "Once rulesets are added, this should extend AbstractRuleSetFactoryTest");
+    }
 }


### PR DESCRIPTION
## Describe the PR

Instead of implementing a XML rule as suggested in the issue I just added the check to the factory test.
For easier debugging the test is now parametrized. Since parametrization over empty list is not possible, the Scala test needed to be updated.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #6012 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

