### PR TITLE
[ci] Exclude build resources from spring-framework for regression tester

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -38,6 +38,7 @@ mvn dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=classpath.t
     <tag>v5.3.13</tag>
 
     <exclude-pattern>.*/build/generated-sources/.*</exclude-pattern>
+    <exclude-pattern>.*/build/resources/.*</exclude-pattern>
 
     <build-command><![CDATA[#!/usr/bin/env bash
 ## Skip gradle execution


### PR DESCRIPTION
Added an exclude pattern for build resources.

Those resources are copied from the source tree. The regression tester tries to link to those when violations occur, but those are not available in the github repo. The violations are anyway duplicates because they are also reported correctly on the file copy that is in the source tree.

See for instance in https://pull-requests.pmd-code.org/pr-6260/eb374bb3c574f6a2a32cfce938f3cea38e72773d/regression/spring-framework/index.html, half of the violations give a 404 when you click on them to reveal the source, as they are linking to the build directory.


<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

