### PR TITLE
[java] chore(style): Fix lambda argument indentation for checkstyle compliance

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -303,7 +303,7 @@ public final class JavaAstUtils {
     public static @NonNull ASTExpression getTopLevelExpr(ASTExpression expr) {
         JavaNode last = expr.ancestorsOrSelf()
                             .takeWhile(it ->
-                                    it instanceof ASTExpression && !(it instanceof ASTLambdaExpression)
+                                it instanceof ASTExpression && !(it instanceof ASTLambdaExpression)
                                         || it instanceof ASTArgumentList && it.getParent() instanceof ASTExpression
                             )
                             .last();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
@@ -161,7 +161,7 @@ public final class ImplicitMemberSymbols {
                 "log",
                 Modifier.PRIVATE | Modifier.STATIC | Modifier.FINAL,
                 (ts, s) ->
-                        ts.declaration(processor.findSymbolCannotFail("org.slf4j.Logger"))
+                    ts.declaration(processor.findSymbolCannotFail("org.slf4j.Logger"))
         );
     }
 


### PR DESCRIPTION
[java] Fix lambda argument indentation for checkstyle compliance

## Describe the PR
Checkstyle is working on fixing false negatives in indentation for lambda arguments (checkstyle/checkstyle#18784). This PR simply changes indentation to allow CI to pass.

Corrects indentation of lambda arguments from level 20 to level 16 to comply with checkstyle Indentation rules. This resolves CI failure: [no-error-pmd](https://app.circleci.com/pipelines/github/checkstyle/checkstyle/41134/workflows/98b89a52-c66b-43d2-9a07-267d36663cda/jobs/1290268)

## Related issues
<!-- PR relates to issues in the `pmd` repo: -->
- Related to checkstyle/checkstyle#18784

## Ready?
- [ ] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

