### PR TITLE
[core] Fix stored XSS in VBHTMLRenderer and YAHTMLRenderer

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -24,6 +24,16 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚀️ New and noteworthy
 
+#### Security fixes
+* This release fixes a stored XSS vulnerability in VBHTMLRenderer and YAHTMLRenderer via unescaped violation messages.  
+  Affects CI/CD pipelines that run PMD with `--format vbhtml` or `--format yahtml` on untrusted source code
+  (e.g. pull requests from external contributors) and expose the HTML report as a build artifact.
+  JavaScript executes in the browser context of anyone who opens the report.  
+  Note: The default `html` format is **not affected** by unescaped violation messages, but a similar problem
+  existed with suppressed violation markers.  
+  If you use these reports, it is recommended to upgrade PMD.  
+  Reported by [Smaran Chand](https://github.com/smaranchand) (@smaranchand).
+
 ### 🌟️ New and Changed Rules
 #### New Rules
 * The new Java rule {% rule java/codestyle/UnnecessaryInterfaceDeclaration %} detects classes that
@@ -43,6 +53,7 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛️ Fixed Issues
 * core
   * [#6471](https://github.com/pmd/pmd/issues/6471): \[core] BaseAntlrTerminalNode should return type instead of index for getTokenKind()
+  * [#6475](https://github.com/pmd/pmd/issues/6475): \[core] Fix stored XSS in VBHTMLRenderer and YAHTMLRenderer
 * doc
   * [#6396](https://github.com/pmd/pmd/pull/6396): \[doc] Mention test-pmd-tool as alternative for testing
 * java-bestpractices

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.renderers;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import net.sourceforge.pmd.reporting.Report;
 import net.sourceforge.pmd.reporting.RuleViolation;
 
@@ -26,6 +28,10 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
     @Override
     public String defaultFileExtension() {
         return "vb.html";
+    }
+
+    private static String escape(String s) {
+        return StringEscapeUtils.escapeHtml4(s);
     }
 
     @Override
@@ -55,7 +61,7 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
                 }
                 filename = nextFilename;
                 sb.append("<table border=\"0\" width=\"80%\">");
-                sb.append("<tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;").append(filename)
+                sb.append("<tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;").append(escape(filename))
                         .append("</font></tr>");
                 sb.append(lineSep);
             }
@@ -68,7 +74,7 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
 
             colorize = !colorize;
             sb.append("<td width=\"50\" align=\"right\"><font class=body>").append(rv.getBeginLine()).append("&nbsp;&nbsp;&nbsp;</font></td>");
-            sb.append("<td><font class=body>").append(rv.getDescription()).append("</font></td>");
+            sb.append("<td><font class=body>").append(escape(rv.getDescription())).append("</font></td>");
             sb.append("</tr>");
             sb.append(lineSep);
             writer.write(sb.toString());
@@ -97,8 +103,8 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
                     sb.append("<tr id=RowColor2>");
                 }
                 colorize = !colorize;
-                sb.append("<td><font class=body>").append(determineFileName(error.getFileId())).append("</font></td>");
-                sb.append("<td><font class=body><pre>").append(error.getDetail()).append("</pre></font></td></tr>");
+                sb.append("<td><font class=body>").append(escape(determineFileName(error.getFileId()))).append("</font></td>");
+                sb.append("<td><font class=body><pre>").append(escape(error.getDetail())).append("</pre></font></td></tr>");
             }
             sb.append("</table>");
             writer.write(sb.toString());
@@ -116,8 +122,8 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
                     sb.append("<tr id=RowColor2>");
                 }
                 colorize = !colorize;
-                sb.append("<td><font class=body>").append(error.rule().getName()).append("</font></td>");
-                sb.append("<td><font class=body>").append(error.issue()).append("</font></td></tr>");
+                sb.append("<td><font class=body>").append(escape(error.rule().getName())).append("</font></td>");
+                sb.append("<td><font class=body>").append(escape(error.issue())).append("</font></td></tr>");
             }
             sb.append("</table>");
             writer.write(sb.toString());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.renderers;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.LinkedList;
@@ -14,6 +15,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -45,6 +47,10 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
     @Override
     public String defaultFileExtension() {
         return "html";
+    }
+
+    private static String escape(String s) {
+        return StringEscapeUtils.escapeHtml4(s);
     }
 
     private void addViolation(RuleViolation violation) {
@@ -118,17 +124,17 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
 
             for (ReportNode node : reportNodesByPackage.values()) {
                 out.print("        <tr><td><b>");
-                out.print(node.getPackageName());
+                out.print(escape(node.getPackageName()));
                 out.print("</b></td> <td>");
                 if (node.hasViolations()) {
                     out.print("<a href=\"");
-                    out.print(node.getClassName());
+                    out.print(URLEncoder.encode(node.getClassName(), "UTF-8"));
                     out.print(".html");
                     out.print("\">");
-                    out.print(node.getClassName());
+                    out.print(escape(node.getClassName()));
                     out.print("</a>");
                 } else {
-                    out.print(node.getClassName());
+                    out.print(escape(node.getClassName()));
                 }
                 out.print("</td> <td>");
                 out.print(node.getViolationCount());
@@ -151,32 +157,32 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
                     out.println("    <head>");
                     out.println("        <meta charset=\"UTF-8\">");
                     out.print("        <title>PMD - ");
-                    out.print(node.getClassName());
+                    out.print(escape(node.getClassName()));
                     out.println("</title>");
                     out.println("    </head>");
                     out.println("    <body>");
                     out.println("        <h2>Class View</h2>");
                     out.print("        <h3 align=\"center\">Class: ");
-                    out.print(node.getClassName());
+                    out.print(escape(node.getClassName()));
                     out.println("</h3>");
                     out.println("        <table border=\"\" align=\"center\" cellspacing=\"0\" cellpadding=\"3\">");
                     out.println("        <tr><th>Method</th><th>Violation</th></tr>");
                     for (RuleViolation violation : node.getViolations()) {
                         out.print("        <tr><td>");
                         String methodName = violation.getAdditionalInfo().get(RuleViolation.METHOD_NAME);
-                        out.print(StringUtil.nullToEmpty(methodName));
+                        out.print(escape(StringUtil.nullToEmpty(methodName)));
                         out.print("</td><td>");
                         out.print("<table border=\"0\">");
 
-                        out.print(renderViolationRow("Rule:", violation.getRule().getName()));
-                        out.print(renderViolationRow("Description:", violation.getDescription()));
+                        out.print(renderViolationRowEscaped("Rule:", violation.getRule().getName()));
+                        out.print(renderViolationRowEscaped("Description:", violation.getDescription()));
 
                         String variableName = violation.getAdditionalInfo().get(RuleViolation.VARIABLE_NAME);
                         if (StringUtils.isNotBlank(variableName)) {
-                            out.print(renderViolationRow("Variable:", variableName));
+                            out.print(renderViolationRowEscaped("Variable:", variableName));
                         }
 
-                        out.print(renderViolationRow("Line:", violation.getEndLine() > 0
+                        out.print(renderViolationRowEscaped("Line:", violation.getEndLine() > 0
                                 ? violation.getBeginLine() + " and " + violation.getEndLine()
                                 : String.valueOf(violation.getBeginLine())));
 
@@ -193,12 +199,12 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
         }
     }
 
-    private String renderViolationRow(String name, String value) {
+    private String renderViolationRowEscaped(String name, String value) {
         return "<tr><td><b>"
-            + name
+            + escape(name)
             + "</b></td>"
             + "<td>"
-            + value
+            + escape(value)
             + "</td></tr>";
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -4,14 +4,27 @@
 
 package net.sourceforge.pmd.renderers;
 
+import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.rule.Rule;
 import net.sourceforge.pmd.reporting.Report.ConfigurationError;
 import net.sourceforge.pmd.reporting.Report.ProcessingError;
+import net.sourceforge.pmd.reporting.RuleViolation;
 
 class VBHTMLRendererTest extends AbstractRendererTest {
 
     @Override
     Renderer getRenderer() {
         return new VBHTMLRenderer();
+    }
+
+    private String getEscapedRuleMessage() {
+        return "This should be escaped: &quot;&lt;script&gt;alert('test')&lt;/script&gt;&quot;.";
+    }
+
+    @Override
+    protected RuleViolation newRuleViolation(int beginLine, int beginColumn, int endLine, int endColumn, Rule rule) {
+        FileLocation loc = createLocation(beginLine, beginColumn, endLine, endColumn);
+        return newRuleViolation(rule, loc, "This should be escaped: \"<script>alert('test')</script>\".");
     }
 
     @Override
@@ -27,7 +40,7 @@ class VBHTMLRendererTest extends AbstractRendererTest {
                 + EOL
                 + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;" + getSourceCodeFilename() + "</font></tr>"
                 + EOL
-                + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>blah</font></td></tr>"
+                + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>" + getEscapedRuleMessage() + "</font></td></tr>"
                 + EOL + "</table><br></center></body></html>" + EOL;
     }
 
@@ -46,6 +59,7 @@ class VBHTMLRendererTest extends AbstractRendererTest {
 
     @Override
     String getExpectedMultiple() {
+        String ruleDescription = getEscapedRuleMessage();
         return "<html><head><title>PMD</title></head><style type=\"text/css\"><!--" + EOL
                 + "body { background-color: white; font-family:verdana, arial, helvetica, geneva; font-size: 16px; font-style: italic; color: black; }"
                 + EOL
@@ -57,9 +71,9 @@ class VBHTMLRendererTest extends AbstractRendererTest {
                 + EOL
                 + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;" + getSourceCodeFilename() + "</font></tr>"
                 + EOL
-                + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>blah</font></td></tr>"
+                + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>" + ruleDescription + "</font></td></tr>"
                 + EOL
-                + "<tr id=RowColor1><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>blah</font></td></tr>"
+                + "<tr id=RowColor1><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>" + ruleDescription + "</font></td></tr>"
                 + EOL + "</table><br></center></body></html>" + EOL;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -46,7 +46,7 @@ class YAHTMLRendererTest extends AbstractRendererTest {
         FileLocation loc = createLocation(beginLine, beginColumn, endLine, endColumn);
         Map<String, String> additionalInfo = CollectionUtil.mapOf(RuleViolation.PACKAGE_NAME, packageNameArg,
                                                                   RuleViolation.CLASS_NAME, classNameArg);
-        return InternalApiBridge.createRuleViolation(new FooRule(), loc, "blah", additionalInfo);
+        return InternalApiBridge.createRuleViolation(new FooRule(), loc, "This should be escaped: \"<script>alert('test')</script>\".", additionalInfo);
     }
 
     @Override

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
@@ -9,8 +9,8 @@
         <h3 align="center">Class: YAHTMLSampleClass1</h3>
         <table border="" align="center" cellspacing="0" cellpadding="3">
         <tr><th>Method</th><th>Violation</th></tr>
-        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
-        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>This should be escaped: &quot;&lt;script&gt;alert('test')&lt;/script&gt;&quot;.</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>This should be escaped: &quot;&lt;script&gt;alert('test')&lt;/script&gt;&quot;.</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
         </table>
     </body>
 </html>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
@@ -9,7 +9,7 @@
         <h3 align="center">Class: YAHTMLSampleClass2</h3>
         <table border="" align="center" cellspacing="0" cellpadding="3">
         <tr><th>Method</th><th>Violation</th></tr>
-        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>This should be escaped: &quot;&lt;script&gt;alert('test')&lt;/script&gt;&quot;.</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
         </table>
     </body>
 </html>


### PR DESCRIPTION
## Describe the PR

These renders don't always escape the output properly.



## Related issues

- Refs https://github.com/pmd/pmd/security/advisories/GHSA-8rr6-2qw5-pc7r

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

