### PR TITLE
[jsp] Fix malformed Javadoc HTML in JspDocStyleTest

### DIFF
--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
@@ -888,19 +888,19 @@ class JspDocStyleTest extends AbstractJspNodesTst {
     private static final String TEST_MULTIPLE_NESTED_TAGS = "<html> <a1> <a2> <a3> </a2> </a1> <b/> <a4/> </html>";
 
     /**
-     * </x> will close before </a>, thus leaving <a> to remain unclosed
+     * {@code </x>} will close before {@code </a>}, thus leaving {@code <a>} to remain unclosed
      */
     private static final String TEST_UNCLOSED_END_AFTER_PARENT_CLOSE = "<x> <a> <b> <b> </x> </a> aa </x> bb </x>";
 
     /**
-     * </z> is just a dangling closing tag not matching any parent. The parser
+     * {@code </z>} is just a dangling closing tag not matching any parent. The parser
      * should disregard it
      */
     private static final String TEST_UNCLOSED_UNMATCHED_CLOSING_TAG = "<x> <a> <b> <b> </z> </a> </x>";
 
     /**
-     * First <a> tag does not close. The first closing of </a> will match the
-     * second opening of a. Another rogue </z> is there for testing compliance
+     * First {@code <a>} tag does not close. The first closing of {@code </a>} will match the
+     * second opening of a. Another rogue {@code </z>} is there for testing compliance
      */
     private static final String TEST_UNCLOSED_START_TAG_WITH_UNMATCHED_CLOSE = "<a> <x> <a> <b> <b> </z> </a> </x>";
 


### PR DESCRIPTION
This change fixes malformed Javadoc comments in `JspDocStyleTest.java` that do not parse correctly.

The fix includes:
* Wrapping unescaped HTML/XML tags (like `</x>`, `</a>`) in `{@code}` blocks to prevent Javadoc parsing errors.

These issues are surfaced by newer Checkstyle versions (specifically `UnusedImportsCheck` which now parses Javadoc). 

See the related Checkstyle change:
https://github.com/checkstyle/checkstyle/pull/18059