### PR TITLE
[java] AvoidDeeplyNestedIfStmts: fix false negative with if-else

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidDeeplyNestedIfStmts.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidDeeplyNestedIfStmts.xml
@@ -43,4 +43,118 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Deep ifs with else</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+        public class Tester {
+            public void foo() {
+                if (true) {
+                } else {
+                    if (true) {
+                        if (true) {
+                            if (true) {
+                                // violation
+                            }
+                        } else {
+
+                        }
+                    } else {
+
+                    }
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Sibling ifs reported separately</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,6</expected-linenumbers>
+        <code><![CDATA[
+        public class Tester {
+            public void foo() {
+                if (true) {
+                    if (true) {
+                        if (true) { }
+                        if (true) { }
+                    }
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>If-else reported once</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+        public class Tester {
+            public void foo() {
+                if (true) {
+                    if (true) {
+                        if (true) { }
+                        else if (true) { }
+                    }
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Chained ifs, not deep enough</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        public class Tester {
+            public void foo() {
+                if (true) {
+                } else if (true) {
+                   if (true) {
+
+                   }
+                } else if (true) {
+                   if (true) {
+
+                   }
+                } else if (true) {
+                   if (true) {
+
+                   }
+                } else if (true) {
+                   if (true) {
+
+                   }
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Deep ifs in lambda</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+        import java.util.stream.Stream;
+        public class Tester {
+            public void foo() {
+                if (Stream.of("").anyMatch(s -> {
+                    if (true) {
+                        if (true) {
+                            if (true) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                })) {
+                    // do nothing
+                }
+            }
+        }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

There were two problems with how if-else statements were handled by this rule:
1) when if-else was encountered, the `depth` was not supposed to increase, but in fact it *decreased*. Meaning that code containing 10 if-else pairs was allowed to have completely unrelated `if` statement (without `else`) 10+2 levels deep and the rule wouldn't trigger.
2) I think the intention was to allow long `if` - `else if` - `else if` -.... `else` chains, but it alse allowed arbitrary nesting of `if`s as long as they had `else` branches.

The PR fixes both by increasing the depth when entering `if` branch and decreasing it right after. This could be further refined by also increasing the depth for `else` branches that contain more statements than a single `if`.

## Related issues

Fixes #1499

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

