### PR TITLE
[doc] chore: add keywords for auxclasspath in Java documentation

### DIFF
--- a/docs/pages/pmd/languages/java.md
+++ b/docs/pages/pmd/languages/java.md
@@ -4,6 +4,7 @@ permalink: pmd_languages_java.html
 author: Clément Fournier
 last_updated: January 2026 (7.21.0)
 tags: [languages, PmdCapableLanguage, CpdCapableLanguage]
+keywords: [auxclasspath, auxiliary, classpath, type resolution]
 summary: "Java-specific features and guidance"
 ---
 


### PR DESCRIPTION
## Describe the PR

When searching for auxclasspath, the page https://docs.pmd-code.org/latest/pmd_languages_java.html#providing-the-auxiliary-classpath was not found.

## Related issues

- Refs #5064

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

