### PR TITLE
[java] Fix #6279: EmptyMethodInAbstractClassShouldBeAbstract should ignore final methods

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -486,7 +486,7 @@ usage by developers who should be implementing their own versions in the concret
 //ClassDeclaration[@RegularClass = true() and pmd-java:modifiers() = "abstract"]
   /ClassBody
     /MethodDeclaration
-    [not(@Name = "finalize" and @Final = true())]
+    [@Final = false()]
     [Block[
       let $size := count(*[not(self::EmptyStatement)])
       return $size = 0

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyMethodInAbstractClassShouldBeAbstract.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyMethodInAbstractClassShouldBeAbstract.xml
@@ -218,7 +218,7 @@ public interface Foo {
     </test-code>
 
     <test-code>
-        <description>#6279 allow final finalize to prevent finalizer attack</description>
+        <description>#6279 allow all final methods</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 package example;
@@ -231,6 +231,10 @@ public abstract class PMDTest {
     @Override
     protected final void finalize() {       // fixed false positive
         // prevent finalizer attack
+    }
+
+    public final int returnCode() {         // fixed false positive
+        return 0;
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

- the PR changes the rule to ignore any method in the abstract class, that is final.
- the example code uses `final void finalize()`

## Related issues

- Fix #6279 
- the issue was derived from https://github.com/pmd/pmd/issues/4742

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

