### PR TITLE
[core] Compatibility with slf4j 2.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <ant.version>1.10.15</ant.version>
         <javadoc.plugin.version>3.12.0</javadoc.plugin.version>
         <antlr.version>4.9.3</antlr.version>
-        <slf4j.version>2.0.17</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <saxon.version>12.5</saxon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Describe the PR

~~Dependency update for 3 slf4j-related packages. This does not increase the required Java version, so it can be hopefully merged for 7.0.x.~~

Checks for the simple logger under two different class names so that it's found with both slf4j 1.x and 2.x.

## Related issues

- See #6144

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

