### PR TITLE
[java] Fix #6058: DanglingJavadoc FP in module-info files

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/DanglingJavadocRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/DanglingJavadocRule.java
@@ -21,6 +21,10 @@ public class DanglingJavadocRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTCompilationUnit unit, Object data) {
+        if (unit.getModuleDeclaration() != null) {
+            return null;
+        }
+
         for (JavaComment comment: unit.getComments()) {
             if (comment instanceof JavadocComment && ((JavadocComment) comment).getOwner() == null) {
                 asCtx(data).addViolationWithPosition(comment.getToken(),

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/DanglingJavadoc.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/DanglingJavadoc.xml
@@ -78,4 +78,20 @@ public class Foo {
 /// violation
     ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6058: javadoc in module-info</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * My Modules Documentation.
+ *
+ * @since 1.0
+ */
+module my.module.name {
+  exports my.module.name;
+  requires org.jspecify;
+}
+    ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

Skip DanglingJavadoc rule for module-info files

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6058 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

