### PR TITLE
[java] Fix #5877: AvoidArrayLoops false-negative when break inside switch statement

### DIFF
--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -71,7 +71,7 @@ If you want to copy/move elements inside the _same_ array (e.g. shift the elemen
 //(ForStatement[ForUpdate//(UnaryExpression[@Operator=('++','--')] | AssignmentExpression[@Operator = ('+=', '-=')][NumericLiteral[@Image = '1']])]
  | WhileStatement | DoStatement)
     [not(.//ContinueStatement)]
-    [not(.//BreakStatement)]
+    [not(.//BreakStatement[not(parent::SwitchFallthroughBranch)])]
     [not(.//ThrowStatement)]
     [not(.//ReturnStatement)]
     [count(Block//AssignmentExpression[@Operator='=']

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidArrayLoops.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidArrayLoops.xml
@@ -450,4 +450,25 @@ class AvoidArrayLoopsSamples {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5877 false-negative when break inside switch statement</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+class Foo {
+    public void bar(int[] source, int condition) {
+        int[] destination = new int[source.length];
+        for (int i = 0; i < source.length; i++) {           // violation line 4
+            destination[i] = source[i];
+            switch (condition) {
+                case 0:
+                    System.out.println("This is an unreachable switch case.");
+                    break;
+            }
+        }
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR
Detect a manual array copy loop that contains an oldschool switch with break.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix https://github.com/pmd/pmd/issues/5877

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

