### PR TITLE
chore: helper script check-all-contributors.sh

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,7 +7,7 @@
     "docs/pages/pmd/projectdocs/credits.md"
   ],
   "imageSize": 100,
-  "commit": true,
+  "commit": false,
   "commitConvention": "none",
   "contributors": [
     {

--- a/.ci/tools/check-all-contributors.sh
+++ b/.ci/tools/check-all-contributors.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+  echo "$0 <new version, e.g. 7.7.0>"
+  exit 1
+fi
+
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NEW_VERSION="$1"
+
+CURL_API_HEADER=(--header "X-GitHub-Api-Version: 2022-11-28")
+CURL_AUTH_HEADER=()
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo -n "GITHUB_TOKEN="
+  IFS= read -r GITHUB_TOKEN
+  if [ -n "$GITHUB_TOKEN" ]; then
+    export GITHUB_TOKEN
+    echo "Using provided GITHUB_TOKEN..."
+  else
+    echo "Not using GITHUB_TOKEN"
+  fi
+fi
+
+if [ -n "$GITHUB_TOKEN" ]; then
+  echo "Will use env var GITHUB_TOKEN for github REST API"
+  CURL_AUTH_HEADER=(--header "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
+# determine current milestone
+MILESTONE_JSON=$(curl "${CURL_API_HEADER[@]}" "${CURL_AUTH_HEADER[@]}" -s "https://api.github.com/repos/pmd/pmd/milestones?state=all&direction=desc&per_page=10&page=1"|jq ".[] | select(.title == \"$NEW_VERSION\")")
+#DEBUG ONLY
+#MILESTONE_JSON='{"number":80,"closed_issues":40}'
+#DEBUG ONLY
+MILESTONE=$(echo "$MILESTONE_JSON" | jq .number)
+
+PAGE="1"
+HAS_NEXT="true"
+ISSUES_JSON=""
+while [ "$HAS_NEXT" = "true" ]; do
+    echo "Fetching issues for milestone ${MILESTONE} page ${PAGE}..."
+    URL="https://api.github.com/repos/pmd/pmd/issues?state=closed&sort=created&direction=asc&per_page=30&page=${PAGE}&milestone=${MILESTONE}"
+    RESPONSE="$(curl "${CURL_API_HEADER[@]}" "${CURL_AUTH_HEADER[@]}" -s -w "\nLink: %header{link}" "$URL")"
+
+    #DEBUG ONLY
+    #echo "$RESPONSE" > issues-response-${PAGE}.txt
+    #RESPONSE="$(cat issues-response-${PAGE}.txt)"
+    #DEBUG ONLY
+
+    LINK_HEADER="$(echo "$RESPONSE" | tail -1)"
+    BODY="$(echo "$RESPONSE" | head -n -1)"
+
+    #DEBUG ONLY
+    #echo "$BODY" > "issues-response-page-${PAGE}.txt"
+    #BODY="$(cat "issues-response-page-${PAGE}.txt")"
+    #DEBUG ONLY
+
+    COMMA=","
+    if [ "$PAGE" -eq 1 ]; then
+        COMMA=""
+    fi
+    ISSUES_JSON="${ISSUES_JSON}${COMMA}${BODY}"
+
+    if [[ $LINK_HEADER == *"; rel=\"next\""* ]]; then
+        HAS_NEXT="true"
+    else
+        HAS_NEXT="false"
+    fi
+    PAGE=$((PAGE + 1))
+
+    #DEBUG ONLY
+    #HAS_NEXT="true"
+    #if [ "$PAGE" -gt 2 ]; then break; fi
+    #DEBUG ONLY
+
+    # stop after 10 pages
+    if [ "$PAGE" -gt 10 ]; then
+        echo
+        echo
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo "!!!!!!!!!!!!!! reached page 10, stopping now !!!!!!!!!!!!!"
+        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+        echo
+        echo
+        break;
+    fi
+done
+
+
+ISSUES_JSON="$(echo "[ $ISSUES_JSON ]" | jq 'flatten(1)')"
+echo "Found $(echo "$ISSUES_JSON" | jq length) issues/pull requests"
+#DEBUG ONLY
+# echo "$ISSUES_JSON" > issues-all.txt
+#DEBUG ONLY
+
+# Users which reported a bug, that has been fixed now (assigned to the milestone)
+BUG_USERS="$(echo "$ISSUES_JSON" | jq 'map(select(has("pull_request") | not)) | [ .[].user.login ] | unique')"
+
+COL_GREEN="\e[32m"
+COL_RED="\e[31m"
+COL_WHITE="\e[37m"
+COL_RESET="\e[0m"
+
+echo
+echo "Checking for bug contributions..."
+# for each user, check if "bug" is already present
+for login in $(echo "$BUG_USERS" | jq --raw-output .[]); do
+  USER_JSON="$(jq '.contributors[] | select(.login == "'"$login"'")' < "$BASEDIR"/.all-contributorsrc)"
+  BUGS="$(echo "$ISSUES_JSON" |  jq 'map(select(has("pull_request") | not)) | map(select(.user.login == "'"$login"'")) | .[] | { number: .number, title: .title, login: .user.login }')"
+  echo -en "${COL_WHITE}$login:${COL_RESET} "
+  if [ -z "$USER_JSON" ]; then
+    echo -e "${COL_RED}Missing user entirely${COL_RESET}"
+    echo "$BUGS"
+  else
+    HAS_BUG="$(echo "$USER_JSON" | jq --raw-output 'if .contributions | contains(["bug"]) | not then "false" else "true" end')"
+    if [ "$HAS_BUG" = "true" ]; then
+      echo -e "${COL_GREEN}ok${COL_RESET}"
+    else
+      echo -e "${COL_RED}bug is missing${COL_RESET}"
+      echo "$BUGS"
+    fi
+  fi
+done
+
+echo
+echo "Checking for code contributions..."
+# Users which submitted a pull request that has been merged (assigned to the milestone)
+CODE_USERS="$(echo "$ISSUES_JSON" | jq 'map(select(has("pull_request"))) | [ .[].user.login ] | unique')"
+
+# for each user, check if "code" is already present
+for login in $(echo "$CODE_USERS" | jq --raw-output .[]); do
+  USER_JSON="$(jq '.contributors[] | select(.login == "'"$login"'")' < "$BASEDIR"/.all-contributorsrc)"
+  PRS="$(echo "$ISSUES_JSON" |  jq 'map(select(has("pull_request"))) | map(select(.user.login == "'"$login"'")) | .[] | { number: .number, title: .title, login: .user.login }')"
+  echo -en "${COL_WHITE}$login:${COL_RESET} "
+  if [ -z "$USER_JSON" ]; then
+    echo -e "${COL_RED}Missing user entirely${COL_RESET}"
+    echo "$PRS"
+  else
+    HAS_CODE="$(echo "$USER_JSON" | jq --raw-output 'if .contributions | contains(["code"]) | not then "false" else "true" end')"
+    if [ "$HAS_CODE" = "true" ]; then
+      echo -e "${COL_GREEN}ok${COL_RESET}"
+    else
+      echo -e "${COL_RED}code is missing${COL_RESET}"
+      echo "$PRS"
+    fi
+  fi
+done
+

--- a/do-release.sh
+++ b/do-release.sh
@@ -122,6 +122,9 @@ if [ "${BUILD_TOOLS_VERSION}" != "${BUILD_TOOLS_VERSION_RELEASE}" ]; then
   exit 1
 fi
 
+echo "*   Run '.ci/tools/check-all-contributors $RELEASE_VERSION' and update contributors"
+echo "    by calling 'npx all-contributors add <username> bug,code' accordingly"
+echo
 echo "*   Update version info in **docs/_config.yml**."
 echo "    remove the SNAPSHOT from site.pmd.version"
 echo

--- a/docs/pages/pmd/devdocs/contributing/contributing.md
+++ b/docs/pages/pmd/devdocs/contributing/contributing.md
@@ -4,7 +4,7 @@ summary: How to contribute to PMD
 tags: [devdocs]
 permalink: pmd_devdocs_contributing.html
 author: Andreas Dangel <andreas.dangel@pmd-code.org>
-last_updated: January 2025 (7.10.0)
+last_updated: January 2026 (7.21.0)
 ---
 
 First off, thanks for taking the time to contribute!
@@ -100,6 +100,7 @@ Or use the CLI:
 
 1. Install the CLI: `npm i` (in PMD's top level directory)
 2. Add yourself: `npx all-contributors add <username> <contribution>`
+3. Commit the changes: `git commit -am "Add @<username> as contributor`
 
 Where `username` is your GitHub username and `contribution` is a `,`-separated list
 of contributions. See [Emoji Key](https://allcontributors.org/docs/en/emoji-key) for a list

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -1,7 +1,7 @@
 ---
 title: Merging pull requests
 permalink: pmd_projectdocs_committers_merging_pull_requests.html
-last_updated: October 2021
+last_updated: January 2026 (7.21.0)
 author: Andreas Dangel <andreas.dangel@adangel.org>
 ---
 
@@ -56,19 +56,17 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
 4.  Add the contributor to `.all-contributorsrc`:
     
     ```
-    npx all-contributors add
+    npx all-contributors add <username> code
     ```
     
-    And follow the instructions. This will create a new commit into to the current branch (pr-123) updating both
-    the file `.all-contributorsrc` and `docs/pages/pmd/projectdocs/credits.md`.
+    This will modify the files `.all-contributorsrc` and `docs/pages/pmd/projectdocs/credits.md`.
+    Commit them with `git commit -am "Add @<username> as a contributor` into the current branch (pr-123).
 
 5.  Now merge the pull request into the main branch:
 
     ```
     git checkout main
-    git merge --no-ff pr-123 -m "Full-title-of-the-pr (#123)
-    
-    Merge pull request #123 from xyz:branch" --log
+    git merge --no-ff pr-123 -m "Full-title-of-the-pr (#123)"
     ```
 
     {%include note.html content="If there are merge conflicts, you'll need to deal with them here." %}

--- a/docs/pages/pmd/projectdocs/committers/releasing.md
+++ b/docs/pages/pmd/projectdocs/committers/releasing.md
@@ -2,7 +2,7 @@
 title: Release process
 permalink: pmd_projectdocs_committers_releasing.html
 author: Romain Pelisse <rpelisse@users.sourceforge.net>, Andreas Dangel <andreas.dangel@pmd-code.org>
-last_updated: June 2025 (7.15.0)
+last_updated: January 2026 (7.21.0)
 ---
 
 This page describes the current status of the release process.
@@ -53,6 +53,22 @@ e.g. it requires that the repo `pmd.github.io` is checked out aside the main pmd
 The script `do-release.sh` is called in the directory `/home/joe/source/pmd` and searches for `../pmd.github.io`.
 
 Also make sure, that the repo "pmd.github.io" is locally up-to-date and has no local changes.
+
+### All Contributors
+
+Before a release, it makes sense to ensure the .all-contributorsrc file is up to date.
+There is a simple script in `.ci/tools/check-all-contributors.sh`, that compares the issues and
+pull request from the given milestone with the users and suggests, whether the all contributors
+list should be updated.
+
+    $ .ci/tool/check-all-contributors.sh <new release version>
+
+This will ask for a GitHub Token to access the GitHub API to read the milestones. Without the token,
+you might run into API rate limiting.
+
+The script doesn't change the all contributors list directly, it only outputs when some contributor
+is missing. You'll need to call `npx all-contributors add <user> bug,code` (or only bug, or only code)
+additionally.
 
 ### The Release Notes and docs
 


### PR DESCRIPTION
## Describe the PR

This script checks that all contributors of issues and pull requests of the given milestone are mentioned in /.all-contributorsrc.

This is useful to run before a release to make sure the contributors list is up to date.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

