### PR TITLE
[java] automatic-module-name header added for pmd-core

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -23,6 +23,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/sandbox/graphs" vcs="Git" />
   </component>
 </project>

--- a/docs/pages/pmd/projectdocs/decisions/adr-3.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-3.md
@@ -70,6 +70,31 @@ of several maven modules.
 * All other modules use the base package `net.sourceforge.pmd.<module>`,
   E.g. `pmd-cli` uses the package `net.sourceforge.pmd.cli`.
 
+#### Java module names
+
+The java module name for the main jar of a maven module correspond to the name of the principal exported API package by the artifact.
+The java module name of a test jar is the main module name with '.tests' appended.
+
+Currently that means the following names for the corresponding maven modules:
+
+* pmd-apex: net.sourceforge.pmd.lang.apex
+* pmd-ant: net.sourceforge.pmd.ant
+* pmd-css: net.sourceforge.pmd.lang.css
+* pmd-go: net.sourceforge.pmd.lang.go
+* pmd-cs: net.sourceforge.pmd.lang.cs
+* pmd-groovy: net.sourceforge.pmd.lang.groovy
+* pmd-gherkin: net.sourceforge.pmd.lang.gherkin
+* pmd-coco: net.sourceforge.pmd.lang.coco
+* pmd-test: net.sourceforge.pmd.test
+* pmd:core: net.sourceforge.pmd for the main and net.sourceforge.pmd.tests for the test artifact
+* pmd-lang-test: net.sourceforge.pmd.lang.test
+* pmd-cpp: net.sourceforge.pmd.lang.cpp
+* pmd-fortran: net.sourceforge.pmd.lang.fortran
+* pmd-dart: net.sourceforge.pmd.lang.dart
+* pmd-html: net.sourceforge.pmd.lang.html
+* pmd-java: net.sourceforge.pmd.lang.java
+* pmd-test-schema: net.sourceforge.pmd.test.schema
+
 ### Criteria for public API
 
 Public API is

--- a/docs/pages/pmd/projectdocs/decisions/adr-3.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-3.md
@@ -77,23 +77,49 @@ The java module name of a test jar is the main module name with '.tests' appende
 
 Currently that means the following names for the corresponding maven modules:
 
-* pmd-apex: net.sourceforge.pmd.lang.apex
 * pmd-ant: net.sourceforge.pmd.ant
-* pmd-css: net.sourceforge.pmd.lang.css
-* pmd-go: net.sourceforge.pmd.lang.go
-* pmd-cs: net.sourceforge.pmd.lang.cs
-* pmd-groovy: net.sourceforge.pmd.lang.groovy
-* pmd-gherkin: net.sourceforge.pmd.lang.gherkin
+* pmd-apex: net.sourceforge.pmd.lang.apex
+* pmd-cli: net.sourceforge.pmd.cli
 * pmd-coco: net.sourceforge.pmd.lang.coco
-* pmd-test: net.sourceforge.pmd.test
-* pmd:core: net.sourceforge.pmd for the main and net.sourceforge.pmd.tests for the test artifact
-* pmd-lang-test: net.sourceforge.pmd.lang.test
+* pmd-core: net.sourceforge.pmd.core
+* pmd-core (test artifact): net.sourceforge.pmd.core.tests
 * pmd-cpp: net.sourceforge.pmd.lang.cpp
-* pmd-fortran: net.sourceforge.pmd.lang.fortran
+* pmd-cs: net.sourceforge.pmd.lang.cs
+* pmd-css: net.sourceforge.pmd.lang.css
 * pmd-dart: net.sourceforge.pmd.lang.dart
+* pmd-dist: net.sourceforge.pmd.dist
+* pmd-doc: net.sourceforge.pmd.doc
+* pmd-fortran: net.sourceforge.pmd.lang.fortran
+* pmd-gherkin: net.sourceforge.pmd.lang.gherkin
+* pmd-go: net.sourceforge.pmd.lang.go
+* pmd-groovy: net.sourceforge.pmd.lang.groovy
 * pmd-html: net.sourceforge.pmd.lang.html
 * pmd-java: net.sourceforge.pmd.lang.java
+* pmd-javascript: net.sourceforge.pmd.lang.javascript
+* pmd-jsp: net.sourceforge.pmd.lang.jsp
+* pmd-julia: net.sourceforge.pmd.lang.julia
+* pmd-kotlin: net.sourceforge.pmd.lang.kotlin
+* pmd-lang-test: net.sourceforge.pmd.lang.test
+* pmd-lua: net.sourceforge.pmd.lang.lua
+* pmd-matlab: net.sourceforge.pmd.lang.matlab
+* pmd-modelica: net.sourceforge.pmd.lang.modelica
+* pmd-objectivec: net.sourceforge.pmd.lang.objectivec
+* pmd-perl: net.sourceforge.pmd.lang.perl
+* pmd-php: net.sourceforge.pmd.lang.php
+* pmd-plsql: net.sourceforge.pmd.lang.plsql
+* pmd-python: net.sourceforge.pmd.lang.python
+* pmd-ruby: net.sourceforge.pmd.lang.ruby
+* pmd-rust: net.sourceforge.pmd.lang.rust
+* pmd-scala_2.12:
+* pmd-scala_2.13:
+* pmd-swift: net.sourceforge.pmd.lang.swift
+* pmd-test: net.sourceforge.pmd.test
 * pmd-test-schema: net.sourceforge.pmd.test.schema
+* pmd-tsql: net.sourceforge.pmd.lang.tsql
+* pmd-velocity: net.sourceforge.pmd.lang.velocity
+* pmd-visualforce:
+* pmd-xml: net.sourceforge.pmd.lang.xml
+
 
 ### Criteria for public API
 

--- a/pmd-ant/pom.xml
+++ b/pmd-ant/pom.xml
@@ -14,7 +14,9 @@
     <artifactId>pmd-ant</artifactId>
     <name>PMD Ant Integration</name>
     <description>Apache Ant integration for PMD.</description>
-
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.ant</Automatic-Module-Name>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.apex</Automatic-Module-Name>
+    </properties>
 
     <build>
         <resources>

--- a/pmd-cli/pom.xml
+++ b/pmd-cli/pom.xml
@@ -11,6 +11,9 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.cli</Automatic-Module-Name>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/pmd-coco/pom.xml
+++ b/pmd-coco/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.coco</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -64,8 +64,22 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>pmd.core.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>pmd.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
 
             <plugin>
@@ -74,6 +88,7 @@
                 <configuration>
                     <!-- overrides the configuration from parent pom: we have here no offline links yet -->
                     <offlineLinks combine.self="override"></offlineLinks>
+                    <excludePackageNames>net.sourceforge.pmd.cache</excludePackageNames>
                 </configuration>
             </plugin>
 

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -10,8 +10,8 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.core</Automatic-Module-Name>
         <!-- default values for the properties provided by git-commit-id-maven-plugin -->
         <git.commit.id>unknown</git.commit.id>
         <git.commit.time>unknown</git.commit.time>
@@ -67,19 +67,12 @@
                         <configuration>
                             <archive>
                                 <manifestEntries>
-                                    <Automatic-Module-Name>pmd.core.tests</Automatic-Module-Name>
+                                    <Automatic-Module-Name>net.sourceforge.pmd.core.tests</Automatic-Module-Name>
                                 </manifestEntries>
                             </archive>
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>pmd.core</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pmd-cpp/pom.xml
+++ b/pmd-cpp/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.cpp</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-cs/pom.xml
+++ b/pmd-cs/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.cs</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-css/pom.xml
+++ b/pmd-css/pom.xml
@@ -12,6 +12,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.css</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-dart/pom.xml
+++ b/pmd-dart/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.dart</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <pmd.dist.bin.baseDirectory>pmd-bin-${project.version}</pmd.dist.bin.baseDirectory>
+        <Automatic-Module-Name>net.sourceforge.pmd.dist</Automatic-Module-Name>
     </properties>
 
     <build>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -13,6 +13,7 @@
     </parent>
 
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.doc</Automatic-Module-Name>
         <java.version>8</java.version>
     </properties>
 

--- a/pmd-fortran/pom.xml
+++ b/pmd-fortran/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.fortran</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-gherkin/pom.xml
+++ b/pmd-gherkin/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.gherkin</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-go/pom.xml
+++ b/pmd-go/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.go</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-groovy/pom.xml
+++ b/pmd-groovy/pom.xml
@@ -10,6 +10,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.groovy</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-html/pom.xml
+++ b/pmd-html/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.html</Automatic-Module-Name>
         <java.version>8</java.version>
     </properties>
 

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <log4j.version>2.25.2</log4j.version>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.java</Automatic-Module-Name>
     </properties>
 
     <build>
@@ -152,13 +153,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>pmd.java</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
 
         </plugins>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -149,6 +149,18 @@
                     </parameter>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>pmd.java</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
     <dependencies>

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.javascript</Automatic-Module-Name>
         <java.version>8</java.version>
     </properties>
 

--- a/pmd-jsp/pom.xml
+++ b/pmd-jsp/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.jsp</Automatic-Module-Name>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/pmd-julia/pom.xml
+++ b/pmd-julia/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.julia</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-kotlin/pom.xml
+++ b/pmd-kotlin/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.kotlin</Automatic-Module-Name>
         <antlr4.visitor>true</antlr4.visitor>
     </properties>
 

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -15,6 +15,9 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.test</Automatic-Module-Name>
+    </properties>
 
     <build>
         <plugins>

--- a/pmd-lua/pom.xml
+++ b/pmd-lua/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.lua</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-matlab/pom.xml
+++ b/pmd-matlab/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.matlab</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.modelica</Automatic-Module-Name>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/pmd-objectivec/pom.xml
+++ b/pmd-objectivec/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.objectivec</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-perl/pom.xml
+++ b/pmd-perl/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.perl</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-php/pom.xml
+++ b/pmd-php/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.php</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-plsql/pom.xml
+++ b/pmd-plsql/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.plsql</Automatic-Module-Name>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/pmd-python/pom.xml
+++ b/pmd-python/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.python</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-ruby/pom.xml
+++ b/pmd-ruby/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.ruby</Automatic-Module-Name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>

--- a/pmd-rust/pom.xml
+++ b/pmd-rust/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.rust</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -33,6 +33,13 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration >
+                        <archive combine.self="override"/>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <configuration>
                         <useDefaultDelimiters>false</useDefaultDelimiters>

--- a/pmd-swift/pom.xml
+++ b/pmd-swift/pom.xml
@@ -12,6 +12,7 @@
     </parent>
 
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.swift</Automatic-Module-Name>
         <antlr4.visitor>true</antlr4.visitor>
     </properties>
 

--- a/pmd-test-schema/pom.xml
+++ b/pmd-test-schema/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <java.version>8</java.version>
+        <Automatic-Module-Name>net.sourceforge.pmd.test.schema</Automatic-Module-Name>
     </properties>
 
     <build>

--- a/pmd-test/pom.xml
+++ b/pmd-test/pom.xml
@@ -11,8 +11,8 @@
         <version>7.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-
     <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.test</Automatic-Module-Name>
         <java.version>8</java.version>
     </properties>
 

--- a/pmd-tsql/pom.xml
+++ b/pmd-tsql/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.tsql</Automatic-Module-Name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pmd-velocity/pom.xml
+++ b/pmd-velocity/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.velocity</Automatic-Module-Name>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/pmd-visualforce/pom.xml
+++ b/pmd-visualforce/pom.xml
@@ -24,6 +24,13 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration >
+                    <archive combine.self="override"/>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
                     <useDefaultDelimiters>false</useDefaultDelimiters>

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -11,6 +11,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <Automatic-Module-Name>net.sourceforge.pmd.lang.xml</Automatic-Module-Name>
+        <java.version>8</java.version>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.4.2</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/tools/listModuleNames.sh
+++ b/tools/listModuleNames.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# lists automatic module names for all modules, using the built jars
+for jar in $(find -name '*.jar'|grep target/pmd|egrep -v -- "-sources.jar|-javadoc.jar")
+do
+	project=$(echo $jar|sed 'sA.*target/AA;sX-[0-9].*XX')
+	unzip  -q -o -d /tmp $jar META-INF/MANIFEST.MF
+	modulename=$(grep Auto /tmp/META-INF/MANIFEST.MF|sed 's/.*://')
+	rm -rf /tmp/META-INF
+	echo '*' $project:$modulename
+done


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

Adds Automatic-Module-Name header to the MANIFEST.MF of pmd-core
Had to exclude pmd.cache from javadoc, as there are no classes there, but checked that subpackages get included in the javadoc.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6167
- Related #4832

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

