### PR TITLE
Bump pmdtester from 1.6.1 to 1.6.2

### DIFF
--- a/.ci/files/Gemfile.lock
+++ b/.ci/files/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
-    pmdtester (1.6.1)
+    pmdtester (1.6.2)
       base64 (~> 0.3)
       bigdecimal (~> 3.2)
       differ (~> 0.1)


### PR DESCRIPTION
## Describe the PR

https://github.com/pmd/pmd-regression-tester/releases/tag/v1.6.2

