### PR TITLE
Fix #5878: [java] DontUseFloatTypeForLoopIndices now checks the UpdateStatement as well

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1481,7 +1481,10 @@ performance need (space or time).
             <property name="xpath">
                 <value>
 <![CDATA[
-//ForStatement/ForInit//VariableId[pmd-java:typeIs('float')]
+//ForStatement[
+    ForInit//VariableId[pmd-java:typeIs('float')]
+    or ForUpdate//VariableAccess[pmd-java:typeIs('float')]
+]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DontUseFloatTypeForLoopIndices.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DontUseFloatTypeForLoopIndices.xml
@@ -37,4 +37,23 @@ public class Count {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>float variable declared before loop - issue #5878</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+class BuggyLoop {
+    public static void main(String[] args) {
+        float i = 0.0f;
+        for (; i < 10.0f; i += 0.5f) { // should raise DontUseFloatTypeForLoopIndices
+            System.out.println(i);
+            if (i > 5.0f)
+                break;
+        }
+        System.out.println("Loop completed at level: " + i);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Also trigger a violation if the loop variable isn't declared in ForInit

## Related issues

- Fix #5878

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)

