### PR TITLE
[java] Fix #6053: ModifierOrder - consider type params

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTLambdaParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTModifierList;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTVoidType;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
@@ -37,8 +38,11 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
     private static final String MSG_KEYWORD_ORDER =
         "Missorted modifiers `{0} {1}`.";
 
-    private static final String MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS =
-        "Missorted modifiers `{0} {1}`. Annotations should be placed before modifiers.";
+    private static final String MSG_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS =
+        "Missorted modifiers `{0} {1}`. Type annotations should be placed before modifiers.";
+
+    private static final String MSG_NON_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS =
+        "Missorted modifiers `{0} {1}`. Non-type annotations should be placed before modifiers.";
 
     private static final String MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE =
         "Missorted modifiers `{0} {1}`. Type annotations should be placed before the type they qualify.";
@@ -85,6 +89,8 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
 
         abstract boolean checkNextAnnot(AnnotMod next, RuleContext ctx);
 
+        abstract boolean checkNextTypeParams(TypeParamsMod next, RuleContext ctx);
+
         @Override
         public abstract String toString();
     }
@@ -115,9 +121,19 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
             if (next.isTypeAnnot != OptionalBool.NO && typeAnnotPosition != TypeAnnotationPosition.ON_DECL) {
                 return false;
             }
-            ctx.addViolationWithPosition(reportNode, token, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, this, next);
+
+            if (next.isTypeAnnot.isTrue()) {
+                ctx.addViolationWithPosition(reportNode, token, MSG_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, this, next);
+            } else {
+                ctx.addViolationWithPosition(reportNode, token, MSG_NON_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, this, next);
+            }
             return true;
 
+        }
+
+        @Override
+        boolean checkNextTypeParams(TypeParamsMod next, RuleContext ctx) {
+            return false;
         }
 
         @Override
@@ -126,7 +142,7 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
         }
     }
 
-    class AnnotMod extends ModifierOrderRule.LastModSeen {
+    class AnnotMod extends LastModSeen {
         private final @Nullable LastModSeen previous;
         private final ASTAnnotation annot;
         private final OptionalBool isTypeAnnot;
@@ -149,8 +165,10 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
                 // annotation sandwiched between keywords
                 if (isTypeAnnot.isTrue() && typeAnnotPosition != TypeAnnotationPosition.ON_DECL) {
                     ctx.addViolationWithMessage(annot, MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE, this, next);
+                } else if (isTypeAnnot.isTrue()) {
+                    ctx.addViolationWithMessage(annot, MSG_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, previous, this);
                 } else {
-                    ctx.addViolationWithMessage(annot, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, previous, this);
+                    ctx.addViolationWithMessage(annot, MSG_NON_TYPE_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, previous, this);
                 }
                 return true;
             }
@@ -165,8 +183,45 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
         }
 
         @Override
+        boolean checkNextTypeParams(TypeParamsMod next, RuleContext ctx) {
+            if (isTypeAnnot.isTrue() && typeAnnotPosition == TypeAnnotationPosition.ON_TYPE) {
+                ctx.addViolationWithMessage(annot, MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE, this, next);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
         public String toString() {
             return PrettyPrintingUtil.prettyPrintAnnot(annot);
+        }
+    }
+
+    class TypeParamsMod extends LastModSeen {
+        private final ASTTypeParameters typeParameters;
+
+        TypeParamsMod(ASTTypeParameters typeParameters) {
+            this.typeParameters = typeParameters;
+        }
+
+        @Override
+        boolean checkNextKeyword(KwMod next, RuleContext ctx) {
+            return false;
+        }
+
+        @Override
+        boolean checkNextAnnot(AnnotMod next, RuleContext ctx) {
+            return false;
+        }
+
+        @Override
+        boolean checkNextTypeParams(TypeParamsMod next, RuleContext ctx) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return typeParameters.getText().toString();
         }
     }
 
@@ -202,6 +257,18 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
                 lastModSeen = kwMod;
                 return false;
             }
+
+            @Override
+            public boolean recordTypeParameters(ASTTypeParameters typeParameters) {
+                TypeParamsMod typeParamsMod = new TypeParamsMod(typeParameters);
+                if (lastModSeen != null) {
+                    if (lastModSeen.checkNextTypeParams(typeParamsMod, ctx)) {
+                        return true;
+                    }
+                }
+                lastModSeen = typeParamsMod;
+                return false;
+            }
         };
 
         readModifierList(modList, eventHandler);
@@ -225,6 +292,9 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
 
     private static @Nullable ASTType getFollowingType(ASTModifierList node) {
         JavaNode nextSibling = node.getNextSibling();
+        if (nextSibling instanceof ASTTypeParameters) {
+            nextSibling = nextSibling.getNextSibling();
+        }
         if (nextSibling instanceof ASTType) {
             return (ASTType) nextSibling;
         }
@@ -252,6 +322,9 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
 
         /** Record that the next modifier is the given one occurring at the given token. */
         boolean recordModifier(JModifier mod, JavaccToken token);
+
+        /** Record that the next "modifier" is the given type parameters. */
+        boolean recordTypeParameters(ASTTypeParameters typeParameters);
     }
 
     /**
@@ -301,7 +374,9 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
             tok = tok.getNext();
         }
 
-
+        if (modList.getNextSibling() instanceof ASTTypeParameters) {
+            events.recordTypeParameters((ASTTypeParameters) modList.getNextSibling());
+        }
     }
 
     private static JModifier getModFromToken(JavaccToken tok) {

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1150,7 +1150,7 @@ public class Foo {
             - `on type`: Type annotations must be placed next to the type they apply to
             - `on decl`: Type annotations must be placed with other annotations, before modifiers.
             This is not enforced if the type annotations syntactically appears within the type, e.g.
-            in `public Map.@Nullable Entry&lt;K,V&gt; method()`.
+            in `public Map.@Nullable Entry&lt;K,V&gt; method()` or `public &lt;T&gt; @NonNull T method()`.
             - `anywhere` (default): Either position fits. They still cannot be interspersed within keyword
             modifiers. Annotations that are not type annotations are still required to be before keyword
             modifiers.

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
@@ -68,10 +68,10 @@ abstract public class Foo { // warn l1
         <expected-problems>5</expected-problems>
         <expected-linenumbers>8,14,17,22,24</expected-linenumbers>
         <expected-messages>
-            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Non-type annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
-            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `static @Decl`. Non-type annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
         </expected-messages>
         <code-ref id="annotations"/>
@@ -88,7 +88,7 @@ abstract public class Foo { // warn l1
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
-            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `static @Decl`. Non-type annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
         </expected-messages>
         <code-ref id="annotations"/>
@@ -100,12 +100,12 @@ abstract public class Foo { // warn l1
         <expected-problems>6</expected-problems>
         <expected-linenumbers>5,8,14,17,22,24</expected-linenumbers>
         <expected-messages>
-            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
-            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeA`. Type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeA`. Type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `static @Decl`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeA`. Type annotations should be placed before modifiers.</message>
         </expected-messages>
         <code-ref id="annotations"/>
     </test-code>
@@ -269,7 +269,7 @@ abstract public class Foo { // warn l1
     </test-code>
 
     <test-code>
-        <description>Sealed class</description>
+        <description>#6057 Sealed class</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
         public abstract sealed class Foo permits Bar {
@@ -278,5 +278,114 @@ abstract public class Foo { // warn l1
         ]]></code>
     </test-code>
 
+    <code-fragment id="methods"><![CDATA[
+class Foo {
+  public @TypeAnnotation Foo bar1a() { return this; }       // line 2
+  @TypeAnnotation public Foo bar1b() { return this; }       // line 3
 
+  public @NotATypeAnnotation Foo bar2a() { return this; }   // line 5
+  @NotATypeAnnotation public Foo bar2b() { return this; }   // line 6
+
+  public @TypeAnnotation <T> Foo bar3a() { return this; }   // line 8
+  public <T> @TypeAnnotation Foo bar3b() { return this; }   // line 9
+  @TypeAnnotation public <T> Foo bar3c() { return this; }   // line 10
+
+  public @NotATypeAnnotation <T> Foo bar4a() { return this; }   // line 12
+  public <T> @NotATypeAnnotation Foo bar4b() { return this; }   // line 13
+  @NotATypeAnnotation public <T> Foo bar4c() { return this; }   // line 14
+}
+@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+@interface TypeAnnotation {}
+
+@interface NotATypeAnnotation {}
+]]></code-fragment>
+
+    <test-code>
+        <description>#6053 Annotation on method with modifiers/generic types (typeAnnotations=anywhere)</description>
+        <rule-property name="typeAnnotations">anywhere</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,12</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="methods"/>
+    </test-code>
+
+    <test-code>
+        <description>#6053 Annotation on method with modifiers/generic types (typeAnnotations=ontype)</description>
+        <rule-property name="typeAnnotations">ontype</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>3,5,8,10,12</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `@TypeAnnotation public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `@TypeAnnotation &lt;T&gt;`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `@TypeAnnotation public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="methods"/>
+    </test-code>
+
+    <test-code>
+        <description>#6053 Annotation on method with modifiers/generic types (typeAnnotations=ondecl)</description>
+        <rule-property name="typeAnnotations">ondecl</rule-property>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>2,5,8,12</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `public @TypeAnnotation`. Type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeAnnotation`. Type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="methods"/>
+    </test-code>
+
+    <code-fragment id="method_params"><![CDATA[
+class Foo {
+  public void bar1a(final @TypeAnnotation Foo foo) {}       // line 2
+  public void bar1b(@TypeAnnotation final Foo foo) {}       // line 3
+
+  public void bar2a(final @NotATypeAnnotation Foo foo) {}   // line 5
+  public void bar2b(@NotATypeAnnotation final Foo foo) {}   // line 6
+}
+
+@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+@interface TypeAnnotation {}
+
+@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.PARAMETER, java.lang.annotation.ElementType.FIELD})
+@interface NotATypeAnnotation {}
+]]></code-fragment>
+    <test-code>
+        <description>#6053 Annotation on method parameter with modifiers/generic types (typeAnnotations=anywhere)</description>
+        <rule-property name="typeAnnotations">anywhere</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `final @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="method_params"/>
+    </test-code>
+    <test-code>
+        <description>#6053 Annotation on method parameter with modifiers/generic types (typeAnnotations=ontype)</description>
+        <rule-property name="typeAnnotations">ontype</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `@TypeAnnotation final`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `final @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="method_params"/>
+    </test-code>
+    <test-code>
+        <description>#6053 Annotation on method parameter with modifiers/generic types (typeAnnotations=ondecl)</description>
+        <rule-property name="typeAnnotations">ondecl</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,5</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `final @TypeAnnotation`. Type annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `final @NotATypeAnnotation`. Non-type annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="method_params"/>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Type params can occur before or after (type) annotations. If the annotations occur after the type params, then they syntactically belong to the type they annotate.

- with typeAnnotations=anywhere, type annotations should be also allowed after modifier keywords and before type parameters.
- extend tests to verify "Annotations that are not type annotations are still required to be before keyword modifiers."
- improve violation messages to distinguish between type and non-type annotation.

## Related issues

- Fix #6053

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

