### PR TITLE
[ci] publish-pull-requests: download latest build result

### DIFF
--- a/.ci/files/pmdtester.rb
+++ b/.ci/files/pmdtester.rb
@@ -38,7 +38,7 @@ def run_pmdtester
       end
 
     rescue StandardError => e
-      message = "⚠ Running pmdtester failed, this message is mainly used to remind the maintainers of PMD."
+      message = "⚠️ Running pmdtester failed, this message is mainly used to remind the maintainers of PMD."
       conclusion = "failure"
       @logger.error "Running pmdtester failed: #{e.inspect}"
     end

--- a/.github/workflows/publish-pull-requests.yml
+++ b/.github/workflows/publish-pull-requests.yml
@@ -70,7 +70,18 @@ jobs:
         run: |
           mkdir docs-artifact
           cd docs-artifact
-          gh run download "${RUN_ID}" --repo pmd/pmd --name docs-artifact
+          # gh run download "${RUN_ID}" --repo pmd/pmd --name docs-artifact
+          # apply workaround for https://github.com/cli/cli/issues/12437
+          download_url=$(gh api \
+            "/repos/pmd/pmd/actions/runs/$RUN_ID/artifacts?name=docs-artifact" \
+            --jq '.artifacts|sort_by(.created_at)|.[-1]|.archive_download_url' \
+          )
+          curl -L \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            --output artifact.zip \
+            $download_url
+          unzip -q artifact.zip
+          rm artifact.zip
       - name: Upload docs-artifact to s3://pmd-pull-requests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_PMD_PULL_REQUESTS_ACCESS_KEY_ID }}
@@ -114,7 +125,18 @@ jobs:
         run: |
           mkdir pmd-regression-tester
           cd pmd-regression-tester
-          gh run download "${RUN_ID}" --repo pmd/pmd --name pmd-regression-tester
+          # gh run download "${RUN_ID}" --repo pmd/pmd --name pmd-regression-tester
+          # apply workaround for https://github.com/cli/cli/issues/12437
+          download_url=$(gh api \
+            "/repos/pmd/pmd/actions/runs/$RUN_ID/artifacts?name=pmd-regression-tester" \
+            --jq '.artifacts|sort_by(.created_at)|.[-1]|.archive_download_url' \
+          )
+          curl -L \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            --output artifact.zip \
+            $download_url
+          unzip -q artifact.zip
+          rm artifact.zip
       - name: Upload regression report to s3://pmd-pull-requests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_PMD_PULL_REQUESTS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Describe the PR

On PR #6379 the first run of pmd-regression-tester failed temporarily while downloading the baseline. That's why the comment says "Running pmdtester failed...".

I then reran the job, that runs the regression tester - second attempt worked. It also triggered a new run of the publish-pull-requests workflow. However, the regression tester result stayed the same.

The reason is, that "gh run download" downloaded the artifact from the first attempt, and not the latest. See https://github.com/cli/cli/issues/12437 .

## Related issues


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

