### PR TITLE
[core] chore: Bump minimum Java version required for building to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -130,13 +130,13 @@ jobs:
           java-version: |
             8
             11
-            21
+            17
             25
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
-        # default java version for all os is 17
+        # default java version for all os is 21
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       # only restore the cache, don't create a new cache
       # Note: this works under Windows only if pom.xml files use LF, so that hashFiles('**/pom.xml')
       # gives the same result (line endings...).
@@ -161,7 +161,7 @@ jobs:
               -PfastSkip -Dcyclonedx.skip=false \
               -Djava8.home="${JAVA_HOME_8_X64}" \
               -Djava11.home="${JAVA_HOME_11_X64}" \
-              -Djava21.home="${JAVA_HOME_21_X64}" \
+              -Djava17.home="${JAVA_HOME_17_X64}" \
               -Djava25.home="${JAVA_HOME_25_X64}"
 
   dogfood:
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -319,7 +319,7 @@ jobs:
           distribution: 'temurin'
           java-version: |
             11
-            17
+            21
       - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 #v1.286.0
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Determine Version
         id: version
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -630,7 +630,7 @@ jobs:
           distribution: 'temurin'
           java-version: |
             11
-            17
+            21
       - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 #v1.286.0
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Determine Version
         id: version
         run: |
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -647,7 +647,7 @@ jobs:
           distribution: 'temurin'
           java-version: |
             11
-            17
+            21
       - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@90be1154f987f4dc0fe0dd0feedac9e473aa4ba8 #v1.286.0
         with:
@@ -732,7 +732,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}
@@ -769,7 +769,7 @@ jobs:
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 #v5.0.2
         with:
           key: maven-${{ hashFiles('**/pom.xml') }}

--- a/docs/pages/pmd/devdocs/building/building_general.md
+++ b/docs/pages/pmd/devdocs/building/building_general.md
@@ -3,14 +3,14 @@ title: Building PMD General Info
 tags: [devdocs]
 permalink: pmd_devdocs_building_general.html
 author: Andreas Dangel <andreas.dangel@pmd-code.org>
-last_updated: September 2025 (7.18.0)
+last_updated: January 2026 (7.21.0)
 ---
 
 ## Before Development
 
-1. Ensure that [Git](https://git-scm.com/) and Java JDK >= 17 are installed.  
+1. Ensure that [Git](https://git-scm.com/) and Java JDK >= 21 are installed.  
    You can get a OpenJDK distribution from e.g. [Adoptium](https://adoptium.net/).  
-   **Note:**  While Java 17 is required for building, running PMD only requires Java 8.
+   **Note:**  While Java 21 is required for building, running PMD only requires Java 8.
 2. Fork the [PMD repository](https://github.com/pmd/pmd) on GitHub as explained in [Fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
 3. Clone your forked repository to your computer:
    ```shell

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -47,6 +47,11 @@ rule properties:
   * Instead of `Unwanted` use `unwanted`
   * The old values still work, but you'll see a deprecation warning.
 
+#### Build Requirement is Java 21
+From now on, Java 21 or newer is required to build PMD. PMD itself still remains compatible with Java 8,
+so that it still can be used in a pure Java 8 environment. This allows us to use the latest
+checkstyle version during the build.
+
 ### 🐛️ Fixed Issues
 * core
   * [#6184](https://github.com/pmd/pmd/issues/6184): \[core] Consistent implementation of enum properties

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/Chars.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/Chars.java
@@ -76,7 +76,7 @@ public final class Chars implements CharSequence {
 
     /** Whether this slice is the empty string. */
     // @SuppressWarnings("PMD.MissingOverride") // with Java 15, isEmpty() has been added to java.lang.CharSequence (#4291)
-    // We compile against Java 8 and execute maven on GitHub Actions with Java 17. So there is no missing override.
+    // We compile against Java 8 and execute maven on GitHub Actions with Java 21. So there is no missing override.
     // However, when executing Maven with Java 15+, then we get MissingOverride (#5299).
     // This is suppressed via maven-pmd-plugin's excludeFromFailureFile
     public boolean isEmpty() {

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -247,10 +247,10 @@
             </build>
         </profile>
         <profile>
-            <id>jdk21-compat-it</id>
+            <id>jdk17-compat-it</id>
             <activation>
                 <property>
-                    <name>java21.home</name>
+                    <name>java17.home</name>
                 </property>
             </activation>
             <build>
@@ -260,15 +260,15 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>jdk21-compat-it</id>
+                                <id>jdk17-compat-it</id>
                                 <goals>
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
                                     <environmentVariables>
-                                        <JAVA_HOME>${java21.home}</JAVA_HOME>
-                                        <PATH>${java21.home}/bin:${env.PATH}</PATH>
+                                        <JAVA_HOME>${java17.home}</JAVA_HOME>
+                                        <PATH>${java17.home}/bin:${env.PATH}</PATH>
                                     </environmentVariables>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -743,7 +743,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[17,)</version>
+                                    <version>[21,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
## Describe the PR

Bumps the minimum Java version required for building PMD to Java 21.
This is only a build requirement. Java 21 is not required at runtime.

This should allow us to upgrade to checkstyle 13.

## Related issues

- Enables #6383

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

