### PR TITLE
[java] Add integration tests to ClassNamingConventions testClassRegex

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -30,7 +30,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
     private final PropertyDescriptor<Pattern> utilityClassRegex = defaultProp("utility class").build();
     private final PropertyDescriptor<Pattern> testClassRegex = defaultProp("test class")
             .desc("Regex which applies to test class names. Since PMD 6.52.0.")
-            .defaultValue("^Test.*$|^[A-Z][a-zA-Z0-9]*Test(s|Case)?$").build();
+            .defaultValue("^(Test|IT).*$|^[A-Z][a-zA-Z0-9]*(Test|Tests|TestCase|IT|ITCase)$").build();
 
 
     public ClassNamingConventionsRule() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -436,7 +436,34 @@ import junit.framework.TestCase;
 public class ExampleTestCase extends TestCase { }
 ]]></code>
     </test-code>
-    
+
+    <test-code>
+        <description>Integration test class with IT suffix should be valid #5919</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class ExampleIT extends TestCase { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Integration test class with ITCase suffix should be valid #5919</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class ExampleITCase extends TestCase { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Integration test class with IT prefix should be valid</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class ITExample extends TestCase { }
+]]></code>
+    </test-code>
+
     <test-code>
         <description>[java] ClassNamingConventions: interfaces are identified as abstract classes (regression in 7.0.0) #4881</description>
         <rule-property name="abstractClassPattern">Abstract[A-Z][a-zA-Z0-9]*</rule-property>


### PR DESCRIPTION
## Describe the PR

Update the default regex pattern for test class naming conventions to include [Maven Failsafe Plugin defaults](https://maven.apache.org/surefire/maven-failsafe-plugin/integration-test-mojo.html#includes):

- Integration test prefix (IT)
- Integration test suffixes (IT, ITCase)

## Related issues

- Fix #5919

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)