### PR TITLE
[java] Fix #5880: False Negatives in DoubleCheckedLocking

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
@@ -128,8 +128,7 @@ public class Foo {
             synchronized (Foo.class) {
                 result = instance;
                 if (result == null) {
-                    instance = new Foo();
-                    result = instance;
+                    result = instance = new Foo();
                 }
             }
         }
@@ -185,6 +184,30 @@ class Foo {
             System.out.println("This will never print.");
         }
         return baz;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>volatile field is referenced indirectly</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private volatile Foo instance;
+
+    public static Foo getInstance() {
+        Foo result = null;
+        result = this.instance;
+        if (result == null) {
+            synchronized (this) {
+                result = this.instance;
+                if (result == null) {
+                    result = new Foo();
+                    this.instance = result;
+                }
+            }
+        }
+        return result;
     }
 }
         ]]></code>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

This PR fixes both False Negatives described in #5880

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5880

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

