### PR TITLE
[java] Fix #6297: AvoidUsingVolatile: Do not report long and double

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -175,7 +175,8 @@ the volatile keyword should not be used for maintenance purpose and portability.
         <priority>2</priority>
         <properties>
             <property name="xpath">
-                <value>//FieldDeclaration[pmd-java:modifiers() = "volatile"]</value>
+                <value>//FieldDeclaration[pmd-java:modifiers() = "volatile"
+                                          and not(PrimitiveType[@Kind = ("double", "long")])]</value>
             </property>
         </properties>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidUsingVolatile.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidUsingVolatile.xml
@@ -13,4 +13,15 @@ public class UsingVolatile {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6297 allow double and long because of non-atomic treatment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+    private volatile double foo;
+    private volatile long bar;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Make an exception for double and long fields in AvoidUsingVolatile because of non-atomic treatment.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix https://github.com/pmd/pmd/issues/6297

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

