### PR TITLE
Bump pmdtester from 1.6.0 to 1.6.1

### DIFF
--- a/.ci/files/Gemfile.lock
+++ b/.ci/files/Gemfile.lock
@@ -2,12 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     concurrent-ruby (1.3.5)
     differ (0.1.2)
-    et-orbi (1.2.11)
+    et-orbi (1.3.0)
       tzinfo
-    fugit (1.11.1)
+    fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     liquid (5.8.7)
@@ -15,10 +15,10 @@ GEM
       strscan (>= 3.1.1)
     logger (1.7.0)
     logger-colors (1.0.0)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
-    pmdtester (1.6.0)
+    pmdtester (1.6.1)
       base64 (~> 0.3)
       bigdecimal (~> 3.2)
       differ (~> 0.1)


### PR DESCRIPTION
## Describe the PR

https://github.com/pmd/pmd-regression-tester/releases/tag/v1.6.1

## Related issues

- Should fix the report of #6021 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

