### PR TITLE
[ci] Use typos gh-action

### DIFF
--- a/.ci/tools/typos.sh
+++ b/.ci/tools/typos.sh
@@ -6,7 +6,7 @@ TYPOS_GH_ANNOTATE=${TYPOS_GH_ANNOTATE:=""}
 # whether to check for a new version of typos
 TYPOS_CHECK_UPDATE=${TYPOS_CHECK_UPDATE:=""}
 
-TYPOS_VERSION="v1.43.5"
+TYPOS_VERSION="v1.44.0"
 if [ -n "$TYPOS_CHECK_UPDATE" ]; then
   echo "Checking for latest typos version..."
   LATEST_TYPO_VERSION=$(curl -s -L \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       - name: Spell Check Repo
-        uses: crate-ci/typos@57b11c6b7e54c402ccd9cda953f1072ec4f78e33 #v1.43.5
+        uses: crate-ci/typos@631208b7aac2daa8b707f55e7331f9112b0e062d #v1.44.0
         # note: don't fail the build on typos, just annotate them
         # so that publish-pull-requests job still runs.
         continue-on-error: true


### PR DESCRIPTION
## Describe the PR

Since https://github.com/crate-ci/typos/pull/1496 has been merged, the gh action should work now.

This has the advantage, that dependabot will keep the version uptodate.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

