### PR TITLE
[java] ConfusingTernary: add configuration property for null checks

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+import static net.sourceforge.pmd.properties.PropertyFactory.enumProperty;
 
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
@@ -56,15 +57,25 @@ public class ConfusingTernaryRule extends AbstractJavaRulechainRule {
     private static final PropertyDescriptor<Boolean> IGNORE_ELSE_IF = booleanProperty("ignoreElseIf")
             .desc("Ignore conditions with an else-if case").defaultValue(false).build();
 
+    private static final PropertyDescriptor<NullCheckBranch> NULL_CHECK_BRANCH = enumProperty("nullCheckBranch", NullCheckBranch.class)
+        .desc("One of `Any`, `Then`, `Else`. For `Any` null checks may have any form,"
+            + " for `Then` only `foo == null` is allowed, for `Else` only `foo != null` is allowed")
+        .defaultValue(NullCheckBranch.Any).build();
+
+    private enum NullCheckBranch {
+        Any, Then, Else
+    }
+
     public ConfusingTernaryRule() {
         super(ASTIfStatement.class, ASTConditionalExpression.class);
         definePropertyDescriptor(IGNORE_ELSE_IF);
+        definePropertyDescriptor(NULL_CHECK_BRANCH);
     }
 
     @Override
     public Object visit(ASTIfStatement node, Object data) {
         // look for "if (match) ..; else .."
-        if (node.getNumChildren() == 3
+        if (node.hasElse()
             && isMatch(node.getCondition())) {
             if (!getProperty(IGNORE_ELSE_IF)
                 || !(node.getElseBranch() instanceof ASTIfStatement)
@@ -85,7 +96,7 @@ public class ConfusingTernaryRule extends AbstractJavaRulechainRule {
     }
 
     // recursive!
-    private static boolean isMatch(ASTExpression node) {
+    private boolean isMatch(ASTExpression node) {
         return isUnaryNot(node) || isNotEquals(node) || isConditionalWithAllMatches(node);
     }
 
@@ -95,18 +106,28 @@ public class ConfusingTernaryRule extends AbstractJavaRulechainRule {
             && ((ASTUnaryExpression) node).getOperator().equals(UnaryOp.NEGATION);
     }
 
-    private static boolean isNotEquals(ASTExpression node) {
+    private boolean isNotEquals(ASTExpression node) {
         if (!(node instanceof ASTInfixExpression)) {
             return false;
         }
         ASTInfixExpression infix = (ASTInfixExpression) node;
         // look for "x != y"
-        return infix.getOperator().equals(BinaryOp.NE)
-            && !(infix.getLeftOperand() instanceof ASTNullLiteral)
-            && !(infix.getRightOperand() instanceof ASTNullLiteral);
+        if (infix.getOperator().equals(BinaryOp.NE)) {
+            return !isNullComparison(infix)
+                || getProperty(NULL_CHECK_BRANCH) == NullCheckBranch.Then;
+
+        }
+        return infix.getOperator().equals(BinaryOp.EQ)
+            && isNullComparison(infix)
+            && getProperty(NULL_CHECK_BRANCH) == NullCheckBranch.Else;
     }
 
-    private static boolean isConditionalWithAllMatches(ASTExpression node) {
+    private boolean isNullComparison(ASTInfixExpression infix) {
+        return infix.getLeftOperand() instanceof ASTNullLiteral
+            || infix.getRightOperand() instanceof ASTNullLiteral;
+    }
+
+    private boolean isConditionalWithAllMatches(ASTExpression node) {
         // look for "match && match" or "match || match"
         if (node instanceof ASTInfixExpression) {
             ASTInfixExpression infix = (ASTInfixExpression) node;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ConfusingTernary.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ConfusingTernary.xml
@@ -27,11 +27,8 @@ public class Foo {
 }
         ]]></code>
     </test-code>
-
-    <test-code>
-        <description>null check, ok (if) - #278</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
+<code-fragment id="nullCheckIfElse">
+    <![CDATA[
 public class Foo {
     String bar2(Object a) {
         if (a != null)
@@ -40,7 +37,66 @@ public class Foo {
             return null;
     }
 }
-        ]]></code>
+        ]]>
+</code-fragment>
+    <code-fragment id="nullCheckIfThen">
+        <![CDATA[
+public class Foo {
+    String bar2(Object a) {
+        if (a == null)
+            return null;
+        else
+            return a.toString();
+    }
+}
+        ]]>
+    </code-fragment>
+    <test-code>
+        <description>null check, ok (if) - #278</description>
+        <expected-problems>0</expected-problems>
+        <code-ref id="nullCheckIfElse"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, ok (if) - any branch</description>
+        <rule-property name="nullCheckBranch">Any</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="nullCheckIfElse"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, ok (if) - else branch</description>
+        <rule-property name="nullCheckBranch">Else</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="nullCheckIfElse"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, not ok (if) - then branch</description>
+        <rule-property name="nullCheckBranch">Then</rule-property>
+        <expected-problems>1</expected-problems>
+        <code-ref id="nullCheckIfElse"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, ok (if) - any branch</description>
+        <rule-property name="nullCheckBranch">Any</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="nullCheckIfThen"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, not ok (if) - else branch</description>
+        <rule-property name="nullCheckBranch">Else</rule-property>
+        <expected-problems>1</expected-problems>
+        <code-ref id="nullCheckIfThen"/>
+    </test-code>
+
+    <test-code>
+        <description>null check, ok (if) - then branch</description>
+        <rule-property name="nullCheckBranch">Then</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="nullCheckIfThen"/>
     </test-code>
 
     <test-code>


### PR DESCRIPTION
## Describe the PR

Adds a property that allows enforcing null checks to be handled consistently by the `then` branch, by the `else` branch, or by any branch (current behavior).

## Related issues

- Fix #6004

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

