### PR TITLE
chore: update javadoc experimental tags

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
@@ -69,7 +69,8 @@ public interface Language extends Comparable<Language> {
      * Dialects are for example different flavors of XML. Dialects must share
      * the same AST as their base language. This makes it so that rules written
      * for the base language can be applied files of all dialects uniformly.
-     * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+     * @since 7.13.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
      */
     @Experimental
     default @Nullable String getBaseLanguageId() {
@@ -80,7 +81,8 @@ public interface Language extends Comparable<Language> {
      * Return true if this language is a dialect of the given language.
      *
      * @param language A language (not null)
-     * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+     * @since 7.13.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
      */
     @Experimental
     @SuppressWarnings("PMD.SimplifyBooleanReturns")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageModuleBase.java
@@ -55,7 +55,8 @@ public abstract class LanguageModuleBase implements Language {
     }
 
     /**
-     * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+     * @since 7.13.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
      */
     @Experimental
     protected LanguageModuleBase(DialectLanguageMetadata metadata) {
@@ -375,7 +376,8 @@ public abstract class LanguageModuleBase implements Language {
          *
          * @param baseLanguageId The id of the base language this is a dialect of.
          * @return A new dialect language metadata model.
-         * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+         * @since 7.13.0
+         * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
          */
         @Experimental
         public DialectLanguageMetadata asDialectOf(String baseLanguageId) {
@@ -442,7 +444,8 @@ public abstract class LanguageModuleBase implements Language {
 
     /**
      * Expresses the language as a dialect of another language.
-     * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+     * @since 7.13.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
      */
     @Experimental
     public static final class DialectLanguageMetadata {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/SuppressionCommentImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/SuppressionCommentImpl.java
@@ -15,7 +15,8 @@ import net.sourceforge.pmd.reporting.ViolationSuppressor.SuppressionCommentWrapp
  *
  * @param <T> Type of Reportable (node, token, lambda)
  *
- * @experimental Since 7.14.0. See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
+ * @since 7.14.0
+ * @experimental See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
  */
 @Experimental
 public class SuppressionCommentImpl<T extends Reportable> implements SuppressionCommentWrapper {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BasePmdDialectLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BasePmdDialectLanguageVersionHandler.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.lang.ast.Parser;
  *
  * @author Juan Martín Sotuyo Dodero
  * @since 7.13.0
- * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+ * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
  */
 @Experimental
 public class BasePmdDialectLanguageVersionHandler extends AbstractPmdLanguageVersionHandler {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBase.java
@@ -40,7 +40,7 @@ import net.sourceforge.pmd.util.designerbindings.DesignerBindings;
  *
  * @author Juan Martín Sotuyo Dodero
  * @since 7.13.0
- * @experimental Since 7.13.0. See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
+ * @experimental See <a href="https://github.com/pmd/pmd/pull/5438">[core] Support language dialects #5438</a>.
  */
 @Experimental
 public class SimpleDialectLanguageModuleBase extends LanguageModuleBase implements PmdCapableLanguage, CpdCapableLanguage {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/impl/UnnecessaryPmdSuppressionRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/impl/UnnecessaryPmdSuppressionRule.java
@@ -27,7 +27,8 @@ import net.sourceforge.pmd.util.CollectionUtil;
  * by {@link RuleSets} to execute after all other rules, so that whether
  * those produce warnings or not is known to this rule.
  *
- * @experimental Since 7.14.0. See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
+ * @since 7.14.0
+ * @experimental See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
  */
 @Experimental
 public class UnnecessaryPmdSuppressionRule extends AbstractRule {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
@@ -157,7 +157,8 @@ public final class RuleContext {
      * @param token   Report location of the violation
      * @param message    Violation message
      * @param formatArgs Format arguments for the message
-     * @experimental Since 7.17.0. This will probably never be stabilized, will instead be
+     * @since 7.17.0
+     * @experimental This will probably never be stabilized, will instead be
      *      replaced by a fluent API or something to report violations. Do not use
      *      this outside of the PMD codebase. See <a href="https://github.com/pmd/pmd/issues/5039">[core] Add fluent API to report violations #5039</a>.
      */
@@ -178,7 +179,8 @@ public final class RuleContext {
      * @param location   Report location of the violation
      * @param message    Violation message
      * @param formatArgs Format arguments for the message
-     * @experimental Since 7.9.0. This will probably never be stabilized, will instead be
+     * @since 7.9.0
+     * @experimental This will probably never be stabilized, will instead be
      *      replaced by a fluent API or something to report violations. Do not use
      *      this outside of the PMD codebase. See <a href="https://github.com/pmd/pmd/issues/5039">[core] Add fluent API to report violations #5039</a>.
      */
@@ -201,7 +203,8 @@ public final class RuleContext {
     }
 
     /**
-     * @experimental Since 7.14.0. See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
+     * @since 7.14.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
      */
     @Experimental
     public void addViolationNoSuppress(Reportable reportable, AstInfo<?> astInfo,

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationSuppressor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationSuppressor.java
@@ -221,7 +221,8 @@ public interface ViolationSuppressor {
     /**
      * Wrapper around a suppression comment.
      *
-     * @experimental Since 7.14.0. See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
+     * @since 7.14.0
+     * @experimental See <a href="https://github.com/pmd/pmd/pull/5609">[core] Add rule to report unnecessary suppression comments/annotations #5609</a>
      */
     @Experimental
     interface SuppressionCommentWrapper {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
@@ -98,6 +98,7 @@ public interface OverloadSelectionResult {
      * constructor call expressions.
      *
      * @see ExprMirror.MethodUsageMirror#getTypeToSearch()
+     * @since 7.14.0
      * @experimental Since 7.14.0
      */
     @Experimental
@@ -107,6 +108,8 @@ public interface OverloadSelectionResult {
     /**
      * Return whether several overloads were applicable, and needed to
      * be disambiguated through specificity checks.
+     *
+     * @since 7.20.0
      * @experimental Since 7.20.0
      */
     @Experimental


### PR DESCRIPTION
## Describe the PR

Make all the experimental tags consistent and add the since version separately.

Basically, this PR proposes this format for experimental api elements:

```java
/**
 * @since x.y.z
 * @experimental Description.
 */
@Experimental
...
```

The question arises, when we promote the experimental API, which version do we use for the since tag then? Should we update the since tag? Or keep it at the first version, when it was introduced? Probably doesn't make a big difference in real life...

Probably https://docs.pmd-code.org/latest/pmd_projectdocs_decisions_adr_3.html should be updated as well...

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

