### PR TITLE
chore: always place type annotations on the type

### DIFF
--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
@@ -286,8 +286,7 @@ public class PmdCommand extends AbstractAnalysisPmdSubcommand<PMDConfiguration> 
     }
 
     @Override
-    @NonNull
-    protected CliExitCode doExecute(PMDConfiguration configuration) {
+    protected @NonNull CliExitCode doExecute(PMDConfiguration configuration) {
         if (benchmark) {
             TimeTracker.startGlobalTracking();
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ClasspathClassLoader.java
@@ -211,8 +211,7 @@ public class ClasspathClassLoader extends URLClassLoader {
     // this is lazily initialized on first query of a module-info.class
     private Map<String, URL> moduleNameToModuleInfoUrls;
 
-    @Nullable
-    private static String extractModuleName(String name) {
+    private static @Nullable String extractModuleName(String name) {
         if (!name.endsWith(MODULE_INFO_SUFFIX_SLASH)) {
             return null;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
@@ -776,8 +776,7 @@ public interface NodeStream<@NonNull T extends Node> extends Iterable<@NonNull T
      * @see #first(Class)
      * @see #firstOpt()
      */
-    @NonNull
-    default T firstOrThrow() {
+    default @NonNull T firstOrThrow() {
         T first = first();
         if (first == null) {
             throw new NoSuchElementException("Empty node stream");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/GenericNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/GenericNode.java
@@ -38,14 +38,12 @@ public interface GenericNode<N extends GenericNode<N>> extends Node {
     N getParent();
 
     @Override
-    @Nullable
-    default N getFirstChild() {
+    default @Nullable N getFirstChild() {
         return getNumChildren() > 0 ? getChild(0) : null;
     }
 
     @Override
-    @Nullable
-    default N getLastChild() {
+    default @Nullable N getLastChild() {
         return getNumChildren() > 0 ? getChild(getNumChildren() - 1) : null;
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -222,7 +222,7 @@ public final class StreamImpl {
         }
 
         @Override
-        protected @NonNull <R extends Node> DescendantNodeStream<R> flatMapDescendants(Function<N, DescendantNodeStream<? extends R>> mapper) {
+        protected <R extends Node> @NonNull DescendantNodeStream<R> flatMapDescendants(Function<N, DescendantNodeStream<? extends R>> mapper) {
             return StreamImpl.empty();
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -220,8 +220,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
      * Create the targeting strategy for this rule.
      * Use the factory methods of {@link RuleTargetSelector}.
      */
-    @NonNull
-    protected RuleTargetSelector buildTargetSelector() {
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
         Set<Class<? extends Node>> crvs = getClassRuleChainVisits();
         return crvs.isEmpty() ? RuleTargetSelector.forRootOnly()
                               : RuleTargetSelector.forTypes(crvs);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
@@ -260,8 +260,7 @@ public class RuleSetWriter {
         return ruleSetReferenceElement;
     }
 
-    @Nullable
-    private Element createPropertiesElement(PropertySource propertySource) {
+    private @Nullable Element createPropertiesElement(PropertySource propertySource) {
 
         Element propertiesElement = null;
         List<PropertyDescriptor<?>> overridden = propertySource.getOverriddenPropertyDescriptors();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelation.java
@@ -156,8 +156,7 @@ class LatticeRelation<K, @NonNull V, C> {
         n.addValueTransitive(val);
     }
 
-    @NonNull
-    private IllegalStateException cycleError(@NonNull Deque<LNode> preds, K k) {
+    private @NonNull IllegalStateException cycleError(@NonNull Deque<LNode> preds, K k) {
         List<String> toStrings = map(toMutableList(), preds, n -> keyToString.apply(n.key));
         toStrings.add(keyToString.apply(k));
         return new IllegalStateException("Cycle in graph: " + String.join(" -> ", toStrings));
@@ -201,8 +200,7 @@ class LatticeRelation<K, @NonNull V, C> {
      *
      * @throws NullPointerException If the key is null
      */
-    @NonNull
-    public C get(@NonNull K key) {
+    public @NonNull C get(@NonNull K key) {
         AssertionUtil.requireParamNotNull("key", key);
         LNode n = nodes.get(key);
         return n == null ? emptyValue : n.computeValue();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
@@ -54,8 +54,7 @@ public final class DomainConversion {
         }
     }
 
-    @NonNull
-    public static AtomicSequence convert(Object obj) {
+    public static @NonNull AtomicSequence convert(Object obj) {
         if (obj instanceof Collection) {
             return getSequenceRepresentation((Collection<?>) obj);
         }
@@ -122,8 +121,7 @@ public final class DomainConversion {
      *
      * @return The converted AtomicValue
      */
-    @NonNull
-    public static AtomicValue getAtomicRepresentation(final Object value) {
+    public static @NonNull AtomicValue getAtomicRepresentation(final Object value) {
 
         /*
         FUTURE When supported, we should consider refactor this implementation to use Pattern Matching

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
@@ -711,7 +711,7 @@ public final class CollectionUtil {
         return as.plusAll(bs);
     }
 
-    public static @NonNull <T> List<T> makeUnmodifiableAndNonNull(@Nullable List<? extends T> list) {
+    public static <T> @NonNull List<T> makeUnmodifiableAndNonNull(@Nullable List<? extends T> list) {
         if (list instanceof PSequence) {
             return (List<T>) list;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
@@ -74,8 +74,7 @@ public final class GraphUtil {
     }
 
 
-    @NonNull
-    private static String escapeDotString(String string) {
+    private static @NonNull String escapeDotString(String string) {
         return string.replaceAll("\\R", "\\\n")
                      .replaceAll("\"", "\\\"");
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAllocation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayAllocation.java
@@ -39,8 +39,7 @@ public final class ASTArrayAllocation extends AbstractJavaExpr implements ASTPri
     }
 
     /** Returns the initializer, if present. */
-    @Nullable
-    public ASTArrayInitializer getArrayInitializer() {
+    public @Nullable ASTArrayInitializer getArrayInitializer() {
         return AstImplUtil.getChildAs(this, getNumChildren() - 1, ASTArrayInitializer.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentExpression.java
@@ -31,8 +31,7 @@ public final class ASTAssignmentExpression extends AbstractJavaExpr implements I
 
     /** Returns the left-hand side, ie the expression being assigned to. */
     @Override
-    @NonNull
-    public ASTAssignableExpr getLeftOperand() {
+    public @NonNull ASTAssignableExpr getLeftOperand() {
         return (ASTAssignableExpr) getChild(0);
     }
 
@@ -46,8 +45,7 @@ public final class ASTAssignmentExpression extends AbstractJavaExpr implements I
 
 
     @Override
-    @NonNull
-    public AssignmentOp getOperator() {
+    public @NonNull AssignmentOp getOperator() {
         return operator;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCatchParameter.java
@@ -49,8 +49,7 @@ public final class ASTCatchParameter extends AbstractJavaNode
     }
 
     @Override
-    @NonNull
-    public ASTVariableId getVarId() {
+    public @NonNull ASTVariableId getVarId() {
         return (ASTVariableId) getLastChild();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassType.java
@@ -112,16 +112,14 @@ public final class ASTClassType extends AbstractJavaTypeNode implements ASTRefer
      *
      * @return A type, or null if this is a base type
      */
-    @Nullable
-    public ASTClassType getQualifier() {
+    public @Nullable ASTClassType getQualifier() {
         return firstChild(ASTClassType.class);
     }
 
     /**
      * Returns the type arguments of this segment if some are specified.
      */
-    @Nullable
-    public ASTTypeArguments getTypeArguments() {
+    public @Nullable ASTTypeArguments getTypeArguments() {
         return firstChild(ASTTypeArguments.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
@@ -97,8 +97,7 @@ public final class ASTConstructorCall extends AbstractInvocationExpr implements 
     }
 
 
-    @Nullable
-    public ASTAnonymousClassDeclaration getAnonymousClassDeclaration() {
+    public @Nullable ASTAnonymousClassDeclaration getAnonymousClassDeclaration() {
         return isAnonymousClass()
                ? (ASTAnonymousClassDeclaration) getLastChild()
                : null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
@@ -54,8 +54,7 @@ public final class ASTEnumConstant extends AbstractJavaTypeNode
     }
 
     @Override
-    @Nullable
-    public ASTArgumentList getArguments() {
+    public @Nullable ASTArgumentList getArguments() {
         return firstChild(ASTArgumentList.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
@@ -71,8 +71,7 @@ public interface ASTExecutableDeclaration
     /**
      * Returns the formal parameters node of this method or constructor.
      */
-    @NonNull
-    default ASTFormalParameters getFormalParameters() {
+    default @NonNull ASTFormalParameters getFormalParameters() {
         return firstChild(ASTFormalParameters.class);
     }
 
@@ -99,8 +98,7 @@ public interface ASTExecutableDeclaration
      * Returns the {@code throws} clause of this declaration, or null
      * if there is none.
      */
-    @Nullable
-    default ASTThrowsList getThrowsList() {
+    default @Nullable ASTThrowsList getThrowsList() {
         return firstChild(ASTThrowsList.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExplicitConstructorInvocation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExplicitConstructorInvocation.java
@@ -41,8 +41,7 @@ public final class ASTExplicitConstructorInvocation extends AbstractJavaTypeNode
 
 
     @Override
-    @NonNull
-    public ASTArgumentList getArguments() {
+    public @NonNull ASTArgumentList getArguments() {
         return (ASTArgumentList) getLastChild();
     }
 
@@ -85,8 +84,7 @@ public final class ASTExplicitConstructorInvocation extends AbstractJavaTypeNode
     }
 
     @Override
-    @Nullable
-    public ASTTypeArguments getExplicitTypeArguments() {
+    public @Nullable ASTTypeArguments getExplicitTypeArguments() {
         return firstChild(ASTTypeArguments.class);
     }
 
@@ -94,8 +92,7 @@ public final class ASTExplicitConstructorInvocation extends AbstractJavaTypeNode
      * Returns the qualifying expression if this is a {@linkplain #isQualified() qualified superclass
      * constructor invocation}.
      */
-    @Nullable
-    public ASTExpression getQualifier() {
+    public @Nullable ASTExpression getQualifier() {
         return AstImplUtil.getChildAs(this, 0, ASTExpression.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpressionStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpressionStatement.java
@@ -29,8 +29,7 @@ public final class ASTExpressionStatement extends AbstractStatement {
 
 
     /** Returns the contained expression. */
-    @NonNull
-    public ASTExpression getExpr() {
+    public @NonNull ASTExpression getExpr() {
         return (ASTExpression) getChild(0);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForeachStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTForeachStatement.java
@@ -33,8 +33,7 @@ public final class ASTForeachStatement extends AbstractStatement implements Inte
 
 
     @Override
-    @NonNull
-    public ASTVariableId getVarId() {
+    public @NonNull ASTVariableId getVarId() {
         // in case of destructuring record patterns, there might be multiple vars
         return getFirstChild().descendants(ASTVariableId.class).first();
     }
@@ -43,8 +42,7 @@ public final class ASTForeachStatement extends AbstractStatement implements Inte
      * Returns the expression that evaluates to the {@link Iterable}
      * being looped upon.
      */
-    @NonNull
-    public ASTExpression getIterableExpr() {
+    public @NonNull ASTExpression getIterableExpr() {
         return firstChild(ASTExpression.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
@@ -48,8 +48,7 @@ public final class ASTFormalParameters extends ASTList<ASTFormalParameter> {
      * Returns the receiver parameter if it is present, otherwise returns
      * null.
      */
-    @Nullable
-    public ASTReceiverParameter getReceiverParameter() {
+    public @Nullable ASTReceiverParameter getReceiverParameter() {
         return AstImplUtil.getChildAs(this, 0, ASTReceiverParameter.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
@@ -67,14 +67,12 @@ public final class ASTLambdaParameter extends AbstractJavaTypeNode
      * Returns the declarator ID of this formal parameter.
      */
     @Override
-    @NonNull
-    public ASTVariableId getVarId() {
+    public @NonNull ASTVariableId getVarId() {
         return firstChild(ASTVariableId.class);
     }
 
     /** Returns the type node of this formal parameter. */
-    @Nullable
-    public ASTType getTypeNode() {
+    public @Nullable ASTType getTypeNode() {
         return firstChild(ASTType.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
@@ -54,15 +54,13 @@ public final class ASTMethodCall extends AbstractInvocationExpr implements Quali
     }
 
     @Override
-    @NonNull
-    public ASTArgumentList getArguments() {
+    public @NonNull ASTArgumentList getArguments() {
         return (ASTArgumentList) getChild(getNumChildren() - 1);
     }
 
 
     @Override
-    @Nullable
-    public ASTTypeArguments getExplicitTypeArguments() {
+    public @Nullable ASTTypeArguments getExplicitTypeArguments() {
         return firstChild(ASTTypeArguments.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -108,8 +108,7 @@ public final class ASTMethodDeclaration extends AbstractExecutableDeclaration<JM
      * Returns the default clause, if this is an annotation method declaration
      * that features one. Otherwise returns null.
      */
-    @Nullable
-    public ASTDefaultValue getDefaultClause() {
+    public @Nullable ASTDefaultValue getDefaultClause() {
         return AstImplUtil.getChildAs(this, getNumChildren() - 1, ASTDefaultValue.class);
     }
 
@@ -124,8 +123,7 @@ public final class ASTMethodDeclaration extends AbstractExecutableDeclaration<JM
      * Returns the extra array dimensions that may be after the
      * formal parameters.
      */
-    @Nullable
-    public ASTArrayDimensions getExtraDimensions() {
+    public @Nullable ASTArrayDimensions getExtraDimensions() {
         return children(ASTArrayDimensions.class).first();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReceiverParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReceiverParameter.java
@@ -57,8 +57,7 @@ public final class ASTReceiverParameter extends AbstractJavaNode {
      * declaration of the inner class, call it C, and the name of the parameter
      * must be {@code Identifier.this} where {@code Identifier} is the simple name of C.
      */
-    @NonNull
-    public ASTClassType getReceiverType() {
+    public @NonNull ASTClassType getReceiverType() {
         return (ASTClassType) getChild(0);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
@@ -44,8 +44,7 @@ public final class ASTRecordDeclaration extends AbstractTypeDeclaration {
     }
 
     @Override
-    @NonNull
-    public ASTRecordComponentList getRecordComponents() {
+    public @NonNull ASTRecordComponentList getRecordComponents() {
         return firstChild(ASTRecordComponentList.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
@@ -63,8 +63,7 @@ public final class ASTResource extends AbstractJavaNode {
         }
     }
 
-    @Nullable
-    public ASTLocalVariableDeclaration asLocalVariableDeclaration() {
+    public @Nullable ASTLocalVariableDeclaration asLocalVariableDeclaration() {
         return AstImplUtil.getChildAs(this, 0, ASTLocalVariableDeclaration.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReturnStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReturnStatement.java
@@ -31,8 +31,7 @@ public final class ASTReturnStatement extends AbstractStatement {
     /**
      * Returns the returned expression, or null if this is a simple return.
      */
-    @Nullable
-    public ASTExpression getExpr() {
+    public @Nullable ASTExpression getExpr() {
         return AstImplUtil.getChildAs(this, 0, ASTExpression.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSuperExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSuperExpression.java
@@ -23,8 +23,7 @@ public final class ASTSuperExpression extends AbstractJavaExpr implements ASTPri
     }
 
 
-    @Nullable
-    public ASTClassType getQualifier() {
+    public @Nullable ASTClassType getQualifier() {
         return getNumChildren() > 0 ? (ASTClassType) getChild(0) : null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThisExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThisExpression.java
@@ -24,8 +24,7 @@ public final class ASTThisExpression extends AbstractJavaExpr implements ASTPrim
     }
 
 
-    @Nullable
-    public ASTClassType getQualifier() {
+    public @Nullable ASTClassType getQualifier() {
         return getNumChildren() > 0 ? (ASTClassType) getChild(0) : null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
@@ -47,8 +47,7 @@ public final class ASTTryStatement extends AbstractStatement {
      * Returns the node for the resource list. This is null if this is
      * not a try-with-resources.
      */
-    @Nullable
-    public ASTResourceList getResources() {
+    public @Nullable ASTResourceList getResources() {
         return AstImplUtil.getChildAs(this, 0, ASTResourceList.class);
     }
 
@@ -74,8 +73,7 @@ public final class ASTTryStatement extends AbstractStatement {
      *
      * @return The finally statement, or null if there is none
      */
-    @Nullable
-    public ASTFinallyClause getFinallyClause() {
+    public @Nullable ASTFinallyClause getFinallyClause() {
         return firstChild(ASTFinallyClause.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
@@ -54,8 +54,7 @@ public final class ASTTypeParameter extends AbstractTypedSymbolDeclarator<JTypeP
      * Returns the type bound node of this parameter,
      * or null if it is not bounded.
      */
-    @Nullable
-    public ASTType getTypeBoundNode() {
+    public @Nullable ASTType getTypeBoundNode() {
         return firstChild(ASTType.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
@@ -47,8 +47,7 @@ public class ASTVariableDeclarator extends AbstractJavaNode implements InternalI
      * Returns the id of the declared variable.
      */
     @Override
-    @NonNull
-    public ASTVariableId getVarId() {
+    public @NonNull ASTVariableId getVarId() {
         return (ASTVariableId) getChild(0);
     }
 
@@ -65,8 +64,7 @@ public class ASTVariableDeclarator extends AbstractJavaNode implements InternalI
     /**
      * Returns the initializer, of the variable, or null if it doesn't exist.
      */
-    @Nullable
-    public ASTExpression getInitializer() {
+    public @Nullable ASTExpression getInitializer() {
         return hasInitializer() ? (ASTExpression) getLastChild() : null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
@@ -84,14 +84,12 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
      * returns {@code int}, and this method returns the dimensions that follow
      * the variable ID. Returns null if there are no such dimensions.
      */
-    @Nullable
-    public ASTArrayDimensions getExtraDimensions() {
+    public @Nullable ASTArrayDimensions getExtraDimensions() {
         return children(ASTArrayDimensions.class).first();
     }
 
-    @NonNull
     @Override
-    public ASTModifierList getModifiers() {
+    public @NonNull ASTModifierList getModifiers() {
         // delegates modifiers
         return getModifierOwnerParent().getModifiers();
     }
@@ -304,8 +302,7 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
     /**
      * Returns the initializer of the variable, or null if it doesn't exist.
      */
-    @Nullable
-    public ASTExpression getInitializer() {
+    public @Nullable ASTExpression getInitializer() {
         if (getParent() instanceof ASTVariableDeclarator) {
             return ((ASTVariableDeclarator) getParent()).getInitializer();
         }
@@ -318,8 +315,7 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
      * type.
      */
     // TODO unreliable, not typesafe and not useful, should be deprecated
-    @Nullable
-    public Node getTypeNameNode() {
+    public @Nullable Node getTypeNameNode() {
         return getTypeNode();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTYieldStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTYieldStatement.java
@@ -41,8 +41,7 @@ public class ASTYieldStatement extends AbstractStatement {
      * Returns the switch expression to which this statement yields a
      * value.
      */
-    @NonNull
-    public ASTSwitchExpression getYieldTarget() {
+    public @NonNull ASTSwitchExpression getYieldTarget() {
         return Objects.requireNonNull(ancestors(ASTSwitchExpression.class).first(),
                                       "Yield statements should only be parsable inside switch expressions");
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AssignmentOp.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AssignmentOp.java
@@ -81,8 +81,7 @@ public enum AssignmentOp implements OperatorLike {
      * if this is a compound operator, otherwise returns
      * null.
      */
-    @Nullable
-    public BinaryOp getBinaryOp() {
+    public @Nullable BinaryOp getBinaryOp() {
         return binaryOp;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
@@ -38,22 +38,19 @@ final class InternalInterfaces {
     interface BinaryExpressionLike extends ASTExpression {
 
         /** Returns the left-hand-side operand. */
-        @NonNull
-        default ASTExpression getLeftOperand() {
+        default @NonNull ASTExpression getLeftOperand() {
             return (ASTExpression) getChild(0);
         }
 
 
         /** Returns the right-hand side operand. */
-        @NonNull
-        default ASTExpression getRightOperand() {
+        default @NonNull ASTExpression getRightOperand() {
             return (ASTExpression) getChild(1);
         }
 
 
         /** Returns the operator. */
-        @NonNull
-        OperatorLike getOperator();
+        @NonNull OperatorLike getOperator();
     }
 
     /**
@@ -65,8 +62,7 @@ final class InternalInterfaces {
 
         /** Returns the first child of this node, never null. */
         @Override
-        @NonNull
-        default JavaNode getFirstChild() {
+        default @NonNull JavaNode getFirstChild() {
             assert getNumChildren() > 0;
             return getChild(0);
         }
@@ -74,8 +70,7 @@ final class InternalInterfaces {
 
         /** Returns the last child of this node, never null. */
         @Override
-        @NonNull
-        default JavaNode getLastChild() {
+        default @NonNull JavaNode getLastChild() {
             assert getNumChildren() > 0;
             return getChild(getNumChildren() - 1);
         }
@@ -84,8 +79,7 @@ final class InternalInterfaces {
     interface AllChildrenAreOfType<T extends JavaNode> extends JavaNode {
 
         @Override
-        @Nullable
-        default T getFirstChild() {
+        default @Nullable T getFirstChild() {
             if (getNumChildren() == 0) {
                 return null;
             }
@@ -94,8 +88,7 @@ final class InternalInterfaces {
 
 
         @Override
-        @Nullable
-        default T getLastChild() {
+        default @Nullable T getLastChild() {
             if (getNumChildren() == 0) {
                 return null;
             }
@@ -111,8 +104,7 @@ final class InternalInterfaces {
 
         /** Returns the first child of this node, never null. */
         @Override
-        @NonNull
-        default T getFirstChild() {
+        default @NonNull T getFirstChild() {
             assert getNumChildren() > 0 : "No children for node implementing AtLeastOneChild " + this;
             return (T) getChild(0);
         }
@@ -120,8 +112,7 @@ final class InternalInterfaces {
 
         /** Returns the last child of this node, never null. */
         @Override
-        @NonNull
-        default T getLastChild() {
+        default @NonNull T getLastChild() {
             assert getNumChildren() > 0 : "No children for node implementing AtLeastOneChild " + this;
             return (T) getChild(getNumChildren() - 1);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeNode.java
@@ -35,8 +35,7 @@ public interface TypeNode extends JavaNode {
      * @return The type mirror. Never returns null; if the type is unresolved, returns
      *     {@link TypeSystem#UNKNOWN}.
      */
-    @NonNull
-    default JTypeMirror getTypeMirror() {
+    default @NonNull JTypeMirror getTypeMirror() {
         return getTypeMirror(TypingContext.DEFAULT);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaDesignerBindings.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaDesignerBindings.java
@@ -113,8 +113,7 @@ public final class JavaDesignerBindings extends DefaultDesignerBindings {
         return info;
     }
 
-    @NonNull
-    private String formatModifierSet(Set<JModifier> modifierSet) {
+    private @NonNull String formatModifierSet(Set<JModifier> modifierSet) {
         return modifierSet.stream().map(JModifier::toString).collect(Collectors.joining(", ", "(", ")"));
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -92,8 +92,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
         return null;
     }
 
-    @NonNull
-    private Deque<JMethodSymbol> getUnsafetyReason(ASTMethodCall call, PVector<ASTMethodDeclaration> recursionGuard) {
+    private @NonNull Deque<JMethodSymbol> getUnsafetyReason(ASTMethodCall call, PVector<ASTMethodDeclaration> recursionGuard) {
         if (!isCallOnThisInstance(call)) {
             return EMPTY_STACK;
         }
@@ -113,8 +112,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
         }
     }
 
-    @NonNull
-    private Deque<JMethodSymbol> getUnsafetyReason(JMethodSymbol method, PVector<ASTMethodDeclaration> recursionGuard) {
+    private @NonNull Deque<JMethodSymbol> getUnsafetyReason(JMethodSymbol method, PVector<ASTMethodDeclaration> recursionGuard) {
         if (method.isStatic()) {
             return EMPTY_STACK; // no access to this instance anyway
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
@@ -116,8 +116,7 @@ public interface JClassSymbol extends JTypeDeclSymbol,
 
 
     /** Returns a class with the given name defined in this class. */
-    @Nullable
-    default JClassSymbol getDeclaredClass(String name) {
+    default @Nullable JClassSymbol getDeclaredClass(String name) {
         for (JClassSymbol klass : getDeclaredClasses()) {
             if (klass.nameEquals(name)) {
                 return klass;
@@ -168,8 +167,7 @@ public interface JClassSymbol extends JTypeDeclSymbol,
 
 
     /** Returns a field with the given name defined in this class. */
-    @Nullable
-    default JFieldSymbol getDeclaredField(String name) {
+    default @Nullable JFieldSymbol getDeclaredField(String name) {
         for (JFieldSymbol field : getDeclaredFields()) {
             if (field.nameEquals(name)) {
                 return field;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFieldSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFieldSymbol.java
@@ -44,8 +44,7 @@ public interface JFieldSymbol extends JVariableSymbol, JAccessibleElementSymbol 
 
 
     @Override
-    @NonNull
-    default String getPackageName() {
+    default @NonNull String getPackageName() {
         return getEnclosingClass().getPackageName();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterOwnerSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterOwnerSymbol.java
@@ -58,8 +58,7 @@ public interface JTypeParameterOwnerSymbol extends JAccessibleElementSymbol {
      * the {@link #getEnclosingClass() enclosing class}, in that order
      * of priority.
      */
-    @Nullable
-    default JTypeParameterOwnerSymbol getEnclosingTypeParameterOwner() {
+    default @Nullable JTypeParameterOwnerSymbol getEnclosingTypeParameterOwner() {
         // may be overridden to add getEnclosingMethod
         return getEnclosingClass();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterSymbol.java
@@ -41,8 +41,7 @@ public interface JTypeParameterSymbol extends JTypeDeclSymbol, BoundToNode<ASTTy
 
 
     @Override
-    @NonNull
-    default String getPackageName() {
+    default @NonNull String getPackageName() {
         return getDeclaringSymbol().getPackageName();
     }
 
@@ -53,8 +52,7 @@ public interface JTypeParameterSymbol extends JTypeDeclSymbol, BoundToNode<ASTTy
     }
 
     @Override
-    @NonNull
-    default JClassSymbol getEnclosingClass() {
+    default @NonNull JClassSymbol getEnclosingClass() {
         JTypeParameterOwnerSymbol ownerSymbol = getDeclaringSymbol();
         return ownerSymbol instanceof JClassSymbol ? (JClassSymbol) ownerSymbol : ownerSymbol.getEnclosingClass();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
@@ -27,22 +27,19 @@ public interface SymbolResolver {
      * the AST implementation or by the type system. Looking up such symbols
      * is undefined behaviour.
      */
-    @Nullable
-    JClassSymbol resolveClassFromBinaryName(@NonNull String binaryName);
+    @Nullable JClassSymbol resolveClassFromBinaryName(@NonNull String binaryName);
 
     /**
      * @since 7.5.0
      */
-    @Nullable
-    JModuleSymbol resolveModule(@NonNull String moduleName);
+    @Nullable JModuleSymbol resolveModule(@NonNull String moduleName);
 
     /**
      * Resolves a class symbol from its canonical name. Periods ('.') may
      * be interpreted as nested-class separators, so for n segments, this
      * performs at most n classloader lookups.
      */
-    @Nullable
-    default JClassSymbol resolveClassFromCanonicalName(@NonNull String canonicalName) {
+    default @Nullable JClassSymbol resolveClassFromCanonicalName(@NonNull String canonicalName) {
         JClassSymbol symbol = resolveClassFromBinaryName(canonicalName);
         if (symbol != null) {
             return symbol;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Loader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Loader.java
@@ -14,8 +14,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 abstract class Loader {
 
 
-    @Nullable
-    abstract InputStream getInputStream() throws IOException;
+    abstract @Nullable InputStream getInputStream() throws IOException;
 
 
     static class FailedLoader extends Loader {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeSigParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeSigParser.java
@@ -331,8 +331,7 @@ final class TypeSigParser {
          * non-null, if the symbol is not found (linkage error) then return
          * an unresolved symbol.
          */
-        @NonNull
-        public abstract JClassSymbol makeClassSymbol(String internalName, int observedArity);
+        public abstract @NonNull JClassSymbol makeClassSymbol(String internalName, int observedArity);
 
 
         public JTypeMirror getBaseType(char baseType) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
@@ -107,8 +107,7 @@ final class AstSymbolMakerVisitor extends JavaVisitorBase<AstSymFactory, Void> {
         return null;
     }
 
-    @NonNull
-    private String makeBinaryName(ASTTypeDeclaration node) {
+    private @NonNull String makeBinaryName(ASTTypeDeclaration node) {
         String simpleName = node.getSimpleName();
         if (node.isLocal()) {
             simpleName = getNextIndexFromHistogram(currentLocalIndices.getFirst(), node.getSimpleName(), 1)
@@ -125,8 +124,7 @@ final class AstSymbolMakerVisitor extends JavaVisitorBase<AstSymFactory, Void> {
                                                          : packageName + "." + simpleName;
     }
 
-    @Nullable
-    private String makeCanonicalName(ASTTypeDeclaration node, String binaryName) {
+    private @Nullable String makeCanonicalName(ASTTypeDeclaration node, String binaryName) {
         if (node.isAnonymous() || node.isLocal() || node.isUnnamedToplevelClass()) {
             return null;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
@@ -74,8 +74,7 @@ public final class JavaResolvers {
         return isAccessibleIn(null, thisPackage, member, false);
     }
 
-    @NonNull
-    static NameResolver<JTypeMirror> moduleImport(Set<String> moduleNames,
+    static @NonNull NameResolver<JTypeMirror> moduleImport(Set<String> moduleNames,
                                                   final SymbolResolver symbolResolver,
                                                   final String thisPackage) {
         return new SingleNameResolver<JTypeMirror>() {
@@ -107,8 +106,7 @@ public final class JavaResolvers {
         };
     }
 
-    @NonNull
-    static NameResolver<JTypeMirror> importedOnDemand(Set<String> lazyImportedPackagesAndTypes,
+    static @NonNull NameResolver<JTypeMirror> importedOnDemand(Set<String> lazyImportedPackagesAndTypes,
                                                       final SymbolResolver symResolver,
                                                       final String thisPackage) {
         return new SingleNameResolver<JTypeMirror>() {
@@ -133,8 +131,7 @@ public final class JavaResolvers {
         };
     }
 
-    @NonNull
-    static NameResolver<JTypeMirror> packageResolver(SymbolResolver symResolver, String packageName) {
+    static @NonNull NameResolver<JTypeMirror> packageResolver(SymbolResolver symResolver, String packageName) {
         return new SingleNameResolver<JTypeMirror>() {
             @Nullable
             @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymTableFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymTableFactory.java
@@ -380,8 +380,7 @@ final class SymTableFactory {
         return typesInPackage(parent, thisPackage, ScopeInfo.SAME_PACKAGE);
     }
 
-    @NonNull
-    private JSymbolTable typesInPackage(JSymbolTable parent, String packageName, ScopeInfo scopeTag) {
+    private @NonNull JSymbolTable typesInPackage(JSymbolTable parent, String packageName, ScopeInfo scopeTag) {
         assert isValidJavaPackageName(packageName) : "Not a package name: " + packageName;
 
         return SymbolTableImpl.withTypes(

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArraySymbolImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArraySymbolImpl.java
@@ -145,14 +145,12 @@ class ArraySymbolImpl implements JClassSymbol {
     }
 
     @Override
-    @NonNull
-    public String getPackageName() {
+    public @NonNull String getPackageName() {
         return getArrayComponent().getPackageName();
     }
 
     @Override
-    @NonNull
-    public String getSimpleName() {
+    public @NonNull String getSimpleName() {
         return getArrayComponent().getSimpleName() + "[]";
     }
 
@@ -168,8 +166,7 @@ class ArraySymbolImpl implements JClassSymbol {
     }
 
     @Override
-    @Nullable
-    public JClassSymbol getEnclosingClass() {
+    public @Nullable JClassSymbol getEnclosingClass() {
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -996,7 +996,7 @@ public final class TypeOps {
     // relies on the fact the original list is unmodifiable or won't be
     // modified
     @SuppressWarnings("unchecked")
-    private static @NonNull <T> List<T> mapPreservingSelf(List<? extends T> ts, Function<? super T, ? extends @NonNull T> subst) {
+    private static <T> @NonNull List<T> mapPreservingSelf(List<? extends T> ts, Function<? super T, ? extends @NonNull T> subst) {
         // Profiling shows, only 10% of calls to this method need to
         // create a new list. Substitution in general is a hot spot
         // of the framework, so optimizing this out is nice


### PR DESCRIPTION
## Describe the PR

This is ModifierOrder with typeAnnotations=ontype

The following snippet will need to be added to build-tools pmd-dogfood-config.xml

```xml
    <rule ref="category/java/codestyle.xml/ModifierOrder">
        <priority>1</priority>
        <properties>
            <property name="typeAnnotations" value="ontype"/>
        </properties>
    </rule>
```

## Related issues

- Refs https://github.com/pmd/build-tools/pull/99#issuecomment-3410884373
- Should be checked again after #6192

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

