### PR TITLE
[java] Switch on enum from another compilation unit without default flagged as not exhaustive

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/NonExhaustiveSwitch.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/NonExhaustiveSwitch.xml
@@ -181,12 +181,12 @@ public class Foo {
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             // Enum from another compilation unit. jsr305 jar is on the classpath.
-            import javax.annotation.meta.When;
+            import org.slf4j.event.Level;
 
             public class Foo {
-                void enumFromAnotherCompilationUnit(When x) {
+                void enumFromAnotherCompilationUnit(Level x) {
                     switch (x) {
-                      case ALWAYS, UNKNOWN, MAYBE, NEVER -> System.out.println("it is on");
+                      case ERROR, WARN, INFO, DEBUG, TRACE -> System.out.println("it is on");
                       // javac is creating a default case here and so the number of
                       // labels in the generated code is 5 rather than the expected 4.
                       // javac is worried that the foreign compilation unit will be


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

