### PR TITLE
[java] Fix #6188: UnitTestsShouldIncludeAssert - FP when TestNG @Test.expectedException is present

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -195,9 +195,9 @@ public final class TestFrameworksUtil {
      */
     public static boolean isExpectAnnotated(ASTMethodDeclaration method) {
         return method.getDeclaredAnnotations()
-                     .filter(TestFrameworksUtil::isJunit4TestAnnotation)
+                     .filter(annotation -> isJunit4TestAnnotation(annotation) || isTestNgMethod(method))
                      .flatMap(ASTAnnotation::getMembers)
-                     .any(it -> "expected".equals(it.getName()));
+                     .any(it -> "expected".equals(it.getName()) || "expectedExceptions".equals(it.getName()));
 
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
@@ -894,4 +894,23 @@ class ShouldIncludeAssertTest {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6188 [java] UnitTestsShouldIncludeAssert - false positive when TestNG @Test.expectedException is present</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.testng.annotations.Test;
+class Foo {
+    @Test(expectedExceptions = IOException.class)
+    public static void alwaysThrows() throws IOException {
+       throw new IOException("expected");
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    void alwaysThrows() throws IOException {
+       throw new IOException("expected");
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6188 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

