### PR TITLE
[doc] CPD: document --report-file parameter

### DIFF
--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -1169,6 +1169,12 @@ p.post-meta time {
     margin-right: 0px;
 }
 
+span.label {
+    border-radius: 0.375rem;
+    padding: 0.35em 0.64em;
+    font-size: 0.75em;
+}
+
 span.label.label-default {
     background-color: gray;
 }
@@ -1176,6 +1182,11 @@ span.label.label-default {
 span.label.label-primary {
     background-color: #f0ad4e;
 }
+
+span.label.label-info {
+    background-color: deepskyblue;
+}
+
 .col-lg-12 .nav li a {
     background-color: white;
 }

--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -4,7 +4,7 @@ tags: [cpd, userdocs]
 summary: "Learn how to use CPD, the copy-paste detector shipped with PMD."
 permalink: pmd_userdocs_cpd.html
 author: Tom Copeland <tom@infoether.com>
-last_updated: August 2025 (7.17.0)
+last_updated: March 2026 (7.23.0)
 ---
 
 ## Overview
@@ -77,7 +77,7 @@ exactly identical.
 
 {% include callout.html 
     type="primary"
-    content="The file collection options are common to PMD and CPD and [described over there](pmd_userdocs_cli_reference.html#file-collection-options)." %}
+    content="<span class='label label-info'>Since 7.14.0</span> The file collection options are common to PMD and CPD and [described over there](pmd_userdocs_cli_reference.html#file-collection-options)." %}
 
 <table>
     <tr>
@@ -113,6 +113,10 @@ exactly identical.
                description="Output format of the analysis report. The available formats
                             are described [here](#available-report-formats)."
                default="text"
+    %}
+    {% include custom/cli_option_row.html options="--report-file,-r"
+               option_arg="path"
+               description="<span class='label label-info'>Since 7.14.0</span> Path to a file to which report output is written. The file is created if it does not exist. If this option is not specified, the report is rendered to standard output."
     %}
     {% include custom/cli_option_row.html options="--[no-]fail-on-error"
                description="Specifies whether CPD exits with non-zero status if recoverable errors occurred.


### PR DESCRIPTION
## Describe the PR

While working on https://github.com/pmd/pmd-regression-tester/pull/169 I noticed, that the parameter `--report-file` is missing in the documentation.

## Related issues

- Refs #5731

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

