### PR TITLE
[core] Flip order of get and update for atomics

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -207,10 +207,10 @@ public final class TimeTracker {
         /* package */ long accumulate(final TimerEntry timerEntry, final long extraData) {
             final long delta = System.nanoTime() - timerEntry.start;
 
-            totalTimeNanos.getAndAdd(delta);
-            selfTimeNanos.getAndAdd(delta - timerEntry.inNestedOperationsNanos);
-            callCount.getAndIncrement(); // NOPMD: UselessPureMethodCall false-positive #6055
-            extraDataCounter.getAndAdd(extraData);
+            totalTimeNanos.addAndGet(delta);
+            selfTimeNanos.addAndGet(delta - timerEntry.inNestedOperationsNanos);
+            callCount.incrementAndGet();
+            extraDataCounter.addAndGet(extraData);
 
             return delta;
         }
@@ -220,8 +220,8 @@ public final class TimeTracker {
          * @param timedResult The {@link TimedResult} to merge
          */
         /* package */ void mergeTimes(final TimedResult timedResult) {
-            totalTimeNanos.getAndAdd(timedResult.totalTimeNanos.get());
-            selfTimeNanos.getAndAdd(timedResult.selfTimeNanos.get());
+            totalTimeNanos.addAndGet(timedResult.totalTimeNanos.get());
+            selfTimeNanos.addAndGet(timedResult.selfTimeNanos.get());
         }
     }
 


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

This has no impact on functionality, the only purpose is to remove a violation suppression and unblock the dogfood check in https://github.com/pmd/pmd/pull/6082

I changed all the getAnd* methods to *AndGet to be consistent within the class.

## Related issues

#6082

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

