### PR TITLE
[java] Remove obsolete JDK version checks

### DIFF
--- a/pmd-java/src/main/javacc/Java.jjt
+++ b/pmd-java/src/main/javacc/Java.jjt
@@ -380,19 +380,11 @@ class JavaParserImpl {
   // Note that this can't be replaced with a syntactic lookahead
   // since "assert" isn't a string literal token
   private boolean isAssertStart() {
-    if (jdkVersion <= 3) {
-      return false;
-    }
-
     return getToken(1).getImageCs().contentEquals("assert");
   }
 
   private boolean isRecordStart() {
     return isRecordTypeSupported() && isKeyword("record") && isToken(2, IDENTIFIER);
-  }
-
-  private boolean isEnumStart() {
-    return jdkVersion >= 5 && isKeyword("enum");
   }
 
   /**
@@ -461,7 +453,7 @@ class JavaParserImpl {
   }
 
   private boolean localTypeDeclGivenNextIsIdent() {
-      return localTypesSupported() && (isRecordStart() || isEnumStart());
+      return localTypesSupported() && (isRecordStart() || isKeyword("enum"));
   }
 
   /**

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
@@ -36,11 +36,6 @@ class ASTImportDeclarationTest extends BaseParserTest {
         assertTrue(i.isStatic());
     }
 
-    @Test
-    void testStaticImportFailsWithJDK14() {
-        assertThrows(ParseException.class, () -> java.parse(TEST3, "1.4"));
-    }
-
     private static final String TEST1 = "import foo.bar.*;\npublic class Foo {}";
 
     private static final String TEST2 = "import foo.bar.Baz;\npublic class Foo {}";

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
@@ -22,209 +22,181 @@ import net.sourceforge.pmd.lang.test.ast.BaseParsingHelper;
 
 class JDKVersionTest extends BaseJavaTreeDumpTest {
 
-    private final JavaParsingHelper java3 = JavaParsingHelper.DEFAULT
-        .withDefaultVersion("1.3")
+    private final JavaParsingHelper java8 = JavaParsingHelper.DEFAULT
+        .withDefaultVersion("1.8")
         .withResourceContext(JDKVersionTest.class, "jdkversiontests/");
 
-    private final JavaParsingHelper java4 = java3.withDefaultVersion("1.4");
-    private final JavaParsingHelper java5 = java3.withDefaultVersion("1.5");
-    private final JavaParsingHelper java7 = java3.withDefaultVersion("1.7");
-    private final JavaParsingHelper java8 = java3.withDefaultVersion("1.8");
-    private final JavaParsingHelper java9 = java3.withDefaultVersion("9");
+    private final JavaParsingHelper java9 = java8.withDefaultVersion("9");
 
     // enum keyword/identifier
     @Test
     void testEnumAsKeywordShouldFailWith14() {
-        assertThrows(ParseException.class, () -> java5.parseResource("jdk14_enum.java"));
-    }
-
-    @Test
-    void testEnumAsIdentifierShouldPassWith14() {
-        java4.parseResource("jdk14_enum.java");
+        assertThrows(ParseException.class, () -> java8.parseResource("jdk14_enum.java"));
     }
 
     @Test
     void testEnumAsKeywordShouldPassWith15() {
-        java5.parseResource("jdk15_enum.java");
+        java8.parseResource("jdk15_enum.java");
     }
 
-    @Test
-    void testEnumAsIdentifierShouldFailWith15() {
-        assertThrows(ParseException.class, () -> java5.parseResource("jdk14_enum.java"));
-    }
     // enum keyword/identifier
 
     // assert keyword/identifier
     @Test
     void testAssertAsKeywordVariantsSucceedWith14() {
-        java4.parseResource("assert_test1.java");
-        java4.parseResource("assert_test2.java");
-        java4.parseResource("assert_test3.java");
-        java4.parseResource("assert_test4.java");
+        java8.parseResource("assert_test1.java");
+        java8.parseResource("assert_test2.java");
+        java8.parseResource("assert_test3.java");
+        java8.parseResource("assert_test4.java");
     }
 
     @Test
     void testAssertAsVariableDeclIdentifierFailsWith14() {
-        assertThrows(ParseException.class, () -> java4.parseResource("assert_test5.java"));
+        assertThrows(ParseException.class, () -> java8.parseResource("assert_test5.java"));
     }
 
     @Test
     void testAssertAsMethodNameIdentifierFailsWith14() {
-        assertThrows(ParseException.class, () -> java4.parseResource("assert_test7.java"));
-    }
-
-    @Test
-    void testAssertAsIdentifierSucceedsWith13() {
-        java3.parseResource("assert_test5.java");
+        assertThrows(ParseException.class, () -> java8.parseResource("assert_test7.java"));
     }
 
     @Test
     void testAssertAsKeywordFailsWith13() {
-        assertThrows(ParseException.class, () -> java3.parseResource("assert_test6.java"));
+        java8.parseResource("assert_test6.java");
     }
     // assert keyword/identifier
 
     @Test
     void testVarargsShouldPassWith15() {
-        java5.parseResource("jdk15_varargs.java");
+        java8.parseResource("jdk15_varargs.java");
     }
 
     @Test
     void testGenericCtorCalls() {
-        java5.parseResource("java5/generic_ctors.java");
+        java8.parseResource("java5/generic_ctors.java");
     }
 
     @Test
     void testGenericSuperCtorCalls() {
-        java5.parseResource("java5/generic_super_ctor.java");
+        java8.parseResource("java5/generic_super_ctor.java");
     }
 
     @Test
     void testAnnotArrayInitializer() {
-        java5.parseResource("java5/annotation_array_init.java");
-    }
-
-    @Test
-    void testVarargsShouldFailWith14() {
-        assertThrows(ParseException.class, () -> java4.parseResource("jdk15_varargs.java"));
+        java8.parseResource("java5/annotation_array_init.java");
     }
 
     @Test
     void testJDK15ForLoopSyntaxShouldPassWith15() {
-        java5.parseResource("jdk15_forloop.java");
+        java8.parseResource("jdk15_forloop.java");
     }
 
     @Test
     void testJDK15ForLoopSyntaxWithModifiers() {
-        java5.parseResource("jdk15_forloop_with_modifier.java");
-    }
-
-    @Test
-    void testJDK15ForLoopShouldFailWith14() {
-        assertThrows(ParseException.class, () -> java4.parseResource("jdk15_forloop.java"));
+        java8.parseResource("jdk15_forloop_with_modifier.java");
     }
 
     @Test
     void testJDK15GenericsSyntaxShouldPassWith15() {
-        java5.parseResource("jdk15_generics.java");
+        java8.parseResource("jdk15_generics.java");
     }
 
     @Test
     void testVariousParserBugs() {
-        java5.parseResource("fields_bug.java");
-        java5.parseResource("gt_bug.java");
-        java5.parseResource("annotations_bug.java");
-        java5.parseResource("constant_field_in_annotation_bug.java");
-        java5.parseResource("generic_in_field.java");
+        java8.parseResource("fields_bug.java");
+        java8.parseResource("gt_bug.java");
+        java8.parseResource("annotations_bug.java");
+        java8.parseResource("constant_field_in_annotation_bug.java");
+        java8.parseResource("generic_in_field.java");
     }
 
     @Test
     void testNestedClassInMethodBug() {
-        java5.parseResource("inner_bug.java");
-        java5.parseResource("inner_bug2.java");
+        java8.parseResource("inner_bug.java");
+        java8.parseResource("inner_bug2.java");
     }
 
     @Test
     void testGenericsInMethodCall() {
-        java5.parseResource("generic_in_method_call.java");
+        java8.parseResource("generic_in_method_call.java");
     }
 
     @Test
     void testGenericINAnnotation() {
-        java5.parseResource("generic_in_annotation.java");
+        java8.parseResource("generic_in_annotation.java");
     }
 
     @Test
     void testGenericReturnType() {
-        java5.parseResource("generic_return_type.java");
+        java8.parseResource("generic_return_type.java");
     }
 
     @Test
     void testMultipleGenerics() {
         // See java/lang/concurrent/CopyOnWriteArraySet
-        java5.parseResource("funky_generics.java");
+        java8.parseResource("funky_generics.java");
         // See java/lang/concurrent/ConcurrentHashMap
-        java5.parseResource("multiple_generics.java");
+        java8.parseResource("multiple_generics.java");
     }
 
     @Test
     void testAnnotatedParams() {
-        java5.parseResource("annotated_params.java");
+        java8.parseResource("annotated_params.java");
     }
 
     @Test
     void testAnnotatedLocals() {
-        java5.parseResource("annotated_locals.java");
+        java8.parseResource("annotated_locals.java");
     }
 
     @Test
-    void testAssertAsIdentifierSucceedsWith13Test2() {
-        java3.parseResource("assert_test5_a.java");
+    void testAssertAsIdentifierFailsJava8() {
+        assertThrows(ParseException.class, () -> java8.parseResource("assert_test5_a.java"));
     }
 
     @Test
     void testBinaryAndUnderscoresInNumericalLiterals() {
-        java7.parseResource("jdk17_numerical_literals.java");
+        java8.parseResource("jdk17_numerical_literals.java");
     }
 
     @Test
     void testStringInSwitch() {
-        java7.parseResource("jdk17_string_in_switch.java");
+        java8.parseResource("jdk17_string_in_switch.java");
     }
 
     @Test
     void testGenericDiamond() {
-        java7.parseResource("jdk17_generic_diamond.java");
+        java8.parseResource("jdk17_generic_diamond.java");
     }
 
     @Test
     void testTryWithResources() {
-        java7.parseResource("jdk17_try_with_resources.java");
+        java8.parseResource("jdk17_try_with_resources.java");
     }
 
     @Test
     void testTryWithResourcesSemi() {
-        java7.parseResource("jdk17_try_with_resources_semi.java");
+        java8.parseResource("jdk17_try_with_resources_semi.java");
     }
 
     @Test
     void testTryWithResourcesMulti() {
-        java7.parseResource("jdk17_try_with_resources_multi.java");
+        java8.parseResource("jdk17_try_with_resources_multi.java");
     }
 
     @Test
     void testTryWithResourcesWithAnnotations() {
-        java7.parseResource("jdk17_try_with_resources_with_annotations.java");
+        java8.parseResource("jdk17_try_with_resources_with_annotations.java");
     }
 
     @Test
     void testMulticatch() {
-        java7.parseResource("jdk17_multicatch.java");
+        java8.parseResource("jdk17_multicatch.java");
     }
 
     @Test
     void testMulticatchWithAnnotations() {
-        java7.parseResource("jdk17_multicatch_with_annotations.java");
+        java8.parseResource("jdk17_multicatch_with_annotations.java");
     }
 
     @Test
@@ -299,7 +271,7 @@ class JDKVersionTest extends BaseJavaTreeDumpTest {
 
     @Test
     void jdk7PrivateMethodInnerClassInterface1() {
-        ASTCompilationUnit acu = java7.parseResource("private_method_in_inner_class_interface1.java");
+        ASTCompilationUnit acu = java8.parseResource("private_method_in_inner_class_interface1.java");
         List<ASTMethodDeclaration> methods = acu.descendants(ASTMethodDeclaration.class).crossFindBoundaries().toList();
         assertEquals(3, methods.size());
         for (ASTMethodDeclaration method : methods) {
@@ -309,7 +281,7 @@ class JDKVersionTest extends BaseJavaTreeDumpTest {
 
     @Test
     void jdk7PrivateMethodInnerClassInterface2() {
-        ParseException thrown = assertThrows(ParseException.class, () -> java7.parseResource("private_method_in_inner_class_interface2.java"));
+        ParseException thrown = assertThrows(ParseException.class, () -> java8.parseResource("private_method_in_inner_class_interface2.java"));
         assertThat(thrown.getMessage(), containsString("line 19"));
     }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTest.kt
@@ -8,8 +8,7 @@ import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.test.ast.shouldBe
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Earliest
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest
-import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_3
-import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_5
+import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_8
 
 /**
  * @author Clément Fournier
@@ -17,14 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_5
  */
 class ASTAnnotationTest : ParserTestSpec({
 
-    parserTestContainer("Test annot fails before JDK 1.4", javaVersions = Earliest..J1_3) {
-        inContext(AnnotationParsingCtx) {
-            "@F" shouldNot parse()
-            "@F(a=1)" shouldNot parse()
-        }
-    }
-
-    parserTestContainer("Marker annotations", javaVersions = J1_5..Latest) {
+    parserTestContainer("Marker annotations", javaVersions = J1_8..Latest) {
         inContext(AnnotationParsingCtx) {
             "@F" should parseAs {
                 child<ASTAnnotation> {
@@ -64,7 +56,7 @@ class ASTAnnotationTest : ParserTestSpec({
         }
     }
 
-    parserTestContainer("Single-value shorthand", javaVersions = J1_5..Latest) {
+    parserTestContainer("Single-value shorthand", javaVersions = J1_8..Latest) {
         inContext(AnnotationParsingCtx) {
             "@F(\"ohio\")" should parseAs {
                 child<ASTAnnotation> {
@@ -132,7 +124,7 @@ class ASTAnnotationTest : ParserTestSpec({
         }
     }
 
-    parserTestContainer("Normal annotation", javaVersions = J1_5..Latest) {
+    parserTestContainer("Normal annotation", javaVersions = J1_8..Latest) {
         inContext(AnnotationParsingCtx) {
             "@F(a=\"ohio\")" should parseAs {
                 child<ASTAnnotation> {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCatchClauseTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCatchClauseTest.kt
@@ -13,15 +13,8 @@ import java.io.IOException
 
 
 class ASTCatchClauseTest : ParserTestSpec({
-    parserTestContainer("Test crash on multicatch", javaVersions = Earliest..J1_6) {
-        inContext(StatementParsingCtx) {
-            "try { } catch (IOException | AssertionError e) { }" should throwParseException {
-                it.message.shouldContain("Composite catch clauses are a feature of Java 1.7, you should select your language version accordingly")
-            }
-        }
-    }
 
-    parserTestContainer("Test single type", javaVersions = J1_5..Latest) {
+    parserTestContainer("Test single type", javaVersions = J1_8..Latest) {
         importedTypes += IOException::class.java
 
         inContext(StatementParsingCtx) {
@@ -44,7 +37,7 @@ class ASTCatchClauseTest : ParserTestSpec({
         }
     }
 
-    parserTestContainer("Test multicatch", javaVersions = J1_7..Latest) {
+    parserTestContainer("Test multicatch", javaVersions = J1_8..Latest) {
         importedTypes += IOException::class.java
 
         inContext(StatementParsingCtx) {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.kt
@@ -477,20 +477,7 @@ $delim
         }
     }
 
-    parserTestContainer("Binary numeric literals - pre java1.7", javaVersions = Earliest..J1_6) {
-        // binary literals were introduced in 1.7
-
-        inContext(ExpressionParsingCtx) {
-            "0b011" shouldNot parse()
-            "0B011" shouldNot parse()
-            "0B0_1__1" shouldNot parse()
-
-            "0B0_1__1l" shouldNot parse()
-            "0b0_11L" shouldNot parse()
-        }
-    }
-
-    parserTestContainer("Binary numeric literals - java1.7+", javaVersions = J1_7..Latest) {
+    parserTestContainer("Binary numeric literals - java1.7+", javaVersions = J1_8..Latest) {
         fun binaryThree(type: PrimitiveTypeKind): NodeSpec<*> = {
             number(type) {
                 it::getValueAsDouble shouldBe 3.0

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTTryStatementTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTTryStatementTest.kt
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast
 
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest
-import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_7
+import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_8
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.J9
 import net.sourceforge.pmd.lang.test.ast.shouldBe
 
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.lang.test.ast.shouldBe
  * @since 7.0.0
  */
 class ASTTryStatementTest : ParserTestSpec({
-    parserTestContainer("Test try with resources", javaVersions = J1_7..Latest) {
+    parserTestContainer("Test try with resources", javaVersions = J1_8..Latest) {
         inContext(StatementParsingCtx) {
             "try (Foo a = 2){}" should parseAs {
                 tryStmt {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTWildcardTypeTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTWildcardTypeTest.kt
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.ast
 
 import net.sourceforge.pmd.lang.test.ast.shouldBe
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest
-import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_5
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_8
 
 /**
@@ -14,7 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaVersion.J1_8
  * @since 7.0.0
  */
 class ASTWildcardTypeTest : ParserTestSpec({
-    parserTestContainer("Test simple names", javaVersions = J1_5..Latest) {
+    parserTestContainer("Test simple names", javaVersions = J1_8..Latest) {
         inContext(TypeParsingCtx) {
             "List<? extends B>" should parseAs {
                 classType("List") {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
@@ -28,7 +28,7 @@ import java.util.*
  * Represents the different Java language versions.
  */
 enum class JavaVersion : Comparable<JavaVersion> {
-    J1_3, J1_4, J1_5, J1_6, J1_7, J1_8, J9, J10, J11,
+    J1_8, J9, J10, J11,
     J12,
     J13,
     J14,

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/Java7InferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/Java7InferenceTest.kt
@@ -13,7 +13,7 @@ import net.sourceforge.pmd.lang.java.types.*
  * @author Clément Fournier
  */
 class Java7InferenceTest : ProcessorTestSpec({
-    parserTest("Java 7 uses return constraints only if args are not enough", javaVersion = J1_7) {
+    parserTest("Java 7 uses return constraints only if args are not enough", javaVersion = J1_8) {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """
             class Gen<T> {
@@ -57,7 +57,7 @@ class Java7InferenceTest : ProcessorTestSpec({
         }
     }
 
-    parserTest("Java 7 uses return constraints if needed", javaVersion = J1_7) {
+    parserTest("Java 7 uses return constraints if needed", javaVersion = J1_8) {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """
             class Gen<T> {
@@ -78,7 +78,7 @@ class Java7InferenceTest : ProcessorTestSpec({
         }
     }
 
-    parserTest("Java 7 doesn't let context flow through ternary", javaVersion = J1_7) {
+    parserTest("Java 7 doesn't let context flow through ternary", javaVersion = J1_8) {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """
             class Gen<T> extends Sup<T> {
@@ -109,7 +109,7 @@ class Java7InferenceTest : ProcessorTestSpec({
         }
     }
 
-    parserTest("Java 7 doesn't use invocation context", javaVersion = J1_7) {
+    parserTest("Java 7 doesn't use invocation context", javaVersion = J1_8) {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """
             class Gen<T> extends Sup<T> {
@@ -146,7 +146,7 @@ class Java7InferenceTest : ProcessorTestSpec({
         }
     }
 
-    parserTest("Java 7 doesn't use invocation context (2)", javaVersion = J1_7) {
+    parserTest("Java 7 doesn't use invocation context (2)", javaVersion = J1_8) {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """
             class Gen<T> extends Sup<T> {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAssertAsIdentifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAssertAsIdentifier.xml
@@ -5,19 +5,6 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>assert as identifier - parameter</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    void bar(String assert) {
-        assert = "hi";
-    }
-}
-        ]]></code>
-        <source-type>java 1.3</source-type>
-    </test-code>
-
-    <test-code>
         <description>assert as identifier - local var</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION

## Describe the PR

Removes two checks for JDK version that are no longer relevant.

## Related issues

Fixes #6095

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

