### PR TITLE
[java] new rule for useless conditions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessConditionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessConditionRule.java
@@ -1,0 +1,35 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+public class UselessConditionRule extends AbstractJavaRulechainRule {
+
+    public UselessConditionRule() {
+        super(ASTIfStatement.class, ASTConditionalExpression.class);
+    }
+
+    @Override
+    public Object visit(ASTIfStatement node, Object data) {
+        if (node.getElseBranch() != null
+                && JavaAstUtils.tokenEquals(node.getThenBranch(), node.getElseBranch())) {
+            asCtx(data).addViolation(node);
+        }
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTConditionalExpression node, Object data) {
+        if (node.getElseBranch() != null
+            && JavaAstUtils.tokenEquals(node.getThenBranch(), node.getElseBranch())) {
+            asCtx(data).addViolation(node);
+        }
+        return data;
+    }
+}

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3380,6 +3380,36 @@ public boolean test(String s) {
         </example>
     </rule>
 
+    <rule name="UselessCondition"
+          language="java"
+          since="3.5"
+          message="Conditional statement ignores the condition"
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.UselessConditionRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#uselesscondition">
+        <description>
+            Conditional statement that does the same thing when the condition is true and false
+            is either incorrect (one of the branches should be changed) or redundant
+            (can be replaced by one of its branches).
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+class Test {
+    int method1() {
+        if (Math.random() > 0.5) {
+            return 1;
+        } else {
+            return 1;
+        }
+    }
+    int method2() {
+        return Math.random() > 0.5 ? 1 : 1;
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="UselessOperationOnImmutable"
           language="java"
           since="3.5"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessConditionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessConditionTest.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+/**
+ * Test for {@link UselessConditionRule}.
+ */
+class UselessConditionTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessCondition.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.github.io/schema/rule-tests_1_1_0.xsd">
+
+    <test-code>
+        <description>Useless if</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        class Test {
+            int method1() {
+                if (Math.random() > 0.5) {
+                    return 1;
+                } else {
+                    return 1;
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Useless conditional expression</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        class Test {
+            int method1() {
+                return Math.random() < 0.5 ? 1 : 1;
+            }
+        }
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION

## Describe the PR

Add a rule for finding useless `if`s and ternary expressions.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

