### PR TITLE
[java] DanglingJavadoc: fix false positive for compact constructors

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclaration.java
@@ -30,7 +30,8 @@ import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
  */
 // TODO make implicit formal parameter node and implement ASTExecutableDeclaration.
 // This might help UnusedAssignmentRule / DataflowPass.ReachingDefsVisitor, see also #4603
-public final class ASTCompactConstructorDeclaration extends AbstractJavaNode implements ASTBodyDeclaration, SymbolDeclaratorNode, ModifierOwner, JavadocCommentOwner, ReturnScopeNode {
+public final class ASTCompactConstructorDeclaration extends AbstractJavaNode
+    implements ASTBodyDeclaration, SymbolDeclaratorNode, ModifierOwner, JavadocCommentOwner, ReturnScopeNode, LeftRecursiveNode {
 
     private JavaccToken identToken;
 

--- a/pmd-java/src/main/javacc/Java.jjt
+++ b/pmd-java/src/main/javacc/Java.jjt
@@ -1287,10 +1287,7 @@ private void CompactConstructorDeclarationLookahead() #void:
 void CompactConstructorDeclaration():
 {}
 {
-  <IDENTIFIER> {
-    jjtThis.setFirstToken(jjtree.peekNode().getFirstToken());
-    jjtThis.setIdentToken(token);
-  }
+  <IDENTIFIER> { jjtThis.setIdentToken(token); }
   Block()
 }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclarationTest.java
@@ -24,4 +24,17 @@ class ASTCompactConstructorDeclarationTest extends BaseParserTest {
                 .get(0);
         assertEquals(1, compactConstructor.getBody().getNumChildren());
     }
+
+    @Test
+    void compactConstructorRange() {
+        ASTCompactConstructorDeclaration compactConstructor = java.getNodes(ASTCompactConstructorDeclaration.class,
+                    "record RecordWithDocumentation(String foo) {"
+                    + "/** JavaDoc */"
+                    + "     RecordWithDocumentation {"
+                    + "         assert foo != null;"
+                    + "     }"
+                    + "}")
+            .get(0);
+        assertEquals("/** JavaDoc */", compactConstructor.getFirstToken().getImage());
+    }
 }


### PR DESCRIPTION
## Describe the PR

The first token of compact constructor must point to the first token of its modifier list for the comment detection to work.

## Related issues

- Fixes #6103

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

