### PR TITLE
[ci] chore: run extensive integration tests under linux only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,9 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         with:
           name: compile-artifact
-      - name: Build with Maven and run unit tests
+      - name: Build with Maven and run unit and integration tests (linux)
+        # under linux we execute more extensive integration tests with various java versions
+        if: ${{ runner.os == 'Linux' }}
         run: |
           ./mvnw --show-version --errors --batch-mode \
               -Dmaven.repo.local=.m2/repository \
@@ -163,6 +165,13 @@ jobs:
               -Djava11.home="${JAVA_HOME_11_X64}" \
               -Djava17.home="${JAVA_HOME_17_X64}" \
               -Djava25.home="${JAVA_HOME_25_X64}"
+      - name: Build with Maven and run unit tests
+        if: ${{ runner.os != 'Linux' }}
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+              -Dmaven.repo.local=.m2/repository \
+              verify \
+              -PfastSkip -Dcyclonedx.skip=false
 
   dogfood:
     needs: compile


### PR DESCRIPTION
These tests were supposed to be run only on the linux runners, but other runners have all the java version installed as well and ran these tests as well. This was not intended and lengthens the build time.

