### PR TITLE
[java] Fix #6256: ignore invalid annotation type

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -83,6 +83,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#2128](https://github.com/pmd/pmd/issues/2128): \[apex] Merge NCSS count rules for Apex
 * java
     * [#5689](https://github.com/pmd/pmd/issues/5689): \[java] Members of record should be in scope in record header
+    * [#6256](https://github.com/pmd/pmd/issues/6256): \[java] java.lang.IllegalArgumentException: Invalid target type of type annotation for method or ctor type annotation: 19
 * java-bestpractices
     * [#5820](https://github.com/pmd/pmd/issues/5820): \[java] GuardLogStatement recognizes that a string is a compile-time constant expression only if at first position
     * [#6188](https://github.com/pmd/pmd/issues/6188): \[java] UnitTestShouldIncludeAssert false positive when TestNG @<!-- -->Test.expectedException present

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
@@ -420,6 +420,14 @@ abstract class GenericSigBase<T extends JTypeParameterOwnerSymbol & AsmStub> {
                         annot, ctx.getEnclosingClass().getCanonicalName(), ctx.getSimpleName());
                 return false;
             }
+            case TypeReference.FIELD: {
+                // avoid exception for Java 16+ bug
+                // see https://github.com/pmd/pmd/issues/6256 and https://bugs.openjdk.org/browse/JDK-8372382
+                LOGGER.debug("Invalid target type FIELD of type annotation {} for method or ctor detected. "
+                        + "The annotation is ignored. Method: {}#{}. See https://github.com/pmd/pmd/issues/6256.",
+                        annot, ctx.getEnclosingClass().getCanonicalName(), ctx.getSimpleName());
+                return false;
+            }
             default:
                 throw new IllegalArgumentException(
                     "Invalid target type of type annotation " + annot + " for method or ctor type annotation: "


### PR DESCRIPTION
## Describe the PR

We simply ignore this invalid type.

## Related issues

- Fix #6256

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

