### PR TITLE
[java] Fix #6092: AssignmentInOperand false positive in 7.17.0 for case statements

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -97,7 +97,8 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
                 return;
             }
             if (parent instanceof ASTSwitchArrowBranch
-                    && parent.getParent() instanceof ASTSwitchStatement) {  // switch expression excluded
+                    && parent.getParent() instanceof ASTSwitchStatement) {
+                // assignments in modern (->) switch statements are ok
                 return;
             }
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
@@ -333,8 +333,8 @@ public class Foo {
 
     <test-code>
         <description>#6092 false positive for case statements</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>18</expected-linenumbers>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>31,35,39</expected-linenumbers>
         <code><![CDATA[
             // assignment allowed in switch statement case
             public class Foo {
@@ -342,9 +342,22 @@ public class Foo {
                     String a = null;
 
                     switch (args[0]) {
-                        case "A" -> a = "a";    // fixed false positive in 'a = "a"'
+                        case "A" -> a = "a";             // fixed false positive in 'a = "a"'
                         default -> {}
                     }
+                    System.out.println("a = " + a);
+
+                    switch (args[0]) {
+                        case "A": a = "b"; break;
+                        default:
+                    }
+                    System.out.println("a = " + a);
+
+                    switch (args[0]) {
+                        case "A": { a = "c"; break; }
+                        default:
+                    }
+                    System.out.println("a = " + a);
                 }
             }
 
@@ -353,12 +366,22 @@ public class Foo {
                 public static void main(String[] args) {
                     int a = 2;
                     int b = switch(a) {
-                        case 2 -> a = 1;    // violation line 18
+                        case 2 -> a = 1;              // violation line 31
                         default -> 0;
+                    };
+                    int c = switch(a) {
+                        case 1 -> { yield a = 1; }    // violation line 35
+                        default -> 0;
+                    };
+                    int d = switch(a) {
+                        case 1: yield a = 1;          // violation line 39
+                        default: yield 0;
                     };
 
                     System.out.println("a = " + a);
                     System.out.println("b = " + b);
+                    System.out.println("c = " + c);
+                    System.out.println("d = " + d);
                 }
             }
         ]]></code>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Add switch arrow branch as additional exception for AssignmentInOperand.
It allows assignments with switch arrow as parent.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6092 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

