### PR TITLE
[core] Fix #4953: Deprecate PMDConfiguration set/getClassloader

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -32,7 +32,6 @@ import net.sourceforge.pmd.ant.InternalApiBridge;
 import net.sourceforge.pmd.ant.PMDTask;
 import net.sourceforge.pmd.ant.SourceLanguage;
 import net.sourceforge.pmd.internal.Slf4jSimpleConfiguration;
-import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
 import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
@@ -244,15 +243,7 @@ public class PMDTaskImpl {
         // need to reload the logger with the new configuration
         Logger log = LoggerFactory.getLogger(PMDTaskImpl.class);
         log.info("Logging is at {}", level);
-        try {
-            doTask();
-        } finally {
-            // only close the classloader, if it is ours. Otherwise we end up with class not found
-            // exceptions
-            if (configuration.getClassLoader() instanceof ClasspathClassLoader) {
-                IOUtil.tryCloseClassLoader(configuration.getClassLoader());
-            }
-        }
+        doTask();
     }
 
 }

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
@@ -304,7 +304,7 @@ public class PmdCommand extends AbstractAnalysisPmdSubcommand<PMDConfiguration> 
                 }
 
                 LOG.debug("Runtime classpath:\n{}", System.getProperty("java.class.path"));
-                LOG.debug("Aux classpath: {}", configuration.getClassLoader());
+                LOG.debug("Aux classpath: {}", configuration.getAuxClasspath());
 
                 if (showProgressBar) {
                     if (configuration.getReportFilePath() == null) {

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
@@ -304,7 +304,7 @@ public class PmdCommand extends AbstractAnalysisPmdSubcommand<PMDConfiguration> 
                 }
 
                 LOG.debug("Runtime classpath:\n{}", System.getProperty("java.class.path"));
-                LOG.debug("Aux classpath: {}", configuration.getAuxClasspath());
+                LOG.debug("Aux classpath: {}", configuration.getAnalysisClasspath());
 
                 if (showProgressBar) {
                     if (configuration.getReportFilePath() == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
-import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +27,7 @@ import net.sourceforge.pmd.lang.rule.RulePriority;
 import net.sourceforge.pmd.lang.rule.RuleSetLoader;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.renderers.RendererFactory;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 import net.sourceforge.pmd.util.AssertionUtil;
 import net.sourceforge.pmd.util.log.internal.SimpleMessageReporter;
 
@@ -76,7 +76,7 @@ import net.sourceforge.pmd.util.log.internal.SimpleMessageReporter;
  * <h2>Language configuration</h2>
  * <ul>
  * <li>Use {@link #setSuppressMarker(String)} to change the comment marker for suppression comments. Defaults to {@value #DEFAULT_SUPPRESS_MARKER}.</li>
- * <li>See {@link #setAuxClasspath(String)} for information for how to configure classpath for Java analysis.</li>
+ * <li>See {@link #setAnalysisClasspath(AnalysisClasspath)} for information for how to configure classpath for Java analysis.</li>
  * <li>You can set additional language properties with {@link #getLanguageProperties(Language)}</li>
  * </ul>
  *
@@ -109,8 +109,12 @@ public class PMDConfiguration extends AbstractConfiguration {
     private boolean ignoreIncrementalAnalysis;
 
     // Aux Classpath (Analysis Classpath) options
+    /**
+     * @deprecated Since 7.21.0. Only kept for backwards compatibility.
+     */
+    @Deprecated
     private ClassLoader classLoader = null;
-    private String auxClasspath = "";
+    private AnalysisClasspath analysisClasspath = new AnalysisClasspath();
 
     public PMDConfiguration() {
         this(DEFAULT_REGISTRY);
@@ -164,7 +168,7 @@ public class PMDConfiguration extends AbstractConfiguration {
      * Get the ClassLoader being used by PMD when processing Rules.
      *
      * @return The ClassLoader being used
-     * @deprecated Since 7.21.0. Use {@link #getAuxClasspath()} instead.
+     * @deprecated Since 7.21.0. Use {@link #getAnalysisClasspath()} instead.
      */
     @Deprecated
     public ClassLoader getClassLoader() {
@@ -177,7 +181,7 @@ public class PMDConfiguration extends AbstractConfiguration {
      *
      * @param classLoader
      *            The ClassLoader to use
-     * @deprecated Since 7.21.0. Use {@link #setAuxClasspath(String)} instead.
+     * @deprecated Since 7.21.0. Use {@link #setAnalysisClasspath(AnalysisClasspath)} instead.
      */
     @Deprecated
     public void setClassLoader(ClassLoader classLoader) {
@@ -198,18 +202,11 @@ public class PMDConfiguration extends AbstractConfiguration {
      * @param classpath The prepended classpath.
      *
      * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist)
-     * @see PMDConfiguration#setAuxClasspath(String)
+     * @see PMDConfiguration#setAnalysisClasspath(AnalysisClasspath)
+     * @see AnalysisClasspath#prepend(String)
      */
     public void prependAuxClasspath(String classpath) {
-        if (StringUtils.isBlank(classpath)) {
-            return;
-        }
-
-        if (auxClasspath.isEmpty()) {
-            auxClasspath = classpath;
-        } else {
-            auxClasspath = classpath + File.pathSeparator + auxClasspath;
-        }
+        analysisClasspath.prepend(classpath);
     }
 
     /**
@@ -217,16 +214,16 @@ public class PMDConfiguration extends AbstractConfiguration {
      * See {@link File#pathSeparator}.
      * @since 7.21.0
      */
-    public void setAuxClasspath(String classpath) {
-        auxClasspath = classpath;
+    public void setAnalysisClasspath(AnalysisClasspath classpath) {
+        analysisClasspath = classpath;
     }
 
     /**
      * @return
      * @since 7.21.0
      */
-    public String getAuxClasspath() {
-        return auxClasspath;
+    public AnalysisClasspath getAnalysisClasspath() {
+        return analysisClasspath;
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -59,6 +59,7 @@ import net.sourceforge.pmd.reporting.Report;
 import net.sourceforge.pmd.reporting.Report.GlobalReportBuilderListener;
 import net.sourceforge.pmd.reporting.ReportStats;
 import net.sourceforge.pmd.reporting.ReportStatsListener;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 import net.sourceforge.pmd.util.AssertionUtil;
 import net.sourceforge.pmd.util.CollectionUtil;
 import net.sourceforge.pmd.util.StringUtil;
@@ -128,7 +129,7 @@ import net.sourceforge.pmd.util.log.PmdReporter;
  * <h2>Specifying the Java classpath</h2>
  *
  * <p>Java rules work better if you specify the path to the compiled classes
- * of the analysed sources. See {@link PMDConfiguration#setAuxClasspath(String)}.
+ * of the analysed sources. See {@link PMDConfiguration#setAnalysisClasspath(AnalysisClasspath)}.
  *
  * <h2>Customizing message output</h2>
  *
@@ -216,7 +217,7 @@ public final class PmdAnalysis implements AutoCloseable {
             //  CLI syntax is implemented. #2947
             props.setProperty(LanguagePropertyBundle.SUPPRESS_MARKER, config.getSuppressMarker());
             if (props.hasDescriptor(JvmLanguagePropertyBundle.AUX_CLASSPATH)) {
-                props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAuxClasspath());
+                props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAnalysisClasspath().asString());
                 // kept only for backwards compatibility, must be called after the property is set, as
                 // setting AUX_CLASSPATH will reset the classloader...
                 ((JvmLanguagePropertyBundle) props).setClassLoader(config.getClassLoader());
@@ -397,7 +398,7 @@ public final class PmdAnalysis implements AutoCloseable {
             @SuppressWarnings("PMD.CloseResource")
             AnalysisCacheListener cacheListener = new AnalysisCacheListener(configuration.getAnalysisCache(),
                                                                             rulesets,
-                                                                            configuration.getAuxClasspath(),
+                                                                            configuration.getAnalysisClasspath(),
                                                                             textFiles);
             listener = GlobalAnalysisListener.tee(listOf(createComposedRendererListener(renderers),
                                                          GlobalAnalysisListener.tee(listeners),

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.rule.internal.RuleSets;
 import net.sourceforge.pmd.reporting.FileAnalysisListener;
 import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
 import net.sourceforge.pmd.reporting.RuleViolation;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 
 /**
  * An analysis cache for incremental analysis.
@@ -63,7 +64,7 @@ public interface AnalysisCache {
      *                                records in the cache are matched to the file
      *                                IDs of these files.
      */
-    void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files);
+    void checkValidity(RuleSets ruleSets, AnalysisClasspath auxClasspath, Collection<? extends TextFile> files);
 
     /**
      * Returns a listener that will be used like in {@link GlobalAnalysisListener#startFileAnalysis(TextFile)}.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCache.java
@@ -58,12 +58,12 @@ public interface AnalysisCache {
      * conditions the good behaviour of {@link #isUpToDate(TextDocument)}.
      *
      * @param ruleSets                The rulesets configured for this analysis.
-     * @param auxclassPathClassLoader The class loader for auxclasspath configured for this analysis.
+     * @param auxClasspath            The analysis classpath configured for this analysis.
      * @param files                   Set of files in the current analysis. File
      *                                records in the cache are matched to the file
      *                                IDs of these files.
      */
-    void checkValidity(RuleSets ruleSets, ClassLoader auxclassPathClassLoader, Collection<? extends TextFile> files);
+    void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files);
 
     /**
      * Returns a listener that will be used like in {@link GlobalAnalysisListener#startFileAnalysis(TextFile)}.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.lang.rule.internal.RuleSets;
 import net.sourceforge.pmd.reporting.FileAnalysisListener;
 import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 
 /**
  * Adapter to wrap {@link AnalysisCache} behaviour in a {@link GlobalAnalysisListener}.
@@ -19,7 +20,7 @@ public class AnalysisCacheListener implements GlobalAnalysisListener {
 
     private final AnalysisCache cache;
 
-    public AnalysisCacheListener(AnalysisCache cache, RuleSets ruleSets, String auxClasspath,
+    public AnalysisCacheListener(AnalysisCache cache, RuleSets ruleSets, AnalysisClasspath auxClasspath,
                                  Collection<? extends TextFile> textFiles) {
         this.cache = cache;
         cache.checkValidity(ruleSets, auxClasspath, textFiles);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AnalysisCacheListener.java
@@ -19,10 +19,10 @@ public class AnalysisCacheListener implements GlobalAnalysisListener {
 
     private final AnalysisCache cache;
 
-    public AnalysisCacheListener(AnalysisCache cache, RuleSets ruleSets, ClassLoader classLoader,
+    public AnalysisCacheListener(AnalysisCache cache, RuleSets ruleSets, String auxClasspath,
                                  Collection<? extends TextFile> textFiles) {
         this.cache = cache;
-        cache.checkValidity(ruleSets, classLoader, textFiles);
+        cache.checkValidity(ruleSets, auxClasspath, textFiles);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
@@ -44,10 +44,10 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
     }
 
     @Override
-    public void checkValidity(RuleSets ruleSets, ClassLoader auxclassPathClassLoader, Collection<? extends TextFile> files) {
+    public void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files) {
         // load cached data before checking for validity
         loadFromFile(cacheFile, files);
-        super.checkValidity(ruleSets, auxclassPathClassLoader, files);
+        super.checkValidity(ruleSets, auxClasspath, files);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/FileAnalysisCache.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.lang.rule.internal.RuleSets;
 import net.sourceforge.pmd.reporting.RuleViolation;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 
 /**
  * An analysis cache backed by a regular file.
@@ -44,7 +45,7 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
     }
 
     @Override
-    public void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files) {
+    public void checkValidity(RuleSets ruleSets, AnalysisClasspath auxClasspath, Collection<? extends TextFile> files) {
         // load cached data before checking for validity
         loadFromFile(cacheFile, files);
         super.checkValidity(ruleSets, auxClasspath, files);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
@@ -35,7 +35,7 @@ public class NoopAnalysisCache implements AnalysisCache {
     }
 
     @Override
-    public void checkValidity(RuleSets ruleSets, ClassLoader auxclassPathClassLoader, Collection<? extends TextFile> files) {
+    public void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files) {
         // noop
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopAnalysisCache.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.lang.rule.internal.RuleSets;
 import net.sourceforge.pmd.reporting.FileAnalysisListener;
 import net.sourceforge.pmd.reporting.RuleViolation;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 
 /**
  * A NOOP analysis cache. Easier / safer than null-checking.
@@ -35,7 +36,7 @@ public class NoopAnalysisCache implements AnalysisCache {
     }
 
     @Override
-    public void checkValidity(RuleSets ruleSets, String auxClasspath, Collection<? extends TextFile> files) {
+    public void checkValidity(RuleSets ruleSets, AnalysisClasspath auxClasspath, Collection<? extends TextFile> files) {
         // noop
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
@@ -5,12 +5,16 @@
 package net.sourceforge.pmd.lang;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
+import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
@@ -21,7 +25,6 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * @author Clément Fournier
  */
 public class JvmLanguagePropertyBundle extends LanguagePropertyBundle {
-
     public static final PropertyDescriptor<String> AUX_CLASSPATH
         = PropertyFactory.stringProperty("auxClasspath")
                          .desc("A classpath to use to resolve references to external types in the analysed sources. "
@@ -30,6 +33,16 @@ public class JvmLanguagePropertyBundle extends LanguagePropertyBundle {
                                    + "the compiled classes corresponding to the analyzed sources themselves, and the JDK classes.")
                          .defaultValue("")
                          .build();
+
+    private static boolean cacheClassLoader = false;
+
+    @InternalApi
+    public static void enabledCacheClassLoader() {
+        cacheClassLoader = true;
+    }
+
+    private static ClassLoader cachedClassLoader;
+    private static String cachedClassLoaderPath;
 
     private ClassLoader classLoader;
 
@@ -47,32 +60,88 @@ public class JvmLanguagePropertyBundle extends LanguagePropertyBundle {
     }
 
     /**
-     * Set the classloader to use for analysis. This overrides the
+     * Set the classloader to use for analysis. This uses the given classloader in addition to the
      * setting of a classpath as a string via {@link #setProperty(PropertyDescriptor, Object)}.
      * If the parameter is null, the classloader returned by {@link #getAnalysisClassLoader()}
-     * is constructed from the value of the {@link #AUX_CLASSPATH auxClasspath} property.
+     * is constructed solely from the value of the {@link #AUX_CLASSPATH auxClasspath} property.
+     *
+     * <p>Note: setting the property {@link #AUX_CLASSPATH} will reset the classloader set previously.</p>
+     *
+     * @deprecated Since 7.21.0. Use the property {@link #AUX_CLASSPATH} instead.
      */
+    @Deprecated
     public void setClassLoader(ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 
     /**
      * Returns the classloader to use to resolve classes for this language.
+     * @deprecated Since 7.21.0. This will be internalized as future version of PMD won't be based on ClassLoader anymore.
+     *             Use the property {@link #AUX_CLASSPATH} instead.
      */
+    @Deprecated
     public @NonNull ClassLoader getAnalysisClassLoader() {
+        // custom, external classloader - just use this
         if (classLoader != null) {
             return classLoader;
         }
-        // load classloader using the property.
-        classLoader = PMDConfiguration.class.getClassLoader();
-        String classpath = getProperty(AUX_CLASSPATH);
-        if (StringUtils.isNotBlank(classpath)) {
+
+        String auxClasspath = getProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH);
+        if (cacheClassLoader) {
+            // we use a cached classloader to help performance boost our rule tests. Otherwise a new ClasspathClassLoader
+            // will be created for every single rule test. Note: the last cached classloader won't be closed and is leaking...
+            if (cachedClassLoader == null || !cachedClassLoaderPath.equals(auxClasspath)) {
+                if (cachedClassLoader instanceof UncloseableClassLoader) {
+                    IOUtil.tryCloseClassLoader(((UncloseableClassLoader) cachedClassLoader).getDelegate());
+                }
+                cachedClassLoader = new UncloseableClassLoader(create(auxClasspath));
+                cachedClassLoaderPath = auxClasspath;
+            }
+            classLoader = cachedClassLoader;
+        } else {
+            classLoader = create(auxClasspath);
+        }
+
+        return classLoader;
+    }
+
+    private ClassLoader create(String auxClasspath) {
+        if (StringUtils.isNotBlank(auxClasspath)) {
             try {
-                classLoader = new ClasspathClassLoader(classpath, classLoader);
+                return new ClasspathClassLoader(auxClasspath, PMDConfiguration.class.getClassLoader());
             } catch (IOException e) {
                 throw new IllegalArgumentException(e);
             }
         }
-        return classLoader;
+        // default fallback, when no analysis classpath has been configured
+        return PMDConfiguration.class.getClassLoader();
+    }
+
+    // not closeable anymore, so that this classloader can be cached and reused
+    private static final class UncloseableClassLoader extends ClassLoader {
+        private final ClassLoader delegate;
+
+        private UncloseableClassLoader(ClassLoader delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return delegate.getResourceAsStream(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return delegate.getResource(name);
+        }
+
+        @Override
+        public String toString() {
+            return UncloseableClassLoader.class.getSimpleName() + "[delegate=" + delegate.toString() + "]";
+        }
+
+        private ClassLoader getDelegate() {
+            return delegate;
+        }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
@@ -71,7 +71,9 @@ public class JvmLanguagePropertyBundle extends LanguagePropertyBundle {
      */
     @Deprecated
     public void setClassLoader(ClassLoader classLoader) {
-        this.classLoader = classLoader;
+        if (classLoader != null) {
+            this.classLoader = new UncloseableClassLoader(classLoader);
+        }
     }
 
     /**
@@ -114,7 +116,7 @@ public class JvmLanguagePropertyBundle extends LanguagePropertyBundle {
             }
         }
         // default fallback, when no analysis classpath has been configured
-        return PMDConfiguration.class.getClassLoader();
+        return new UncloseableClassLoader(PMDConfiguration.class.getClassLoader());
     }
 
     // not closeable anymore, so that this classloader can be cached and reused

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AnalysisClasspath.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AnalysisClasspath.java
@@ -1,0 +1,78 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
+
+/**
+ * Represents a classpath used for JVM languages during analysis.
+ *
+ * @since 7.21.0
+ */
+public class AnalysisClasspath {
+    private final List<Path> classpath = new ArrayList<>();
+
+    public void prepend(String classpath) {
+        if (StringUtils.isBlank(classpath)) {
+            return;
+        }
+
+        this.classpath.addAll(0, from(classpath).getClasspath());
+    }
+
+    public List<Path> getClasspath() {
+        return classpath;
+    }
+
+    @Override
+    public String toString() {
+        return asString();
+    }
+
+    /**
+     * Returns a platform dependend string of all classpath components.
+     * @return
+     */
+    public String asString() {
+        return classpath.stream().map(Path::toString).collect(Collectors.joining(File.pathSeparator));
+    }
+
+    public static AnalysisClasspath currentJvm() {
+        Path javaHome = Paths.get(System.getProperty("java.home"));
+        Path jrtFs = javaHome.resolve("lib/jrt-fs.jar");
+        Path rtJar = javaHome.resolve("lib/rt.jar");
+
+        if (Files.exists(jrtFs)) {
+            AnalysisClasspath analysisClasspath = new AnalysisClasspath();
+            analysisClasspath.prepend(jrtFs.toString());
+            return analysisClasspath;
+        } else if (Files.exists(rtJar)) {
+            AnalysisClasspath analysisClasspath = new AnalysisClasspath();
+            analysisClasspath.prepend(rtJar.toString());
+            return analysisClasspath;
+        }
+        throw new IllegalStateException("Could not determine current jvm classpath");
+    }
+
+    public static AnalysisClasspath from(String classpath) {
+        List<Path> paths = ClasspathClassLoader.parseClasspath(classpath)
+                .stream().map(u -> Paths.get(URI.create(u.toString())))
+                .collect(Collectors.toList());
+        AnalysisClasspath analysisClasspath = new AnalysisClasspath();
+        analysisClasspath.classpath.addAll(paths);
+        return analysisClasspath;
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -32,6 +33,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.RulePriority;
 import net.sourceforge.pmd.renderers.CSVRenderer;
 import net.sourceforge.pmd.renderers.Renderer;
+import net.sourceforge.pmd.util.AnalysisClasspath;
 
 class PmdConfigurationTest {
 
@@ -56,11 +58,11 @@ class PmdConfigurationTest {
         PMDConfiguration configuration = new PMDConfiguration();
         assertNull(configuration.getClassLoader(), "No default ClassLoader");
         configuration.prependAuxClasspath("some.jar");
-        assertEquals("some.jar", configuration.getAuxClasspath());
+        assertEquals(Paths.get("some.jar").toAbsolutePath().toString(), configuration.getAnalysisClasspath().asString());
         assertNull(configuration.getClassLoader(), "Still no ClassLoader");
 
         configuration.setClassLoader(null);
-        assertEquals("some.jar", configuration.getAuxClasspath());
+        assertEquals(Paths.get("some.jar").toAbsolutePath().toString(), configuration.getAnalysisClasspath().asString());
         assertNull(configuration.getClassLoader(), "Still no ClassLoader");
         configuration.setClassLoader(PMDConfiguration.class.getClassLoader());
         assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader());
@@ -69,11 +71,12 @@ class PmdConfigurationTest {
     @Test
     void testAuxClasspath() {
         PMDConfiguration configuration = new PMDConfiguration();
-        assertEquals("", configuration.getAuxClasspath());
-        configuration.setAuxClasspath("file1.jar");
-        assertEquals("file1.jar", configuration.getAuxClasspath());
+        assertEquals("", configuration.getAnalysisClasspath().asString());
+        configuration.setAnalysisClasspath(AnalysisClasspath.from("file1.jar"));
+        assertEquals(Paths.get("file1.jar").toAbsolutePath().toString(), configuration.getAnalysisClasspath().asString());
         configuration.prependAuxClasspath("prepended.jar");
-        assertEquals("prepended.jar" + File.pathSeparator + "file1.jar", configuration.getAuxClasspath());
+        assertEquals(Paths.get("prepended.jar").toAbsolutePath()
+                + File.pathSeparator + Paths.get("file1.jar").toAbsolutePath(), configuration.getAnalysisClasspath().asString());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -7,19 +7,16 @@ package net.sourceforge.pmd;
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -30,7 +27,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
-import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
 import net.sourceforge.pmd.lang.CpdOnlyDummyLanguage;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.RulePriority;
@@ -58,62 +54,26 @@ class PmdConfigurationTest {
     @Test
     void testClassLoader() {
         PMDConfiguration configuration = new PMDConfiguration();
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Default ClassLoader");
+        assertNull(configuration.getClassLoader(), "No default ClassLoader");
         configuration.prependAuxClasspath("some.jar");
-        assertEquals(ClasspathClassLoader.class, configuration.getClassLoader().getClass(),
-                "Prepended ClassLoader class");
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(1, urls.length, "urls length");
-        assertTrue(urls[0].toString().endsWith("/some.jar"), "url[0]");
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader().getParent(),
-                "parent classLoader");
+        assertEquals("some.jar", configuration.getAuxClasspath());
+        assertNull(configuration.getClassLoader(), "Still no ClassLoader");
+
         configuration.setClassLoader(null);
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(),
-                "Revert to default ClassLoader");
+        assertEquals("some.jar", configuration.getAuxClasspath());
+        assertNull(configuration.getClassLoader(), "Still no ClassLoader");
+        configuration.setClassLoader(PMDConfiguration.class.getClassLoader());
+        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader());
     }
 
     @Test
-    void auxClasspathWithRelativeFileEmpty() {
-        String relativeFilePath = "src/test/resources/net/sourceforge/pmd/auxclasspath-empty.cp";
+    void testAuxClasspath() {
         PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(0, urls.length);
-    }
-
-    @Test
-    void auxClasspathWithRelativeFileEmpty2() {
-        String relativeFilePath = "./src/test/resources/net/sourceforge/pmd/auxclasspath-empty.cp";
-        PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(0, urls.length);
-    }
-
-    @Test
-    void auxClasspathWithRelativeFile() throws URISyntaxException {
-        final String FILE_SCHEME = "file";
-
-        String currentWorkingDirectory = new File("").getAbsoluteFile().toURI().getPath();
-        String relativeFilePath = "src/test/resources/net/sourceforge/pmd/auxclasspath.cp";
-        PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        URI[] uris = new URI[urls.length];
-        for (int i = 0; i < urls.length; i++) {
-            uris[i] = urls[i].toURI();
-        }
-        URI[] expectedUris = new URI[] {
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "lib1.jar", null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "other/directory/lib2.jar", null),
-            new URI(FILE_SCHEME, null, new File("/home/jondoe/libs/lib3.jar").getAbsoluteFile().toURI().getPath(), null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "classes", null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "classes2", null),
-            new URI(FILE_SCHEME, null, new File("/home/jondoe/classes").getAbsoluteFile().toURI().getPath(), null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory, null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "relative source dir/bar", null),
-        };
-        assertArrayEquals(expectedUris, uris);
+        assertEquals("", configuration.getAuxClasspath());
+        configuration.setAuxClasspath("file1.jar");
+        assertEquals("file1.jar", configuration.getAuxClasspath());
+        configuration.prependAuxClasspath("prepended.jar");
+        assertEquals("prepended.jar" + File.pathSeparator + "file1.jar", configuration.getAuxClasspath());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/FileAnalysisCacheTest.java
@@ -19,8 +19,6 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -117,7 +115,7 @@ class FileAnalysisCacheTest {
     @Test
     void testStorePersistsFilesWithViolations() throws IOException {
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
-        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        cache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
         final FileAnalysisListener cacheListener = cache.startFileAnalysis(sourceFile);
         
         cache.isUpToDate(sourceFile);
@@ -133,7 +131,7 @@ class FileAnalysisCacheTest {
         cache.persist();
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        reloadedCache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
         assertTrue(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file with violations is not up to date");
 
@@ -150,7 +148,7 @@ class FileAnalysisCacheTest {
     @Test
     void testStorePersistsFilesWithViolationsAndProcessingErrors() throws IOException {
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
-        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        cache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
         final FileAnalysisListener cacheListener = cache.startFileAnalysis(sourceFile);
 
         cache.isUpToDate(sourceFile);
@@ -169,7 +167,7 @@ class FileAnalysisCacheTest {
         cache.persist();
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        reloadedCache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
         assertFalse(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes file is up to date although processing errors happened earlier");
 
@@ -195,7 +193,7 @@ class FileAnalysisCacheTest {
         when(mockFile.readContents()).thenReturn(TextFileContent.fromCharSeq("abc"));
 
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
-        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        cache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
 
         try (TextDocument doc0 = TextDocument.create(mockFile)) {
             cache.isUpToDate(doc0);
@@ -213,7 +211,7 @@ class FileAnalysisCacheTest {
 
     private void reloadWithOneViolation(TextFile mockFile) throws IOException {
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(mockFile));
+        reloadedCache.checkValidity(mock(RuleSets.class), "", setOf(mockFile));
         try (TextDocument doc1 = TextDocument.create(mockFile)) {
             assertTrue(reloadedCache.isUpToDate(doc1),
                        "Cache believes unmodified file with violations is not up to date");
@@ -228,12 +226,12 @@ class FileAnalysisCacheTest {
     @Test
     void testCacheValidityWithNoChanges() throws IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final ClassLoader cl = mock(ClassLoader.class);
+        final String auxClasspath = "";
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(rs, cl, setOf(sourceFileBackend));
+        reloadedCache.checkValidity(rs, auxClasspath, setOf(sourceFileBackend));
         assertTrue(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is not up to date without ruleset / classpath changes");
     }
@@ -241,16 +239,15 @@ class FileAnalysisCacheTest {
     @Test
     void testCacheValidityWithIrrelevantChanges() throws IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final URLClassLoader cl = mock(URLClassLoader.class);
-        when(cl.getURLs()).thenReturn(new URL[] {});
+        String auxClasspath = "";
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final File classpathFile = Files.createTempFile(tempFolder, null, "foo.xml").toFile();
-        when(cl.getURLs()).thenReturn(new URL[] { classpathFile.toURI().toURL(), });
+        auxClasspath = classpathFile.toString();
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(rs, cl, setOf(sourceFileBackend));
+        reloadedCache.checkValidity(rs, auxClasspath, setOf(sourceFileBackend));
         assertTrue(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is not up to date without ruleset / classpath changes");
     }
@@ -258,43 +255,40 @@ class FileAnalysisCacheTest {
     @Test
     void testRulesetChangeInvalidatesCache() throws IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final ClassLoader cl = mock(ClassLoader.class);
+        final String auxClasspath = "";
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         when(rs.getChecksum()).thenReturn(1L);
-        reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+        reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
         assertFalse(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is up to date after ruleset changed");
     }
 
     @Test
-    void testAuxClasspathNonExistingAuxclasspathEntriesIgnored() throws MalformedURLException, IOException {
+    void testAuxClasspathNonExistingAuxclasspathEntriesIgnored() throws IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final URLClassLoader cl = mock(URLClassLoader.class);
-        when(cl.getURLs()).thenReturn(new URL[] { tempFolder.resolve("non-existing-dir").toFile().toURI().toURL(), });
+        final String auxClasspath = tempFolder.resolve("non-existing-dir").toString();
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final FileAnalysisCache analysisCache = new FileAnalysisCache(newCacheFile);
-        when(cl.getURLs()).thenReturn(new URL[] {});
-        analysisCache.checkValidity(rs, cl, setOf(sourceFileBackend));
+        analysisCache.checkValidity(rs, "", setOf(sourceFileBackend));
         assertTrue(analysisCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is not up to date after non-existing auxclasspath entry removed");
     }
 
     @Test
-    void testAuxClasspathChangeWithoutDFAorTypeResolutionDoesNotInvalidatesCache() throws MalformedURLException, IOException {
+    void testAuxClasspathChangeWithoutDFAorTypeResolutionDoesNotInvalidatesCache() throws IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final URLClassLoader cl = mock(URLClassLoader.class);
-        when(cl.getURLs()).thenReturn(new URL[] { });
+        String auxClasspath = "";
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        when(cl.getURLs()).thenReturn(new URL[] { Files.createTempFile(tempFolder, null, null).toFile().toURI().toURL(), });
-        reloadedCache.checkValidity(rs, cl, setOf(sourceFileBackend));
+        auxClasspath = Files.createTempFile(tempFolder, null, null).toString();
+        reloadedCache.checkValidity(rs, auxClasspath, setOf(sourceFileBackend));
         assertTrue(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is not up to date after auxclasspath changed when no rule cares");
     }
@@ -302,14 +296,13 @@ class FileAnalysisCacheTest {
     @Test
     void testAuxClasspathChangeInvalidatesCache() throws MalformedURLException, IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final URLClassLoader cl = mock(URLClassLoader.class);
-        when(cl.getURLs()).thenReturn(new URL[] { });
+        String auxClasspath = "";
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         final File classpathFile = Files.createTempFile(tempFolder, null, "foo.class").toFile();
-        when(cl.getURLs()).thenReturn(new URL[] { classpathFile.toURI().toURL(), });
+        auxClasspath = classpathFile.toString();
 
         // Make sure the auxclasspath file is not empty
         Files.write(classpathFile.toPath(), "some text".getBytes());
@@ -317,7 +310,7 @@ class FileAnalysisCacheTest {
         final Rule r = mock(Rule.class);
         when(r.getLanguage()).thenReturn(mock(Language.class));
         when(rs.getAllRules()).thenReturn(Collections.singleton(r));
-        reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+        reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
         assertFalse(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes unmodified file is up to date after auxclasspath changed");
     }
@@ -325,22 +318,22 @@ class FileAnalysisCacheTest {
     @Test
     void testAuxClasspathJarContentsChangeInvalidatesCache() throws MalformedURLException, IOException {
         final RuleSets rs = mock(RuleSets.class);
-        final URLClassLoader cl = mock(URLClassLoader.class);
 
         final File classpathFile = Files.createTempFile(tempFolder, null, "foo.class").toFile();
-        when(cl.getURLs()).thenReturn(new URL[] { classpathFile.toURI().toURL(), });
+
+        String auxClasspath = classpathFile.toString();
 
         final Rule r = mock(Rule.class);
         when(r.getLanguage()).thenReturn(mock(Language.class));
         when(rs.getAllRules()).thenReturn(Collections.singleton(r));
 
-        setupCacheWithFiles(newCacheFile, rs, cl);
+        setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
         // Edit the auxclasspath referenced file
         Files.write(classpathFile.toPath(), "some text".getBytes());
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+        reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
         assertFalse(reloadedCache.isUpToDate(sourceFile),
                 "Cache believes cache is up to date when a auxclasspath file changed");
     }
@@ -349,14 +342,14 @@ class FileAnalysisCacheTest {
     void testClasspathNonExistingEntryIsIgnored() throws Exception {
         restoreSystemProperties(() -> {
             final RuleSets rs = mock(RuleSets.class);
-            final ClassLoader cl = mock(ClassLoader.class);
+            final String auxClasspath = "";
 
             System.setProperty("java.class.path", System.getProperty("java.class.path") + File.pathSeparator
                     + tempFolder.toFile().getAbsolutePath() + File.separator + "non-existing-dir");
 
             final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
             try {
-                reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+                reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
             } catch (final Exception e) {
                 fail("Validity check failed when classpath includes non-existing directories");
             }
@@ -367,18 +360,18 @@ class FileAnalysisCacheTest {
     void testClasspathChangeInvalidatesCache() throws Exception {
         restoreSystemProperties(() -> {
             final RuleSets rs = mock(RuleSets.class);
-            final ClassLoader cl = mock(ClassLoader.class);
+            final String auxClasspath = "";
 
             final File classpathFile = Files.createTempFile(tempFolder, null, "foo.class").toFile();
 
-            setupCacheWithFiles(newCacheFile, rs, cl);
+            setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
             // Edit the classpath referenced file
             Files.write(classpathFile.toPath(), "some text".getBytes());
             System.setProperty("java.class.path", System.getProperty("java.class.path") + File.pathSeparator + classpathFile.getAbsolutePath());
 
             final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-            reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+            reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
             assertFalse(reloadedCache.isUpToDate(sourceFile),
                     "Cache believes cache is up to date when the classpath changed");
         });
@@ -388,7 +381,7 @@ class FileAnalysisCacheTest {
     void testClasspathContentsChangeInvalidatesCache() throws Exception {
         restoreSystemProperties(() -> {
             final RuleSets rs = mock(RuleSets.class);
-            final ClassLoader cl = mock(ClassLoader.class);
+            final String auxClasspath = "";
 
             final File classpathFile = Files.createTempFile(tempFolder, null, "foo.class").toFile();
 
@@ -396,13 +389,13 @@ class FileAnalysisCacheTest {
             Files.write(classpathFile.toPath(), "some text".getBytes());
             System.setProperty("java.class.path", System.getProperty("java.class.path") + File.pathSeparator + classpathFile.getAbsolutePath());
 
-            setupCacheWithFiles(newCacheFile, rs, cl);
+            setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
             // Change the file's contents
             Files.write(classpathFile.toPath(), "some other text".getBytes());
 
             final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-            reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+            reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
             assertFalse(reloadedCache.isUpToDate(sourceFile),
                     "Cache believes cache is up to date when a classpath file changed");
         });
@@ -412,8 +405,8 @@ class FileAnalysisCacheTest {
     void testWildcardClasspath() throws Exception {
         restoreSystemProperties(() -> {
             final RuleSets rs = mock(RuleSets.class);
-            final ClassLoader cl = mock(ClassLoader.class);
-            setupCacheWithFiles(newCacheFile, rs, cl);
+            final String auxClasspath = "";
+            setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
             // Prepare two class files
             createZipFile("mylib1.jar");
@@ -431,7 +424,7 @@ class FileAnalysisCacheTest {
     void testWildcardClasspathContentsChangeInvalidatesCache() throws Exception {
         restoreSystemProperties(() -> {
             final RuleSets rs = mock(RuleSets.class);
-            final ClassLoader cl = mock(ClassLoader.class);
+            final String auxClasspath = "";
 
             // Prepare two jar files
             final File classpathJar1 = createZipFile("mylib1.jar");
@@ -439,14 +432,14 @@ class FileAnalysisCacheTest {
 
             System.setProperty("java.class.path", System.getProperty("java.class.path") + File.pathSeparator + tempFolder.toFile().getAbsolutePath() + "/*");
 
-            setupCacheWithFiles(newCacheFile, rs, cl);
+            setupCacheWithFiles(newCacheFile, rs, auxClasspath);
 
             // Change one file's contents (ie: adding more entries)
             classpathJar1.delete();
             createZipFile(classpathJar1.getName(), 2);
 
             final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-            reloadedCache.checkValidity(rs, cl, Collections.emptySet());
+            reloadedCache.checkValidity(rs, auxClasspath, Collections.emptySet());
             assertFalse(reloadedCache.isUpToDate(sourceFile),
                     "Cache believes cache is up to date when the classpath changed");
         });
@@ -461,17 +454,17 @@ class FileAnalysisCacheTest {
 
     @Test
     void testFileIsUpToDate() throws IOException {
-        setupCacheWithFiles(newCacheFile, mock(RuleSets.class), mock(ClassLoader.class));
+        setupCacheWithFiles(newCacheFile, mock(RuleSets.class), "");
 
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
-        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class), setOf(sourceFileBackend));
+        cache.checkValidity(mock(RuleSets.class), "", setOf(sourceFileBackend));
         assertTrue(cache.isUpToDate(sourceFile),
                 "Cache believes a known, unchanged file is not up to date");
     }
 
     @Test
     void testFileIsNotUpToDateWhenEdited() throws IOException {
-        setupCacheWithFiles(newCacheFile, mock(RuleSets.class), mock(ClassLoader.class));
+        setupCacheWithFiles(newCacheFile, mock(RuleSets.class), "");
 
         // Edit the file
         TextFileContent text = TextFileContent.fromCharSeq("some text");
@@ -486,10 +479,10 @@ class FileAnalysisCacheTest {
 
     private void setupCacheWithFiles(final File cacheFile,
                                      final RuleSets ruleSets,
-                                     final ClassLoader classLoader) throws IOException {
+                                     final String auxClasspath) throws IOException {
         // Setup a cache file with an entry for an empty Source.java with no violations
         final FileAnalysisCache cache = new FileAnalysisCache(cacheFile);
-        cache.checkValidity(ruleSets, classLoader, setOf(sourceFileBackend));
+        cache.checkValidity(ruleSets, auxClasspath, setOf(sourceFileBackend));
 
         cache.isUpToDate(sourceFile);
         cache.persist();

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
@@ -49,7 +49,7 @@ class ClassLoadingChildFirstTest {
         config.prependAuxClasspath(file.toAbsolutePath().toString());
 
         JvmLanguagePropertyBundle props = (JvmLanguagePropertyBundle) JavaLanguageModule.getInstance().newPropertyBundle();
-        props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAuxClasspath());
+        props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAnalysisClasspath().asString());
         TypeSystem typeSystem = TypeSystem.usingClassLoaderClasspath(props.getAnalysisClassLoader());
 
         JClassType voidClass = typeSystem.BOXED_VOID;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Test;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
+import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
+import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
@@ -46,7 +48,9 @@ class ClassLoadingChildFirstTest {
         PMDConfiguration config = new PMDConfiguration();
         config.prependAuxClasspath(file.toAbsolutePath().toString());
 
-        TypeSystem typeSystem = TypeSystem.usingClassLoaderClasspath(config.getClassLoader());
+        JvmLanguagePropertyBundle props = (JvmLanguagePropertyBundle) JavaLanguageModule.getInstance().newPropertyBundle();
+        props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAuxClasspath());
+        TypeSystem typeSystem = TypeSystem.usingClassLoaderClasspath(props.getAnalysisClassLoader());
 
         JClassType voidClass = typeSystem.BOXED_VOID;
         List<JMethodSymbol> declaredMethods = voidClass.getSymbol().getDeclaredMethods();

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/RuleTst.java
@@ -31,7 +31,7 @@ import org.xml.sax.InputSource;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PmdAnalysis;
-import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
+import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.TextFile;
@@ -269,7 +269,7 @@ public abstract class RuleTst {
         return runTestFromString(test.getCode(), rule, test.getLanguageVersion());
     }
 
-    private static final ClassLoader TEST_AUXCLASSPATH_CLASSLOADER;
+    private static final String TEST_AUXCLASSPATH;
 
     static {
         final Path PATH_TO_JRT_FS_JAR;
@@ -290,11 +290,7 @@ public abstract class RuleTst {
             }
         }
 
-        try {
-            TEST_AUXCLASSPATH_CLASSLOADER = new ClasspathClassLoader(PATH_TO_JRT_FS_JAR.toString(), PMDConfiguration.class.getClassLoader());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        TEST_AUXCLASSPATH = PATH_TO_JRT_FS_JAR.toString();
     }
 
     /**
@@ -305,7 +301,8 @@ public abstract class RuleTst {
         configuration.setIgnoreIncrementalAnalysis(true);
         configuration.setDefaultLanguageVersion(languageVersion);
         configuration.setThreads(0); // don't use separate threads
-        configuration.setClassLoader(TEST_AUXCLASSPATH_CLASSLOADER);
+        configuration.setAuxClasspath(TEST_AUXCLASSPATH);
+        JvmLanguagePropertyBundle.enabledCacheClassLoader();
 
         try (PmdAnalysis pmd = PmdAnalysis.create(configuration)) {
             pmd.files().addFile(TextFile.forCharSeq(code, FileId.fromPathLikeString("file"), languageVersion));


### PR DESCRIPTION
## Describe the PR

This is my own attempt to this issue...

Things to think about, stuff that is not ready
* should we really rename auxclasspath to analysisclasspath? What is the correct name? Auxclasspath is older, but IMHO AnalysisClasspath sounds better
* should we introduce now AnalysisClasspath or keep it as a simple String in PMDConfiguration?
* When should we validate the provided auxclasspath (e.g. do the provided paths exist, etc.). We probably should do this not here, but in #5064 .
* documentation / api doc and tests
  * especially the usage scenarios you mention in the description of #6312 (e.g. reusing PMDConfiguration)
* This is API compatible, but heavily changes the semantics of PMDConfiguration - e.g. the sequence of the calls prependAuxclasspath, getClassloader.getURLs() doesn't work anymore (we used that in unit tests). Is this a problem?
  * In summary I think, the main culprit is that PMDConfiguration is more than data
* Were should the logic be placed to interpret the classpath string provided to PMD? I've extracted it into separately used methods in ClasspathClassloader, but it maybe belongs to AnalysisClasspath
* Maybe the performance problem for our rule unit tests could be solved in a more elegant way - ideally some solution, that we can keep (and no temporary solution)
* commit messages here need to be redone
* ...


Some ideas on how to approach part of this and make this change even smaller:
* first refactor ClasspathClassloader to define, where the logic for parsing a string into URLs belong
* refactor Analysis Cache / Fingerprinter to not use URLs, if possible. If at all, we should use URIs.


## Related issues

- Fix #4953

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

