### PR TITLE
[java,apex,plsql,velocity] Change description of "minimum" parameter

### DIFF
--- a/docs/pages/pmd/userdocs/configuring_rules.md
+++ b/docs/pages/pmd/userdocs/configuring_rules.md
@@ -45,7 +45,7 @@ will cause the rule to be ignored.
 
 Properties make it easy to customise the behaviour of a rule directly from the xml. They come in several types,
 which correspond to the type of their values. For example, NPathComplexity declares a property "reportLevel",
-with an integer value type, and which corresponds to the threshold above which a method will be reported.
+with an integer value type, and which corresponds to the threshold at or above which a method will be reported.
 If you believe that its default value of 200 is too high, you could lower it to e.g. 150 in the following way:
 
 ```xml

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
@@ -30,7 +30,7 @@ public abstract class AbstractCounterCheckRule<T extends ApexNode<?>> extends Ab
 
     private final PropertyDescriptor<Integer> reportLevel =
         CommonPropertyDescriptors.reportLevelProperty()
-                                 .desc("Threshold above which a node is reported")
+                                 .desc("Threshold at or above which a node is reported")
                                  .require(positive())
                                  .defaultValue(defaultReportLevel()).build();
     private final Class<T> nodeType;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
@@ -30,7 +30,7 @@ public class SwitchDensityRule extends AbstractJavaRulechainRule {
 
     private static final PropertyDescriptor<Integer> REPORT_LEVEL =
             CommonPropertyDescriptors.reportLevelProperty()
-                    .desc("Threshold above which a switch statement or expression is reported")
+                    .desc("Threshold at or above which a switch statement or expression is reported")
                     .require(positive())
                     .defaultValue(10)
                     .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -23,7 +23,7 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
 
     private final PropertyDescriptor<Integer> reportLevel =
         CommonPropertyDescriptors.reportLevelProperty()
-                                 .desc("Threshold above which a node is reported")
+                                 .desc("Threshold at or above which a node is reported")
                                  .require(positive())
                                  .defaultValue(defaultReportLevel()).build();
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
@@ -43,7 +43,7 @@ abstract class AbstractCounterCheckRule<T extends PLSQLNode> extends AbstractPLS
 
     private final PropertyDescriptor<Integer> reportLevel =
         CommonPropertyDescriptors.reportLevelProperty()
-                                 .desc("Threshold above which a node is reported")
+                                 .desc("Threshold at or above which a node is reported")
                                  .require(positive())
                                  .defaultValue(defaultReportLevel()).build();
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
@@ -18,7 +18,7 @@ public class ExcessiveTemplateLengthRule extends AbstractVtlRule {
 
     private static final PropertyDescriptor<Integer> REPORT_LEVEL =
         CommonPropertyDescriptors.reportLevelProperty()
-                                 .desc("Threshold above which a node is reported")
+                                 .desc("Threshold at or above which a node is reported")
                                  .require(positive())
                                  .defaultValue(1000)
                                  .build();


### PR DESCRIPTION
## Describe the PR

Change description of "minimum" parameter from "above" to "at or above". "above" implies, that we only trigger on value > limit. But all of these already trigger on value >= limit.

## Related issues

- Should be merged after #6021, so this is actually true.

## Ready?

- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)

