### PR TITLE
chore(deps): bump org.mozilla:rhino from 1.7.15 to 1.7.15.1

### DIFF
--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <version>1.7.15</version>
+            <version>1.7.15.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Describe the PR


## Related issues

- Fix https://github.com/pmd/pmd/security/dependabot/87
- CVE-2025-66453

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

