### PR TITLE
[java] Fix #4257: Allow ignoring methods in OnlyOneReturn

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -4,20 +4,31 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import java.util.List;
+
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
 
+    private static final PropertyDescriptor<List<String>> IGNORED_METHOD_NAMES
+            = PropertyFactory.stringListProperty("ignoredMethodNames")
+                    .defaultValues("compareTo", "equals")
+                    .desc("Method names that are ignored from checking for only one return.")
+                    .build();
+
     public OnlyOneReturnRule() {
         super(ASTMethodDeclaration.class);
+        definePropertyDescriptor(IGNORED_METHOD_NAMES);
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        if (node.getBody() == null) {
+        if (node.getBody() == null || isIgnoredMethod(node)) {
             return null;
         }
 
@@ -28,5 +39,9 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
             asCtx(data).addViolation(returnStmt);
         }
         return null;
+    }
+
+    private boolean isIgnoredMethod(ASTMethodDeclaration node) {
+        return getProperty(IGNORED_METHOD_NAMES).contains(node.getName());
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
@@ -129,4 +129,34 @@ public class OnlyOneReturn {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4257 allow ignoring methods, compareTo and equals as default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Objects;
+
+public class Person implements Comparable<Person> {
+    private String name = "Name";
+    private int age = 27;
+
+    @Override
+    public int compareTo(Person other) {
+        if (other == null) return 1;
+        if (this.age < other.age) return -1;
+        if (this.age > other.age) return 1;
+        return this.name.compareTo(other.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Person other = (Person) obj;
+        if (this.age != other.age) return false;
+        return Objects.equals(this.name, other.name);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Introduce the property `ignoredMethodNames`, which defaults to `compareTo` and `equals`. The property is a String List (instead of regex) to align with the other ignore* properties ignoredFieldNames and ignoredAnnotations.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix https://github.com/pmd/pmd/issues/4257

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)