### PR TITLE
[java] Fix #6072: OverrideBothEqualsAndHashCodeOnComparable should not be required for record classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -93,6 +93,7 @@ import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.internal.ast.AstLocalVarSym;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
+import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -730,6 +731,13 @@ public final class JavaAstUtils {
         return "hashCode".equals(node.getName())
             && node.getArity() == 0
             && !node.isStatic();
+    }
+
+    public static boolean isCompareToMethod(ASTMethodDeclaration method) {
+        return "compareTo".equals(method.getName())
+                && method.getArity() == 1
+                && method.getResultTypeNode().getTypeMirror().isPrimitive(JPrimitiveType.PrimitiveTypeKind.INT)
+                && !method.isStatic();
     }
 
     public static boolean isArrayLengthFieldAccess(ASTExpression node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashCodeOnComparableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashCodeOnComparableRule.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
-import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -31,13 +30,6 @@ public class OverrideBothEqualsAndHashCodeOnComparableRule extends OverrideBothE
         return !TypeTestUtil.isA(Comparable.class, node) || TypeTestUtil.isA(Enum.class, node);
     }
 
-    private static boolean isCompareToMethod(ASTMethodDeclaration method) {
-        return "compareTo".equals(method.getName())
-                && method.getArity() == 1
-                && method.getResultTypeNode().getTypeMirror().isPrimitive(JPrimitiveType.PrimitiveTypeKind.INT)
-                && !method.isStatic();
-    }
-
     private static boolean hasBrokenEqualsMethod(ASTTypeDeclaration node) {
         for (ASTMethodDeclaration m : node.getDeclarations(ASTMethodDeclaration.class)) {
             if ("equals".equals(m.getName()) && !JavaAstUtils.isEqualsMethod(m)) {
@@ -52,7 +44,7 @@ public class OverrideBothEqualsAndHashCodeOnComparableRule extends OverrideBothE
     protected void maybeReport(RuleContext ctx, ASTTypeDeclaration node, ASTMethodDeclaration hashCodeMethod, ASTMethodDeclaration equalsMethod) {
         ASTMethodDeclaration compareToMethod = node
                 .getDeclarations(ASTMethodDeclaration.class)
-                .first(OverrideBothEqualsAndHashCodeOnComparableRule::isCompareToMethod);
+                .first(JavaAstUtils::isCompareToMethod);
         if (compareToMethod == null) {
             return;
         }

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2440,10 +2440,6 @@ public class Foo {        // perfect, both methods provided
             Note 1: This rule is related to {% rule OverrideBothEqualsAndHashcode %}. It
             will report missing `equals()` and/or `hashCode()` methods for classes only
             that implement `Comparable`.
-
-            Note 2: This rule also reports records that implement `Comparable`. While
-            for records, `equals()` and `hashCode()` are generated, you still must make
-            sure that `compareTo()` is consistent with `equals()`.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashCodeOnComparable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashCodeOnComparable.xml
@@ -234,11 +234,7 @@
     </test-code>
     <test-code>
         <description>Record with Comparable and no explicit equals/hashCode</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
-        <expected-messages>
-            <message>When implementing Comparable, both equals() and hashCode() should be overridden</message>
-        </expected-messages>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
             public record Foo(int x, int y) implements Comparable<Foo> {
                 @Override


### PR DESCRIPTION
## Describe the PR

The logic in OverrideBothEqualsAndHashCodeOnComparable is: If a class implements Comparable, the natural order defined by .compareTo() should be [_consistent with equals_](https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html). And no matter how I define .compareTo(), it cannot be consistent with the default implementation of Object.equals(). That's why I need to define a custom .equals(). And once I define a custom equals(), I need a custom .hashCode() as well. So far I agree 100%.

But records already have a sane implementation of .equals() and .hashCode(). And a custom .compareTo() that (a) complies with the contract of Comparable.compareTo() and (b) compares all the members will almost automatically be consistent with the auto-defined .equals() for records. So all these cases will be false-positives. I'd guess that for records, this rule will produce more false-positives than false negatives.

That's why this PR changes the rule, so that a record that implements Comparable but doesn't implement .equals() and .hashCode() does not trigger a violation. We simply don't know if the custom .compareTo() is consistent with equals, and should thus err on the side of not producing a violation.

## Related issues

- Fix #6072

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

