### PR TITLE
[core] Deprecate old symboltable API

### DIFF
--- a/docs/pages/pmd/devdocs/major_contributions/adding_a_new_javacc_based_language.md
+++ b/docs/pages/pmd/devdocs/major_contributions/adding_a_new_javacc_based_language.md
@@ -3,7 +3,7 @@ title: Adding PMD support for a new JavaCC grammar based language
 short_title: Adding a new language with JavaCC
 tags: [devdocs, extending]
 summary: "How to add a new language to PMD using JavaCC grammar."
-last_updated: December 2023 (7.0.0)
+last_updated: November 2025 (7.19.0)
 sidebar: pmd_sidebar
 permalink: pmd_devdocs_major_adding_new_language_javacc.html
 folder: pmd/devdocs
@@ -293,7 +293,7 @@ see [Java-specific features and guidance](pmd_languages_java.html).
 {% capture deprecated_symbols_api_note %}
 With PMD 7.0.0 the symbol table and type resolution implementation has been
 rewritten from scratch. There is still an old API for symbol table support, that is used by PLSQL,
-see {% jdoc_package core::lang.symboltable %}. This will be deprecated and should not be used.
+see {% jdoc_package core::lang.symboltable %}. This has been deprecated and should not be used.
 {% endcapture %}
 {% include note.html content=deprecated_symbols_api_note %}
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,8 +25,17 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* core
+  * [#4767](https://github.com/pmd/pmd/issues/4767): \[core] Deprecate old symboltable API
 
 ### 🚨️ API Changes
+
+#### Deprecations
+* core
+  * {%jdoc_package core::lang.symboltable %}: All classes in this package are deprecated.
+    The symbol table and type resolution implementation for Java has been rewritten from scratch
+    for PMD 7.0.0. This package is the remains of the old symbol table API, that is only used by
+    PL/SQL. For PMD 8.0.0 all these classes will be removed from pmd-core.
 
 ### ✨️ Merged pull requests
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractNameDeclaration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractNameDeclaration.java
@@ -6,7 +6,10 @@ package net.sourceforge.pmd.lang.symboltable;
 
 /**
  * Base class for all name declarations.
+ *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public abstract class AbstractNameDeclaration implements NameDeclaration {
 
     protected ScopedNode node;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
@@ -14,7 +14,10 @@ import java.util.Set;
 
 /**
  * Base class for any {@link Scope}. Provides useful default implementations.
+ *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public abstract class AbstractScope implements Scope {
 
     private Scope parent;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Applier.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Applier.java
@@ -7,6 +7,10 @@ package net.sourceforge.pmd.lang.symboltable;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
+/**
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
+ */
+@Deprecated
 public final class Applier {
 
     private Applier() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ImageFinderFunction.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ImageFinderFunction.java
@@ -10,6 +10,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+/**
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
+ */
+@Deprecated
 public class ImageFinderFunction implements Predicate<NameDeclaration> {
 
     private final Set<String> images;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameDeclaration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameDeclaration.java
@@ -7,7 +7,10 @@ package net.sourceforge.pmd.lang.symboltable;
 /**
  * This is a declaration of a name, e.g. a variable or method name. See
  * {@link AbstractNameDeclaration} for a base class.
+ *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public interface NameDeclaration {
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameOccurrence.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/NameOccurrence.java
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.lang.symboltable;
 /**
  * A {@link NameOccurrence} represents one usage of a name declaration.
  *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public interface NameOccurrence {
     /**
      * Gets the location where the usage occurred.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Scope.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/Scope.java
@@ -17,7 +17,10 @@ import java.util.Set;
  * @see <a href=
  *      "http://docs.oracle.com/javase/specs/jls/se7/html/jls-6.html#jls-6.3">Java
  *      Language Specification, 6.3: Scope of a Declaration</a>
+ *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public interface Scope {
     /**
      * Retrieves this scope's parent

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ScopedNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/ScopedNode.java
@@ -8,7 +8,10 @@ import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * A {@link Node} which knows about the scope within it has been declared.
+ *
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
  */
+@Deprecated
 public interface ScopedNode extends Node {
 
     Scope getScope();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/package-info.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+/**
+ * @deprecated Since 7.19.0. All classes in this package are deprecated. The symbol table and type
+ * resolution implementation for Java has been rewritten from scratch for PMD 7.0.0. This package
+ * is the remains of the old symbol table API, that is only used by PL/SQL. For PMD 8.0.0 all these
+ * classes will be removed from pmd-core.
+ */
+@Deprecated
+package net.sourceforge.pmd.lang.symboltable;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/symboltable/ApplierTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/symboltable/ApplierTest.java
@@ -12,6 +12,10 @@ import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * @deprecated Since 7.19.0. For more info, see {@link net.sourceforge.pmd.lang.symboltable}.
+ */
+@Deprecated
 class ApplierTest {
 
     private static class MyFunction implements Predicate<Object> {


### PR DESCRIPTION
## Describe the PR

This only deprecates the package. It is still in use by PLSQL.
I briefly tried to get rid of this usage already now, but this would be an incompatible change in PLSQL.
That means, the final cleanup is for #5703 then.

## Related issues

- Fixes #4767

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

