### PR TITLE
[java] CloseResource: Allow to ignore managed resources

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1084,6 +1084,12 @@ the types, if the type resolution / auxclasspath is not correctly setup.
 Note: Since PMD 6.16.0 the default value for the property `types` contains `java.lang.AutoCloseable` and detects
 now cases where the standard `java.io.*Stream` classes are involved. In order to restore the old behaviour,
 just remove "AutoCloseable" from the types.
+
+The property `allowedResourceMethodPatterns` can be used to specify method invocation patterns that return
+resources which are managed externally and don't need to be closed by the caller. This is useful for
+servlet-related streams like `HttpServletRequest.getReader()` or `HttpServletResponse.getWriter()`,
+which are managed by the servlet container. The patterns use InvocationMatcher syntax
+(e.g., `javax.servlet.ServletRequest#getReader()`).
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2135,4 +2135,139 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Servlet managed resource should not be reported (javax.servlet)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.BufferedReader;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ServletExample {
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        BufferedReader reader = request.getReader();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            System.out.println(line);
+        }
+
+        PrintWriter writer = response.getWriter();
+        writer.println("Hello World");
+
+        ServletOutputStream out = response.getOutputStream();
+        out.write(new byte[] {1, 2, 3});
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Regular PrintWriter not from servlet should still be reported</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.PrintWriter;
+import java.io.FileWriter;
+
+public class RegularWriter {
+    public void write() throws Exception {
+        // Regular PrintWriter should still be flagged
+        PrintWriter writer = new PrintWriter(new FileWriter("test.txt"));
+        writer.println("Hello");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Custom allowedResourceMethodPatterns property</description>
+        <rule-property name="allowedResourceMethodPatterns">com.example.MyFactory#getResource()</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.InputStream;
+import com.example.MyFactory;
+
+public class CustomPattern {
+    public void read(MyFactory factory) throws Exception {
+        InputStream stream = factory.getResource();
+        int c = stream.read();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Empty allowedResourceMethodPatterns should not cause issues</description>
+        <rule-property name="allowedResourceMethodPatterns"></rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.BufferedReader;
+import javax.servlet.http.HttpServletRequest;
+
+public class ServletExample {
+    public void doPost(HttpServletRequest request) throws Exception {
+        // When patterns are empty, servlet streams should be reported
+        BufferedReader reader = request.getReader();
+        String line = reader.readLine();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Explicit allowedResourceMethodPatterns with jakarta.servlet patterns</description>
+        <rule-property name="allowedResourceMethodPatterns">jakarta.servlet.ServletRequest#getReader(),jakarta.servlet.ServletResponse#getWriter()</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+public class ServletExample {
+    public void doRequest(ServletRequest request, ServletResponse response) throws Exception {
+        BufferedReader reader = request.getReader();
+        String line = reader.readLine();
+
+        PrintWriter writer = response.getWriter();
+        writer.println(line);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Wrapped servlet stream (ObjectOutputStream wrapping response.getOutputStream()) should not be reported</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.ObjectOutputStream;
+import javax.servlet.http.HttpServletResponse;
+
+public class ServletExample {
+    public void doGet(HttpServletResponse response) throws Exception {
+        ObjectOutputStream oos = new ObjectOutputStream(response.getOutputStream());
+        oos.writeObject("Hello");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Wrapped servlet stream (BufferedReader wrapping request.getReader()) should not be reported</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.BufferedReader;
+import java.io.LineNumberReader;
+import javax.servlet.http.HttpServletRequest;
+
+public class ServletExample {
+    public void doPost(HttpServletRequest request) throws Exception {
+        LineNumberReader lnr = new LineNumberReader(request.getReader());
+        String line = lnr.readLine();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Allow to configure method that will consider created ressource as "managed" and that should not be manually closed.

## Related issues

- Fix #6436

## Ready?


- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

