### PR TITLE
[core] Fix BaseAntlrTerminalNode getTokenKind to return type instead of index

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNode.java
@@ -63,7 +63,7 @@ public abstract class BaseAntlrTerminalNode<N extends AntlrNode<N>>
     }
 
     protected int getTokenKind() {
-        return antlrNode.symbol.getTokenIndex();
+        return antlrNode.symbol.getType();
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNodeTest.java
@@ -1,51 +1,111 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.ast.impl.antlr4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenSource;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
 class BaseAntlrTerminalNodeTest {
+
     static class TestTerminalNode extends BaseAntlrTerminalNode<TestTerminalNode> {
+
         private final String text;
+
         TestTerminalNode(Token token, String text) {
             super(token);
             this.text = text;
         }
+
         @Override
+        @NonNull
         public String getText() {
             return text;
         }
+
         @Override
+        @NonNull
         public String getXPathNodeName() {
             return "TestTerminalNode";
         }
     }
 
     static class DummyToken implements Token {
+
         private final int type;
         private final int index;
+
         DummyToken(int type, int index) {
             this.type = type;
             this.index = index;
         }
-        @Override public int getType() { return type; }
-        @Override public int getTokenIndex() { return index; }
-        @Override public String getText() { return null; }
-        @Override public int getLine() { return 0; }
-        @Override public int getCharPositionInLine() { return 0; }
-        @Override public int getChannel() { return 0; }
-        @Override public int getStartIndex() { return 0; }
-        @Override public int getStopIndex() { return 0; }
-        @Override public org.antlr.v4.runtime.TokenSource getTokenSource() { return null; }
-        @Override public org.antlr.v4.runtime.CharStream getInputStream() { return null; }
+
+        @Override
+        public int getType() {
+            return type;
+        }
+
+        @Override
+        public int getTokenIndex() {
+            return index;
+        }
+
+        @Override
+        public String getText() {
+            return null;
+        }
+
+        @Override
+        public int getLine() {
+            return 0;
+        }
+
+        @Override
+        public int getCharPositionInLine() {
+            return 0;
+        }
+
+        @Override
+        public int getChannel() {
+            return 0;
+        }
+
+        @Override
+        public int getStartIndex() {
+            return 0;
+        }
+
+        @Override
+        public int getStopIndex() {
+            return 0;
+        }
+
+        @Override
+        public TokenSource getTokenSource() {
+            return null;
+        }
+
+        @Override
+        public CharStream getInputStream() {
+            return null;
+        }
     }
 
     @Test
     void getTokenKindReturnsTokenType() {
         int expectedType = 42;
         int dummyIndex = 99;
+
         DummyToken token = new DummyToken(expectedType, dummyIndex);
+
         TestTerminalNode node = new TestTerminalNode(token, "foo");
+
         // This should return the token type, not the index
         assertEquals(expectedType, node.getTokenKind(), "getTokenKind() should return token type");
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNodeTest.java
@@ -1,0 +1,52 @@
+package net.sourceforge.pmd.lang.ast.impl.antlr4;
+
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseAntlrTerminalNodeTest {
+    static class TestTerminalNode extends BaseAntlrTerminalNode<TestTerminalNode> {
+        private final String text;
+        TestTerminalNode(Token token, String text) {
+            super(token);
+            this.text = text;
+        }
+        @Override
+        public String getText() {
+            return text;
+        }
+        @Override
+        public String getXPathNodeName() {
+            return "TestTerminalNode";
+        }
+    }
+
+    static class DummyToken implements Token {
+        private final int type;
+        private final int index;
+        DummyToken(int type, int index) {
+            this.type = type;
+            this.index = index;
+        }
+        @Override public int getType() { return type; }
+        @Override public int getTokenIndex() { return index; }
+        @Override public String getText() { return null; }
+        @Override public int getLine() { return 0; }
+        @Override public int getCharPositionInLine() { return 0; }
+        @Override public int getChannel() { return 0; }
+        @Override public int getStartIndex() { return 0; }
+        @Override public int getStopIndex() { return 0; }
+        @Override public org.antlr.v4.runtime.TokenSource getTokenSource() { return null; }
+        @Override public org.antlr.v4.runtime.CharStream getInputStream() { return null; }
+    }
+
+    @Test
+    void getTokenKindReturnsTokenType() {
+        int expectedType = 42;
+        int dummyIndex = 99;
+        DummyToken token = new DummyToken(expectedType, dummyIndex);
+        TestTerminalNode node = new TestTerminalNode(token, "foo");
+        // This should return the token type, not the index
+        assertEquals(expectedType, node.getTokenKind(), "getTokenKind() should return token type");
+    }
+}

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTokenAccessTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTokenAccessTest.java
@@ -1,0 +1,44 @@
+package net.sourceforge.pmd.lang.kotlin.ast;
+
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtKotlinFile;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.junit.jupiter.api.Test;
+
+import static net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Minimal test that parses a Kotlin snippet and asserts generated token accessors
+ * which call getToken/getTokens return expected terminal nodes.
+ *
+ * This is to show a bug where antlr4.BaseAntlrTerminalNode#getTokenKind() returns index instead of type (aka kind).
+ */
+public class KotlinParserTokenAccessTest {
+
+    @Test
+    public void testGetTokensInKtAssignmentAndOperator() {
+        String code = "class Foo { fun foo() { var a = 42; a += 1 } }";
+
+        // Parse using KotlinParsingHelper
+        KtKotlinFile root = KotlinParsingHelper.DEFAULT.parse(code);
+
+        assertNotNull(root);
+
+        // Traverse to the first function declaration in the file
+        KtFunctionDeclaration fn = root.descendants(KtFunctionDeclaration.class).first();
+        assertNotNull(fn, "Expected a function declaration in the parsed Kotlin file");
+
+        // Find the first KtAssignmentAndOperator node within the function body
+        KtAssignmentAndOperator idNode = fn.descendants(KtAssignmentAndOperator.class).first();
+        assertNotNull(idNode, "Expected a assignmentAndOperator within the function node");
+        // Call the generated accessor that returns the ADD_ASSIGNMENT terminal node.
+        // This calls getToken/getTokens under the hood and will exercise
+        // BaseAntlrInnerNode#getToken(s).
+        TerminalNode tn = idNode.ADD_ASSIGNMENT();
+        assertNotNull(tn, "Expected an ADD_ASSIGNMENT terminal node");
+        assertEquals("+=", tn.getText());
+        assertEquals(ADD_ASSIGNMENT, tn.getSymbol().getType());
+    }
+}

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTokenAccessTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTokenAccessTest.java
@@ -1,13 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.kotlin.ast;
 
-import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
-import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtKotlinFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.junit.jupiter.api.Test;
 
-import static net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtAssignmentAndOperator;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtKotlinFile;
 
 /**
  * Minimal test that parses a Kotlin snippet and asserts generated token accessors
@@ -15,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  *
  * This is to show a bug where antlr4.BaseAntlrTerminalNode#getTokenKind() returns index instead of type (aka kind).
  */
-public class KotlinParserTokenAccessTest {
+class KotlinParserTokenAccessTest {
 
     @Test
-    public void testGetTokensInKtAssignmentAndOperator() {
+    void testGetTokensInKtAssignmentAndOperator() {
         String code = "class Foo { fun foo() { var a = 42; a += 1 } }";
 
         // Parse using KotlinParsingHelper
@@ -39,6 +44,6 @@ public class KotlinParserTokenAccessTest {
         TerminalNode tn = idNode.ADD_ASSIGNMENT();
         assertNotNull(tn, "Expected an ADD_ASSIGNMENT terminal node");
         assertEquals("+=", tn.getText());
-        assertEquals(ADD_ASSIGNMENT, tn.getSymbol().getType());
+        assertEquals(KotlinParser.ADD_ASSIGNMENT, tn.getSymbol().getType());
     }
 }


### PR DESCRIPTION
## Describe the PR

This fixes return value of `net.sourceforge.pmd.lang.ast.impl.antlr4.BaseAntlrTerminalNode#getTokenKind` and adds two unit tests to validate the behaviour.

## Related issues

- Fix #6471 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

