### PR TITLE
[java] Fix #4910: if-statement triggers ConsecutiveAppendsShouldReuse

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
@@ -36,7 +37,10 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
             @Nullable JVariableSymbol variable = getVariableAppended(node);
             if (variable != null) {
                 @Nullable JVariableSymbol nextVariable = getVariableAppended((ASTExpressionStatement) nextSibling);
-                if (nextVariable != null && nextVariable.equals(variable)) {
+                if (nextVariable != null
+                        && nextVariable.equals(variable)
+                        && !(node.getParent() instanceof ASTIfStatement)
+                ) {
                     asCtx(data).addViolation(node);
                 }
             }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveAppendsShouldReuse.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveAppendsShouldReuse.xml
@@ -299,4 +299,19 @@ public class Foo {
             }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#4910 if-statement without blocks</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+                public void foo(boolean condition, StringBuilder builder) {
+                    // expressions in if-statements without blocks are siblings
+                    if (condition)
+                        builder.append("first");
+                    else
+                        builder.append("second");
+                }
+            }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Allow consecutive append statements in if-else-statements without blocks.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix https://github.com/pmd/pmd/issues/4910

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

