### PR TITLE
[ci] Fix #5873: Run integration tests with Java 25 additionally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
             8
             17
             21
+            25
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         # default java version for all os is 11
         with:
@@ -160,7 +161,8 @@ jobs:
               -PfastSkip -Dcyclonedx.skip=false \
               -Djava8.home="${JAVA_HOME_8_X64}" \
               -Djava17.home="${JAVA_HOME_17_X64}" \
-              -Djava21.home="${JAVA_HOME_21_X64}"
+              -Djava21.home="${JAVA_HOME_21_X64}" \
+              -Djava25.home="${JAVA_HOME_25_X64}"
 
   dogfood:
     needs: compile

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,7 @@ This is a {{ site.pmd.release_type }} release.
 * java-multithreading
   * [#5880](https://github.com/pmd/pmd/issues/5880): \[java] DoubleCheckedLocking is not detected if more than 1 assignment or more than 2 if statements
 * misc
+  * [#5873](https://github.com/pmd/pmd/issues/5873): \[ci] Run integration test with Java 25
   * [#6012](https://github.com/pmd/pmd/issues/6012): \[pmd-rulesets] Rulesets should be in alphabetical order
 
 ### 🚨 API Changes

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -277,5 +277,36 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk25-compat-it</id>
+            <activation>
+                <property>
+                    <name>java25.home</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jdk25-compat-it</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <environmentVariables>
+                                        <JAVA_HOME>${java25.home}</JAVA_HOME>
+                                        <PATH>${java25.home}/bin:${env.PATH}</PATH>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Describe the PR

- Runs PMD with Java 25 in our integration tests during CI builds

## Related issues

- Fix #5873

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

