### PR TITLE
[java] Fix 6038: make AvoidCatchingGenericException configurable

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -58,13 +58,25 @@ Avoid catching generic exceptions such as NullPointerException, RuntimeException
         </description>
         <priority>3</priority>
         <properties>
+            <property
+                    name="typesThatShouldntBeCaught"
+                    type="List[String]"
+                    description="List of canonical type names that should trigger a violation if used in a catch clause."
+            >
+                <value>
+                    java.lang.NullPointerException,
+                    java.lang.Exception,
+                    java.lang.RuntimeException,
+                    java.lang.Throwable,
+                    java.lang.Error
+                </value>
+            </property>
             <property name="xpath">
                 <value>
 <![CDATA[
 //CatchParameter//ClassType[
-        pmd-java:typeIsExactly('java.lang.NullPointerException') or
-        pmd-java:typeIsExactly('java.lang.Exception') or
-        pmd-java:typeIsExactly('java.lang.RuntimeException')]
+    some $type in $typesThatShouldntBeCaught
+    satisfies pmd-java:typeIsExactly($type)]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -50,7 +50,7 @@ public abstract class Example {
     <rule name="AvoidCatchingGenericException"
           since="4.2.6"
           language="java"
-          message="Avoid catching generic exceptions such as NullPointerException, RuntimeException, Exception in try-catch block"
+          message="Avoid catching generic exception {0} in try-catch block"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoidcatchinggenericexception">
         <description>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -76,7 +76,7 @@ Avoid catching generic exceptions in try-catch blocks. Catching overly broad exc
         <priority>3</priority>
         <properties>
             <property
-                    name="typesThatShouldntBeCaught"
+                    name="typesThatShouldNotBeCaught"
                     type="List[String]"
                     description="List of canonical type names that should trigger a violation if used in a catch clause."
             >
@@ -92,7 +92,7 @@ Avoid catching generic exceptions in try-catch blocks. Catching overly broad exc
                 <value>
 <![CDATA[
 //CatchParameter//ClassType[
-    some $type in $typesThatShouldntBeCaught
+    some $type in $typesThatShouldNotBeCaught
     satisfies pmd-java:typeIsExactly($type)]
 ]]>
                 </value>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -54,7 +54,24 @@ public abstract class Example {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoidcatchinggenericexception">
         <description>
-Avoid catching generic exceptions such as NullPointerException, RuntimeException, Exception in try-catch block.
+Avoid catching generic exceptions in try-catch blocks. Catching overly broad exception types makes it difficult to understand what can actually go wrong in your code and can hide real problems.
+
+**Why these exceptions should not be caught:**
+
+* **Exception**: This is the base class for all checked exceptions. Catching it means you're handling all possible checked exceptions the same way, which is rarely appropriate and makes error handling less precise.
+
+* **RuntimeException**: These represent programming errors (like logic bugs) that should typically be fixed in code rather than caught and handled. Catching them can hide bugs that should be addressed during development.
+
+* **NullPointerException**: This usually indicates a programming error (accessing null references). Rather than catching it, code should be written to avoid null pointer dereferences through null checks or defensive programming.
+
+* **Throwable**: This is the superclass of all errors and exceptions. Catching it means you're trying to handle both recoverable exceptions and serious errors (like OutOfMemoryError) the same way, which is dangerous.
+
+* **Error**: These represent serious problems that applications should not try to handle (like OutOfMemoryError, StackOverflowError). Catching Error can prevent the JVM from properly terminating when it encounters unrecoverable situations.
+
+**Better approaches:**
+- Catch specific exception types that you can meaningfully handle
+- Use multiple catch blocks for different exception types that require different handling
+- Consider using defensive programming techniques to prevent exceptions rather than catching them
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -229,12 +229,17 @@ void foo() {
     <rule name="AvoidCatchingNPE"
           language="java"
           since="1.8"
+          deprecated="true"
           message="Avoid catching NullPointerException; consider removing the cause of the NPE."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidcatchingnpe">
         <description>
 Code should never throw NullPointerExceptions under normal circumstances.  A catch block may hide the
 original error, causing other, more subtle problems later on.
+
+**Deprecated:** This rule is deprecated since PMD 7.17.0 and will be removed with PMD 8.0.0.
+This rule has been subsumed by {% rule AvoidCatchingGenericException %},
+which is now configurable as to which exceptions cause a violation.
         </description>
         <priority>3</priority>
         <properties>
@@ -263,12 +268,17 @@ public class Foo {
     <rule name="AvoidCatchingThrowable"
           language="java"
           since="1.2"
+          deprecated="true"
           message="A catch statement should never catch throwable since it includes errors."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidcatchingthrowable">
         <description>
 Catching Throwable errors is not recommended since its scope is very broad. It includes runtime issues such as
 OutOfMemoryError that should be exposed and managed separately.
+
+**Deprecated:** This rule is deprecated since PMD 7.17.0 and will be removed with PMD 8.0.0.
+This rule has been subsumed by {% rule AvoidCatchingGenericException %},
+which is now configurable as to which exceptions cause a violation.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -126,7 +126,7 @@
     <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
     <rule ref="category/java/design.xml/AvoidCatchingGenericException">
         <properties>
-            <property name="typesThatShouldntBeCaught" value="java.lang.Throwable,java.lang.Error" />
+            <property name="typesThatShouldNotBeCaught" value="java.lang.Throwable,java.lang.Error" />
         </properties>
     </rule>
     <!-- <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts" /> -->

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -124,7 +124,11 @@
 
 
     <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
-    <!-- <rule ref="category/java/design.xml/AvoidCatchingGenericException" /> -->
+    <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+        <properties>
+            <property name="typesThatShouldntBeCaught" value="java.lang.Throwable,java.lang.Error" />
+        </properties>
+    </rule>
     <!-- <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidRethrowingException" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException" /> -->
@@ -193,8 +197,6 @@
     <!-- <rule ref="category/java/errorprone.xml/AvoidAssertAsIdentifier" /> -->
     <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop"/>
     <!-- <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" /> -->
-    <!-- <rule ref="category/java/errorprone.xml/AvoidCatchingNPE" /> -->
-    <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable"/>
     <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
     <!-- <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals" /> -->
     <!-- <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier" /> -->

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
@@ -6,7 +6,7 @@
 
     <test-code>
         <description>failure case</description>
-        <expected-problems>3</expected-problems>
+        <expected-problems>5</expected-problems>
         <code><![CDATA[
 public class Foo {
     void bar() {
@@ -14,6 +14,8 @@ public class Foo {
         } catch (NullPointerException e) {
         } catch (Exception e) {
         } catch (RuntimeException e) {
+        } catch (Throwable e) {
+        } catch (Error e) {
         }
     }
 }
@@ -34,6 +36,41 @@ public class Foo {
 class FooException extends RuntimeException {}
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>catching another type - violation, if so configured</description>
+        <rule-property name="typesThatShouldntBeCaught">java.lang.IllegalStateException</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        try {
+        } catch (IllegalStateException e) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no longer a failure, because of configuration</description>
+        <rule-property name="typesThatShouldntBeCaught">java.lang.IllegalStateException</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        try {
+        } catch (NullPointerException e) {
+        } catch (Exception e) {
+        } catch (RuntimeException e) {
+        } catch (Throwable e) {
+        } catch (Error e) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
     <test-code>
         <description>catching subclass of NPE, ok</description>
         <expected-problems>0</expected-problems>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
@@ -39,7 +39,7 @@ class FooException extends RuntimeException {}
 
     <test-code>
         <description>catching another type - violation, if so configured</description>
-        <rule-property name="typesThatShouldntBeCaught">java.lang.IllegalStateException</rule-property>
+        <rule-property name="typesThatShouldNotBeCaught">java.lang.IllegalStateException</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -54,7 +54,7 @@ public class Foo {
 
     <test-code>
         <description>no longer a failure, because of configuration</description>
-        <rule-property name="typesThatShouldntBeCaught">java.lang.IllegalStateException</rule-property>
+        <rule-property name="typesThatShouldNotBeCaught">java.lang.IllegalStateException</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidCatchingGenericException.xml
@@ -72,6 +72,23 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>validate violation message</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Avoid catching generic exception NullPointerException in try-catch block</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        try {
+        } catch (NullPointerException e) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>catching subclass of NPE, ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

This PR merges AvoidCatchingNPE and AvoidCatchingThrowable into AvoidCatchingGenericException

## Related issues

- Fix #6038

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

