### PR TITLE
chore(deps): bump nokogiri to 1.19.1

### DIFF
--- a/.ci/files/Gemfile.lock
+++ b/.ci/files/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       strscan (>= 3.1.1)
     logger (1.7.0)
     logger-colors (1.0.0)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     pmdtester (1.6.2)

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
     minitest (5.25.5)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)


### PR DESCRIPTION
- Fixes https://github.com/pmd/pmd/security/dependabot/94
- Fixes https://github.com/pmd/pmd/security/dependabot/95
