### PR TITLE
[java] New Rule: UnnecessaryInterfaceDeclaration

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -23,6 +23,5 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/sandbox/graphs" vcs="Git" />
   </component>
 </project>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationRule.java
@@ -1,0 +1,66 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTExtendsList;
+import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
+import net.sourceforge.pmd.lang.java.ast.ASTList;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
+public class UnnecessaryInterfaceDeclarationRule extends AbstractJavaRulechainRule {
+
+    private static final PropertyDescriptor<List<String>> ALLOWED_INTERFACES
+        = PropertyFactory.stringListProperty("allowedInterfaces")
+        .defaultValues("java.io.Serializable")
+        .desc("Interfaces that are allowed to be declared explicitly.")
+        .build();
+
+    public UnnecessaryInterfaceDeclarationRule() {
+        super(ASTClassDeclaration.class);
+        definePropertyDescriptor(ALLOWED_INTERFACES);
+    }
+
+    @Override
+    public Object visit(ASTClassDeclaration node, Object context) {
+        Map<JTypeMirror, JavaNode> directSupertypes = new HashMap<>();
+        ASTList<?> ext = node.children(ASTExtendsList.class).first();
+        ASTList<?> impl = node.children(ASTImplementsList.class).first();
+        Stream.of(ext, impl).filter(Objects::nonNull).forEach(list -> {
+            for (ASTClassType supertypeNode : list.children(ASTClassType.class)) {
+                JTypeMirror supertype = supertypeNode.getTypeMirror();
+                for (Map.Entry<JTypeMirror, JavaNode> supertype1 : directSupertypes.entrySet()) {
+                    checkRelated(supertypeNode, supertype, supertype1.getKey(), context);
+                    checkRelated(supertype1.getValue(), supertype1.getKey(), supertype, context);
+                }
+                directSupertypes.put(supertype, supertypeNode);
+            }
+        });
+        return null;
+    }
+
+    private void checkRelated(JavaNode supertypeNode, JTypeMirror supertype, JTypeMirror supertype1,
+                              Object context) {
+        List<String> allowed = getProperty(ALLOWED_INTERFACES);
+        if (allowed.contains(supertype.toString())) {
+            return;
+        }
+        if (TypeTestUtil.isA(supertype, supertype1)) {
+            asCtx(context).addViolation(supertypeNode, supertype, supertype1);
+        }
+    }
+}

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1804,6 +1804,34 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="UnnecessaryInterfaceDeclaration"
+          language="java"
+          since="7.22.0"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryInterfaceDeclarationRule"
+          message="Unnecessary interface declaration ''{0}'', already provided by ''{1}''."
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryinterfacedeclaration">
+        <description>
+            Implicitly declaring that a class implements an interface already implemented by its
+            superclass or parent interface is not necessary.
+        </description>
+        <priority>4</priority>
+        <example>
+            <![CDATA[
+interface I {
+}
+
+interface J extends I {
+}
+
+class A implements I, J { // Unnecessary to declare that A implements I, since J already extends I
+}
+
+class C extends A implements J { // Unnecessary to declare that C implements J, since A already implements J
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="UnnecessaryLocalBeforeReturn"
           language="java"
           deprecated="true"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationTest.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+/**
+ * Test for {@link UnnecessaryInterfaceDeclarationRule}.
+ */
+public class UnnecessaryInterfaceDeclarationTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryInterfaceDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryInterfaceDeclaration.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_2_0_0.xsd">
+
+    <test-code>
+        <description>class and interfaces</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>7,12,15</expected-linenumbers>
+        <expected-messages>
+            <message>Unnecessary interface declaration 'I', already provided by 'J'.</message>
+            <message>Unnecessary interface declaration 'I', already provided by 'J'.</message>
+            <message>Unnecessary interface declaration 'J', already provided by 'A'.</message>
+        </expected-messages>
+        <code><![CDATA[
+interface I {
+}
+
+interface J extends I {
+}
+
+class A implements I,
+    J {
+}
+
+class B implements J,
+    I {
+}
+
+class C extends A implements J {
+}
+
+class D implements I {
+}
+
+class E extends D implements J {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>interfaces</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>Unnecessary interface declaration 'I', already provided by 'J'.</message>
+        </expected-messages>
+        <code><![CDATA[
+interface I {
+}
+
+interface J extends I {
+}
+
+interface K extends I,
+  J {
+}
+
+interface L extends I {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>serializable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.Serializable;
+
+interface J extends Serializable {
+}
+
+interface K extends J, Serializable {
+}
+
+class A implements J, Serializable {
+}
+
+class B extends A implements Serializable {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>serializable disallowed</description>
+        <rule-property name="allowedInterfaces"/>
+        <expected-problems>3</expected-problems>
+        <code><![CDATA[
+interface J extends java.io.Serializable {
+}
+
+interface K extends J, java.io.Serializable {
+}
+
+class A implements J, java.io.Serializable {
+}
+
+class B extends A implements java.io.Serializable {
+}
+        ]]></code>
+    </test-code>
+</test-data>
+


### PR DESCRIPTION
## Describe the PR

Add a new rule that reports unnecessary "implements" and "extends" declarations.
Similar to https://www.jetbrains.com/help/inspectopedia/RedundantInterfaceDeclaration.html

The IntelliJ's rule has two settings, to allow `Serializable` and/or `Cloneable`. Here I implemented a single property that allows listing arbitrary interfaces, with `Serializable` being the default exemption (it seems to be declared quite often explicitly in JDK and Spring even if not needed).


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

