### PR TITLE
[doc] Fix copy URL button

### DIFF
--- a/docs/js/customscripts.js
+++ b/docs/js/customscripts.js
@@ -55,7 +55,7 @@ $(document).ready(function () {
         if (target) {
             if (navigator.clipboard) {
                 const url = new URL(location.href);
-                url.hash = event.target.parentNode.id;
+                url.hash = target.parentNode.id;
                 event.preventDefault();
                 event.stopImmediatePropagation();
 


### PR DESCRIPTION
It was missing the actual anchor hash

Refs #6098
