### PR TITLE
chore: remove public methods from SourceManager

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* general
+  * [#5701](https://github.com/pmd/pmd/issues/5701): \[core] net.sourceforge.pmd.cpd.SourceManager has public methods
 
 ### 🚨️ API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
@@ -66,7 +66,7 @@ class SourceManager implements AutoCloseable {
         return textDocument;
     }
 
-    public int size() {
+    int size() {
         return files.size();
     }
 
@@ -80,7 +80,7 @@ class SourceManager implements AutoCloseable {
     }
 
     @SuppressWarnings("PMD.CloseResource")
-    public Chars getSlice(Mark mark) {
+    Chars getSlice(Mark mark) {
         TextFile textFile = fileByPathId.get(mark.getToken().getFileId());
         assert textFile != null : "No such file " + mark.getToken().getFileId();
         TextDocument doc = get(textFile);
@@ -90,7 +90,7 @@ class SourceManager implements AutoCloseable {
         return doc.sliceOriginalText(lineRange);
     }
 
-    public String getFileDisplayName(FileId fileId) {
+    String getFileDisplayName(FileId fileId) {
         return fileNameRenderer.getDisplayName(fileId);
     }
 }


### PR DESCRIPTION
## Describe the PR

SourceManager itself is package-private, so the effective visibility of those methods won't be public anyway.

## Related issues

- Fixes #5701

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

