### PR TITLE
[java] Fix #4576: UseShortArrayInitializer with arrays of parametrized types (generic array creation)

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -2138,7 +2138,7 @@ E.g. `int[] x = new int[] { 1, 2, 3 };` can be written as `int[] x = { 1, 2, 3 }
             <property name="xpath">
                 <value><![CDATA[
 //VariableDeclarator
-    [not(parent::*/ArrayType/ClassType/TypeArguments)]
+    [not(parent::*/ArrayType/ClassType/TypeArguments[ClassType or WildcardType/ClassType])]
     [VariableId[@TypeInferred = false() and @ArrayType = true()]]
     [ArrayAllocation/ArrayInitializer]
                 ]]></value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseShortArrayInitializer.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseShortArrayInitializer.xml
@@ -106,18 +106,29 @@ public class UseShortArrayExample {
     </test-code>
     <test-code>
         <description>#4576 ignore arrays of parametrized types</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>19,20</expected-linenumbers>
         <code><![CDATA[
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-public class Foo  {
+public class Foo {
+    @SuppressWarnings("unchecked")
     public void bar() {
         Set<Integer> set1 = new HashSet<>();
+        Map<Integer, String> map1 = new HashMap<>();
 
-        // short version would be a 'generic array creation' compiler error
-        @SuppressWarnings("unchecked")
-        Set<Integer>[] setArray = new Set[] { set1 };
+        // skip with class type arguments or bounded wildcards
+        // the short version would be a 'generic array creation' compiler error
+        Set<Integer>[] skippedSets = new Set[] { set1 };
+        Map<?, String>[] skippedMaps1 = new Map[] { map1 };
+        Map<?, ? extends String>[] skippedMaps2 = new Map[] { map1 };
+
+        // type arguments of unbounded wildcards only are still reported
+        Set<?>[] reportedClasses = new Set[] { set1 };  // violation line 19
+        Map<?, ?>[] reportedMaps = new Map[] { map1 };  // violation line 20
     }
 }
         ]]></code>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Do not report arrays with parametrized types because the short version is a 'generic array creation' compiler error.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix https://github.com/pmd/pmd/issues/4576

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

