### PR TITLE
chore: update javadoc deprecated tags

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
@@ -67,6 +67,9 @@ public class CPDTask extends Task {
 
     private static final String TEXT_FORMAT = "text";
     private static final String XML_FORMAT = "xml";
+    /**
+     * @deprecated Since 7.3.0.
+     */
     @Deprecated
     private static final String XMLOLD_FORMAT = "xmlold";
     private static final String CSV_FORMAT = "csv";
@@ -78,6 +81,9 @@ public class CPDTask extends Task {
     private boolean ignoreIdentifiers;
     private boolean ignoreAnnotations;
     private boolean ignoreUsings;
+    /**
+     * @deprecated Since 7.3.0.
+     */
     @Deprecated
     private boolean skipLexicalErrors;
     private boolean skipDuplicateFiles;
@@ -241,7 +247,7 @@ public class CPDTask extends Task {
     }
 
     /**
-     * @deprecated Use {@link #setFailOnError(boolean)} instead.
+     * @deprecated Since 7.3.0. Use {@link #setFailOnError(boolean)} instead.
      */
     @Deprecated
     public void setSkipLexicalErrors(boolean skipLexicalErrors) {

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractAnalysisPmdSubcommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/AbstractAnalysisPmdSubcommand.java
@@ -55,6 +55,9 @@ public abstract class AbstractAnalysisPmdSubcommand<C extends AbstractConfigurat
 
         boolean usesDeprecatedIgnoreListOption = false;
 
+        /**
+         * @deprecated Since 7.14.0. Use {@code --exclude-file-list} instead.
+         */
         @Option(names = "--ignore-list",
                 description = "(DEPRECATED: use --exclude-file-list) Path to a file containing a list of files to exclude from the analysis, one path per line. "
                               + "This option can be combined with --dir, --file-list and --uri.")

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
@@ -74,7 +74,7 @@ public class CpdCommand extends AbstractAnalysisPmdSubcommand<CPDConfiguration> 
     private boolean ignoreIdentifierAndLiteralSequences;
 
     /**
-     * @deprecated Since 7.3.0. Use --[no-]fail-on-error instead.
+     * @deprecated Since 7.3.0. Use {@code --[no-]fail-on-error} instead.
      */
     @Option(names = "--skip-lexical-errors",
             description = "Skip files which can't be tokenized due to invalid characters, instead of aborting with an error. Deprecated - use --[no-]fail-on-error instead.")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -67,6 +67,9 @@ public class CPDConfiguration extends AbstractConfiguration {
 
     private boolean ignoreIdentifierAndLiteralSequences = false;
 
+    /**
+     * @deprecated Since 7.3.0.
+     */
     @Deprecated
     // Note: The default value was false until up to 7.3.0 and is true since 7.4.0
     private boolean skipLexicalErrors = true;
@@ -231,7 +234,7 @@ public class CPDConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * @deprecated This option will be removed. With {@link #isFailOnError()}, you can
+     * @deprecated Since 7.3.0. This option will be removed. With {@link #isFailOnError()}, you can
      * control whether lexical errors should fail the build or not.
      */
     @Deprecated
@@ -240,7 +243,7 @@ public class CPDConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * @deprecated This option will be removed. With {@link #setFailOnError(boolean)}, you can
+     * @deprecated Since 7.3.0. This option will be removed. With {@link #setFailOnError(boolean)}, you can
      * control whether lexical errors should fail the build or not.
      */
     @Deprecated

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLOldRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLOldRenderer.java
@@ -13,7 +13,7 @@ import java.io.Writer;
  *
  * <p>This renderer is available as "xmlold".
  *
- * @deprecated Update your tools to use the standard XML renderer "xml" again.
+ * @deprecated Since 7.3.0. Update your tools to use the standard XML renderer "xml" again.
  */
 @Deprecated
 public class XMLOldRenderer implements CPDReportRenderer {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrToken.java
@@ -34,7 +34,7 @@ public class AntlrToken implements GenericToken<AntlrToken> {
      * @param previousComment The previous comment
      * @param textDoc         The text document
      *
-     * @deprecated Don't create antlr tokens directly, use an {@link AntlrTokenManager}
+     * @deprecated Since 7.3.0. Don't create antlr tokens directly, use an {@link AntlrTokenManager}
      */
     @Deprecated
     public AntlrToken(final Token token, final AntlrToken previousComment, TextDocument textDoc) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractTokenManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractTokenManager.java
@@ -33,7 +33,7 @@ public abstract class AbstractTokenManager implements TokenManager<JavaccToken> 
     }
 
     /**
-     * @deprecated since 7.14.0. Use {@link #getSuppressionComments()} instead.
+     * @deprecated Since 7.14.0. Use {@link #getSuppressionComments()} instead.
      */
     @Deprecated
     public Map<Integer, String> getSuppressMap() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/package-info.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/package-info.java
@@ -3,10 +3,15 @@
  */
 
 /**
- * @deprecated Since 7.19.0. All classes in this package are deprecated. The symbol table and type
+ * <strong>Deprecated: Since 7.19.0.</strong><br>
+ * <em>
+ * All classes in this package are deprecated. The symbol table and type
  * resolution implementation for Java has been rewritten from scratch for PMD 7.0.0. This package
  * is the remains of the old symbol table API, that is only used by PL/SQL. For PMD 8.0.0 all these
  * classes will be removed from pmd-core.
+ * </em>
+ *
+ * @deprecated Since 7.19.0.
  */
 @Deprecated
 package net.sourceforge.pmd.lang.symboltable;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVWriter.java
@@ -9,14 +9,17 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 /**
  * A generic writer that formats input items into rows and columns per the
  * provided column descriptors.
  *
  * @author Brian Remedios
  * @param <T>
- * @deprecated This is internal API and an implementation detail for {@link CSVRenderer}.
+ * @apiNote This is internal API and an implementation detail for {@link CSVRenderer}.
  */
+@InternalApi
 class CSVWriter<T> {
 
     private final String separator; // e.g., the comma

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassDeclaration.java
@@ -60,7 +60,7 @@ public final class ASTClassDeclaration extends AbstractTypeDeclaration {
 
 
     /**
-     * @deprecated Use {@link #getPermitsClause()} or {@link JClassSymbol#getPermittedSubtypes()}
+     * @deprecated Since 7.8.0. Use {@link #getPermitsClause()} or {@link JClassSymbol#getPermittedSubtypes()}
      */
     @Deprecated
     public List<ASTClassType> getPermittedSubclasses() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -51,7 +51,7 @@ public final class ASTFieldDeclaration extends AbstractJavaNode
      *
      * @return a String representing the name of the variable
      *
-     * @deprecated FieldDeclaration may declare several variables, so this is not exhaustive
+     * @deprecated Since 6.10.0. FieldDeclaration may declare several variables, so this is not exhaustive
      *     Iterate on the {@linkplain ASTVariableId VariableIds} instead
      */
     @Deprecated

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaExpression.java
@@ -86,7 +86,7 @@ public final class ASTLambdaExpression extends AbstractJavaExpr implements Funct
     /**
      * Returns the body of this expression, if it is a block.
      *
-     * @deprecated Use {@link #getBlockBody()}
+     * @deprecated Since 7.1.0. Use {@link #getBlockBody()}
      */
     @Deprecated
     public @Nullable ASTBlock getBlock() {
@@ -96,7 +96,7 @@ public final class ASTLambdaExpression extends AbstractJavaExpr implements Funct
     /**
      * Returns the body of this expression, if it is an expression.
      *
-     * @deprecated Use {@link #getExpressionBody()}
+     * @deprecated Since 7.1.0. Use {@link #getExpressionBody()}
      */
     @Deprecated
     public @Nullable ASTExpression getExpression() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordPattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordPattern.java
@@ -49,7 +49,7 @@ public final class ASTRecordPattern extends AbstractJavaPattern {
     /**
      * Returns the declared variable.
      *
-     * @deprecated This method was added here by mistake. Record patterns don't declare a pattern variable
+     * @deprecated Since 7.3.0. This method was added here by mistake. Record patterns don't declare a pattern variable
      * for the whole pattern, but rather for individual record components, which can be accessed via
      * {@link #getComponentPatterns()}.
      */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SyntacticJavaTokenizerFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SyntacticJavaTokenizerFactory.java
@@ -19,7 +19,7 @@ import net.sourceforge.pmd.lang.java.internal.JavaLanguageProperties;
  * Creates a tokenizer, that uses the syntactic grammar to provide context
  * for the tokenizer when reducing the input characters to tokens.
  *
- * @deprecated This implementation has been superseded. It is not necessary to parse Java code in order to tokenize it.
+ * @deprecated Since 7.2.0. This implementation has been superseded. It is not necessary to parse Java code in order to tokenize it.
  */
 @Deprecated
 public final class SyntacticJavaTokenizerFactory {
@@ -27,6 +27,9 @@ public final class SyntacticJavaTokenizerFactory {
         // factory class
     }
 
+    /**
+     * @deprecated Since 7.2.0. This implementation has been superseded. It is not necessary to parse Java code in order to tokenize it.
+     */
     @Deprecated
     public static TokenManager<JavaccToken> createTokenizer(CharStream cs) {
         final List<JavaccToken> tokenList = new ArrayList<>();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitAssertionsShouldIncludeMessageRule.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 /**
- * @deprecated The rule was renamed {@link UnitTestAssertionsShouldIncludeMessageRule}
+ * @deprecated Since 7.7.0. The rule was renamed {@link UnitTestAssertionsShouldIncludeMessageRule}
  */
 @Deprecated
 public class JUnitAssertionsShouldIncludeMessageRule extends UnitTestAssertionsShouldIncludeMessageRule {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestContainsTooManyAssertsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestContainsTooManyAssertsRule.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 /**
- * @deprecated The rule was renamed {@link UnitTestContainsTooManyAssertsRule}
+ * @deprecated Since 7.7.0. The rule was renamed {@link UnitTestContainsTooManyAssertsRule}
  */
 @Deprecated
 public class JUnitTestContainsTooManyAssertsRule extends UnitTestContainsTooManyAssertsRule {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 /**
- * @deprecated The rule was renamed {@link UnitTestShouldIncludeAssertRule}
+ * @deprecated Since 7.7.0. The rule was renamed {@link UnitTestShouldIncludeAssertRule}
  */
 @Deprecated
 public class JUnitTestsShouldIncludeAssertRule extends UnitTestShouldIncludeAssertRule {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
@@ -29,7 +29,7 @@ public class ExcessiveImportsRule extends AbstractJavaCounterCheckRule<ASTCompil
     }
 
     /**
-     * @deprecated since 7.18.0. This method is not used anymore and shouldn't be implemented.
+     * @deprecated Since 7.18.0. This method is not used anymore and shouldn't be implemented.
      */
     @Deprecated
     protected boolean isViolation(ASTCompilationUnit node, int reportLevel) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -38,7 +38,7 @@ public class ExcessiveParameterListRule extends AbstractJavaCounterCheckRule<AST
     }
 
     /**
-     * @deprecated since 7.18.0. This method is not used anymore and shouldn't be implemented.
+     * @deprecated Since 7.18.0. This method is not used anymore and shouldn't be implemented.
      */
     @Deprecated
     protected boolean isViolation(ASTFormalParameters node, int reportLevel) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
@@ -40,7 +40,7 @@ public class ExcessivePublicCountRule extends AbstractJavaCounterCheckRule<ASTTy
     }
 
     /**
-     * @deprecated since 7.18.0. This method is not used anymore and shouldn't be implemented.
+     * @deprecated Since 7.18.0. This method is not used anymore and shouldn't be implemented.
      */
     @Deprecated
     protected boolean isViolation(ASTTypeDeclaration node, int reportLevel) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -98,9 +98,9 @@ public class SingularFieldRule extends AbstractJavaRulechainRule {
     /**
      * This method is only relevant for this rule. It will be removed in the future.
      *
-     * @deprecated This method will be removed. Don't use it.
+     * @deprecated Since 7.1.0. This method will be removed. Don't use it.
      */
-    @Deprecated //(since = "7.1.0", forRemoval = true)
+    @Deprecated
     public static boolean mayBeSingular(ModifierOwner varId) {
         return isPrivateNotFinal(varId);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -407,6 +407,9 @@ public final class TypeOps {
         return SubtypeVisitor.INFERENCE.isConvertible(t, s, true);
     }
 
+    /**
+     * @deprecated Since 7.2.0. Use {@link #isConvertible(JTypeMirror, JTypeMirror)} or {@link #isConvertibleNoCapture(JTypeMirror, JTypeMirror)} instead.
+     */
     @Deprecated // unused
     public static Convertibility isConvertible(@NonNull JTypeMirror t, @NonNull JTypeMirror s, boolean capture) {
         return SubtypeVisitor.PURE.isConvertible(t, s, capture);

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/BaseParsingHelper.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/BaseParsingHelper.kt
@@ -47,6 +47,9 @@ abstract class BaseParsingHelper<Self : BaseParsingHelper<Self, T>, T : RootNode
         val configLanguageProperties: LanguagePropertyBundle.() -> Unit = {}
     ) {
 
+        /**
+         * @deprecated Since 7.12.0. Overload added for binary compatibility.
+         */
         @Deprecated("Overload added for binary compatibility")
         constructor(
             doProcess: Boolean,
@@ -64,6 +67,9 @@ abstract class BaseParsingHelper<Self : BaseParsingHelper<Self, T>, T : RootNode
             suppressMarker,
             configLanguageProperties = {})
 
+        /**
+         * @deprecated Since 7.12.0. Overload added for binary compatibility.
+         */
         @Deprecated("Overload added for binary compatibility")
         fun copy(
             doProcess: Boolean,

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/test/ast/IntelliMarker.kt
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.Test
  * Kotest, but was removed in 4.2.0 without explanation.
  */
 interface IntelliMarker {
+    /**
+     * @deprecated Since 7.16.0. This is not an API.
+     */
     @Deprecated("This is not an API")
     fun primer() {
     }


### PR DESCRIPTION
## Describe the PR

This PR updates the deprecated tags to always contain the version, since the element has been deprecated. This makes it easy to see, when something has been deprecated.

For now, this is not consistently applied. For future, we need to manually ensure this.
Essentially, this PR proposes this format:

```java
/**
 * @deprecated Since x.y.z. Description.
 */
@Deprecated
...
```


Btw. javadoc creates an overview: https://docs.pmd-code.org/apidocs/pmd-core/latest/deprecated-list.html

It also fixes the missing deprecated info for package [net.sourceforge.pmd.lang.symboltable](https://docs.pmd-code.org/apidocs/pmd-core/latest/net/sourceforge/pmd/lang/symboltable/package-summary.html)

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

