### PR TITLE
[apex] New Rule: AvoidInterfaceAsMapKeyRule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -61,6 +61,10 @@ public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> 
         return multifileAnalysis.getFileIssues(fileId.getAbsolutePath());
     }
 
+    public @NonNull ApexMultifileAnalysis getMultifileAnalysis() {
+        return multifileAnalysis;
+    }
+
     @Override
     public String getDefiningType() {
         // an apex file can contain only one top level type

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -20,15 +21,11 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.lang.apex.ApexLanguageProcessor;
 import net.sourceforge.pmd.lang.apex.ApexLanguageProperties;
 
-import com.nawforce.apexlink.api.MethodSummary;
 import com.nawforce.apexlink.api.Org;
 import com.nawforce.apexlink.api.Package;
-import com.nawforce.apexlink.api.ParameterSummary;
 import com.nawforce.apexlink.api.TypeSummary;
 import com.nawforce.pkgforce.diagnostics.LoggerOps;
-import com.nawforce.pkgforce.modifiers.Modifier;
 import com.nawforce.pkgforce.names.TypeIdentifier;
-import com.nawforce.pkgforce.names.TypeName;
 import io.github.apexdevtools.api.Issue;
 
 /**
@@ -126,16 +123,19 @@ public final class ApexMultifileAnalysis {
     }
 
     /**
-     * Returns true if the org contains a type with the given simple name whose nature is "interface".
+     * Returns true if any type summary in the org matches the given predicate.
+     * This enables rules to define their own matching logic using lambdas or method references.
      * Returns false when multifile analysis is unavailable.
+     *
+     * @param predicate the predicate to test each TypeSummary against
+     * @return true if any TypeSummary matches the predicate
      */
-    public boolean isInterfaceInOrg(String simpleTypeName) {
+    public boolean anyTypeMatches(Predicate<TypeSummary> predicate) {
         if (org == null) {
             return false;
         }
         for (TypeSummary summary : getAllTypeSummaries()) {
-            if ("interface".equalsIgnoreCase(summary.nature())
-                    && summary.typeName().name().value().equalsIgnoreCase(simpleTypeName)) {
+            if (predicate.test(summary)) {
                 return true;
             }
         }
@@ -143,29 +143,12 @@ public final class ApexMultifileAnalysis {
     }
 
     /**
-     * Returns true if the org contains an abstract class that implements the given interface (by simple name)
-     * and also defines {@code equals(Object)} or {@code hashCode()}.
-     * Returns false when multifile analysis is unavailable.
+     * Returns an unmodifiable list of all type summaries in the org.
+     * Returns an empty list when multifile analysis is unavailable.
+     * This enables rules to perform complex cross-type analysis.
      */
-    public boolean hasAbstractImplementorWithEqualsOrHashCode(String interfaceSimpleName) {
-        if (org == null) {
-            return false;
-        }
-        for (TypeSummary summary : getAllTypeSummaries()) {
-            if (!"class".equalsIgnoreCase(summary.nature())) {
-                continue;
-            }
-            if (!isAbstractModifier(summary)) {
-                continue;
-            }
-            if (!summaryImplementsInterface(summary, interfaceSimpleName)) {
-                continue;
-            }
-            if (summaryDefinesEqualsOrHashCode(summary)) {
-                return true;
-            }
-        }
-        return false;
+    public List<TypeSummary> getTypeSummaries() {
+        return getAllTypeSummaries();
     }
 
     /**
@@ -200,45 +183,6 @@ public final class ApexMultifileAnalysis {
         while (nested.hasNext()) {
             collectTypeSummaries(nested.next(), result);
         }
-    }
-
-    private static boolean isAbstractModifier(TypeSummary summary) {
-        scala.collection.Iterator<Modifier> iter = summary.modifiers().iterator();
-        while (iter.hasNext()) {
-            if ("abstract".equalsIgnoreCase(iter.next().name())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean summaryImplementsInterface(TypeSummary summary, String interfaceSimpleName) {
-        scala.collection.Iterator<TypeName> iter = summary.interfaces().iterator();
-        while (iter.hasNext()) {
-            if (iter.next().name().value().equalsIgnoreCase(interfaceSimpleName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean summaryDefinesEqualsOrHashCode(TypeSummary summary) {
-        scala.collection.Iterator<MethodSummary> iter = summary.methods().iterator();
-        while (iter.hasNext()) {
-            MethodSummary method = iter.next();
-            String methodName = method.name();
-            if ("hashCode".equalsIgnoreCase(methodName) && !method.parameters().iterator().hasNext()) {
-                return true;
-            }
-            if ("equals".equalsIgnoreCase(methodName)) {
-                scala.collection.Iterator<ParameterSummary> params = method.parameters().iterator();
-                if (params.hasNext() && "Object".equalsIgnoreCase(params.next().typeName().name().value())
-                        && !params.hasNext()) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     /*

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.multifile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,8 +20,15 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.lang.apex.ApexLanguageProcessor;
 import net.sourceforge.pmd.lang.apex.ApexLanguageProperties;
 
+import com.nawforce.apexlink.api.MethodSummary;
 import com.nawforce.apexlink.api.Org;
+import com.nawforce.apexlink.api.Package;
+import com.nawforce.apexlink.api.ParameterSummary;
+import com.nawforce.apexlink.api.TypeSummary;
 import com.nawforce.pkgforce.diagnostics.LoggerOps;
+import com.nawforce.pkgforce.modifiers.Modifier;
+import com.nawforce.pkgforce.names.TypeIdentifier;
+import com.nawforce.pkgforce.names.TypeName;
 import io.github.apexdevtools.api.Issue;
 
 /**
@@ -43,6 +51,9 @@ public final class ApexMultifileAnalysis {
     // Create a new org for each analysis
     // Null if failed.
     private final @Nullable Org org;
+
+    // Lazily computed flat list of all TypeSummary objects in the org (including nested types).
+    private List<TypeSummary> allTypeSummaries = null;
 
     static {
         // Setup logging
@@ -112,6 +123,122 @@ public final class ApexMultifileAnalysis {
         // Extract issues for a specific metadata file from the org
         return org == null ? Collections.emptyList()
                            : Collections.unmodifiableList(Arrays.asList(org.issues().issuesForFile(filename)));
+    }
+
+    /**
+     * Returns true if the org contains a type with the given simple name whose nature is "interface".
+     * Returns false when multifile analysis is unavailable.
+     */
+    public boolean isInterfaceInOrg(String simpleTypeName) {
+        if (org == null) {
+            return false;
+        }
+        for (TypeSummary summary : getAllTypeSummaries()) {
+            if ("interface".equalsIgnoreCase(summary.nature())
+                    && summary.typeName().name().value().equalsIgnoreCase(simpleTypeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the org contains an abstract class that implements the given interface (by simple name)
+     * and also defines {@code equals(Object)} or {@code hashCode()}.
+     * Returns false when multifile analysis is unavailable.
+     */
+    public boolean hasAbstractImplementorWithEqualsOrHashCode(String interfaceSimpleName) {
+        if (org == null) {
+            return false;
+        }
+        for (TypeSummary summary : getAllTypeSummaries()) {
+            if (!"class".equalsIgnoreCase(summary.nature())) {
+                continue;
+            }
+            if (!isAbstractModifier(summary)) {
+                continue;
+            }
+            if (!summaryImplementsInterface(summary, interfaceSimpleName)) {
+                continue;
+            }
+            if (summaryDefinesEqualsOrHashCode(summary)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns a flat list of all TypeSummary objects in the org, including nested types.
+     * The result is computed once and then cached.
+     */
+    private synchronized List<TypeSummary> getAllTypeSummaries() {
+        if (allTypeSummaries != null) {
+            return allTypeSummaries;
+        }
+        if (org == null) {
+            allTypeSummaries = Collections.emptyList();
+            return allTypeSummaries;
+        }
+        List<TypeSummary> summaries = new ArrayList<>();
+        for (Package pkg : org.getPackages()) {
+            for (TypeIdentifier typeId : pkg.getTypeIdentifiers(false)) {
+                TypeSummary summary = pkg.getSummaryOfType(typeId);
+                if (summary != null) {
+                    collectTypeSummaries(summary, summaries);
+                }
+            }
+        }
+        allTypeSummaries = Collections.unmodifiableList(summaries);
+        return allTypeSummaries;
+    }
+
+    /** Adds the given summary and all its nested type summaries (recursively) to the list. */
+    private static void collectTypeSummaries(TypeSummary summary, List<TypeSummary> result) {
+        result.add(summary);
+        scala.collection.Iterator<TypeSummary> nested = summary.nestedTypes().iterator();
+        while (nested.hasNext()) {
+            collectTypeSummaries(nested.next(), result);
+        }
+    }
+
+    private static boolean isAbstractModifier(TypeSummary summary) {
+        scala.collection.Iterator<Modifier> iter = summary.modifiers().iterator();
+        while (iter.hasNext()) {
+            if ("abstract".equalsIgnoreCase(iter.next().name())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean summaryImplementsInterface(TypeSummary summary, String interfaceSimpleName) {
+        scala.collection.Iterator<TypeName> iter = summary.interfaces().iterator();
+        while (iter.hasNext()) {
+            if (iter.next().name().value().equalsIgnoreCase(interfaceSimpleName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean summaryDefinesEqualsOrHashCode(TypeSummary summary) {
+        scala.collection.Iterator<MethodSummary> iter = summary.methods().iterator();
+        while (iter.hasNext()) {
+            MethodSummary method = iter.next();
+            String methodName = method.name();
+            if ("hashCode".equalsIgnoreCase(methodName) && !method.parameters().iterator().hasNext()) {
+                return true;
+            }
+            if ("equals".equalsIgnoreCase(methodName)) {
+                scala.collection.Iterator<ParameterSummary> params = method.parameters().iterator();
+                if (params.hasNext() && "Object".equalsIgnoreCase(params.next().typeName().name().value())
+                        && !params.hasNext()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /*

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysis.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -120,26 +119,6 @@ public final class ApexMultifileAnalysis {
         // Extract issues for a specific metadata file from the org
         return org == null ? Collections.emptyList()
                            : Collections.unmodifiableList(Arrays.asList(org.issues().issuesForFile(filename)));
-    }
-
-    /**
-     * Returns true if any type summary in the org matches the given predicate.
-     * This enables rules to define their own matching logic using lambdas or method references.
-     * Returns false when multifile analysis is unavailable.
-     *
-     * @param predicate the predicate to test each TypeSummary against
-     * @return true if any TypeSummary matches the predicate
-     */
-    public boolean anyTypeMatches(Predicate<TypeSummary> predicate) {
-        if (org == null) {
-            return false;
-        }
-        for (TypeSummary summary : getAllTypeSummaries()) {
-            if (predicate.test(summary)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
@@ -5,20 +5,15 @@
 package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTApexFile;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclarationStatements;
-import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileAnalysis;
@@ -26,14 +21,27 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 
+import com.nawforce.apexlink.api.MethodSummary;
+import com.nawforce.apexlink.api.ParameterSummary;
+import com.nawforce.apexlink.api.TypeSummary;
+import com.nawforce.pkgforce.modifiers.Modifier;
+import com.nawforce.pkgforce.names.TypeName;
+
 /**
  * Flags use of an interface as Map key when that interface has an implementing class
  * that is abstract and defines equals or hashCode. In Apex, Map operations like
  * containsKey do not dispatch to the correct equals/hashCode in that case.
  *
+ * <p>Requires multifile analysis: set the {@code PMD_APEX_ROOT_DIRECTORY} environment variable
+ * to the root of your SFDX project (where {@code sfdx-project.json} lives). Without it the
+ * rule produces no violations.
+ *
  * @see <a href="https://github.com/pmd/pmd/issues/6492">Issue 6492</a>
  */
 public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AvoidInterfaceAsMapKeyRule.class);
+    private static boolean warnedAboutMissingOrg = false;
 
     @Override
     protected @NonNull RuleTargetSelector buildTargetSelector() {
@@ -42,32 +50,20 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTApexFile node, Object data) {
-        List<MapKeyUsage> mapKeyUsages = collectMapKeyUsages(node);
         ApexMultifileAnalysis mfa = node.getMultifileAnalysis();
-
-        if (!mfa.isFailed()) {
-            // Org is loaded: use cross-file type hierarchy for accurate detection.
-            for (MapKeyUsage usage : mapKeyUsages) {
-                String keySimpleName = usage.keyTypeSimpleName;
-                if (mfa.isInterfaceInOrg(keySimpleName)
-                        && mfa.hasAbstractImplementorWithEqualsOrHashCode(keySimpleName)) {
-                    asCtx(data).addViolation(usage.reportNode);
-                }
+        if (mfa.isFailed()) {
+            if (!warnedAboutMissingOrg) {
+                warnedAboutMissingOrg = true;
+                LOG.warn("AvoidInterfaceAsMapKey rule not enforced: multifile analysis unavailable. "
+                        + "Set PMD_APEX_ROOT_DIRECTORY to enable cross-file type resolution.");
             }
-        } else {
-            // No org available: fall back to single-file analysis.
-            Set<String> interfaceSimpleNames = getInterfaceSimpleNamesInFile(node);
-            Map<String, ASTUserClass> classesBySimpleName = getClassesBySimpleName(node);
-
-            for (MapKeyUsage usage : mapKeyUsages) {
-                String keySimpleName = usage.keyTypeSimpleName;
-                if (!interfaceSimpleNames.contains(keySimpleName)) {
-                    continue;
-                }
-                Set<ASTUserClass> implementors = findImplementorsOf(keySimpleName, classesBySimpleName);
-                if (hasAbstractImplementorWithEqualsOrHashCode(implementors, classesBySimpleName)) {
-                    asCtx(data).addViolation(usage.reportNode);
-                }
+            return data;
+        }
+        List<TypeSummary> allTypes = mfa.getTypeSummaries();
+        for (MapKeyUsage usage : collectMapKeyUsages(node)) {
+            TypeHierarchyChecker checker = new TypeHierarchyChecker(usage.keyTypeSimpleName, allTypes);
+            if (checker.isViolation()) {
+                asCtx(data).addViolation(usage.reportNode);
             }
         }
         return data;
@@ -81,8 +77,7 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
             if (typeName != null && typeName.startsWith("Map<")) {
                 List<String> args = field.getTypeArguments();
                 if (args.size() >= 2) {
-                    String keyType = args.get(0);
-                    usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), field));
+                    usages.add(new MapKeyUsage(Helper.getSimpleTypeName(args.get(0)), field));
                 }
             }
         }
@@ -104,131 +99,6 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
         return usages;
     }
 
-    private Set<String> getInterfaceSimpleNamesInFile(ASTApexFile root) {
-        Set<String> names = new HashSet<>();
-        for (ASTUserInterface iface : root.descendants(ASTUserInterface.class).crossFindBoundaries()) {
-            names.add(iface.getSimpleName());
-        }
-        return names;
-    }
-
-    private Map<String, ASTUserClass> getClassesBySimpleName(ASTApexFile root) {
-        Map<String, ASTUserClass> map = new HashMap<>();
-        for (ASTUserClass clazz : root.descendants(ASTUserClass.class).crossFindBoundaries()) {
-            map.put(clazz.getSimpleName(), clazz);
-        }
-        return map;
-    }
-
-    /**
-     * Find all classes in the file that implement the given interface (directly or via superclass).
-     */
-    private Set<ASTUserClass> findImplementorsOf(String interfaceSimpleName, Map<String, ASTUserClass> classesBySimpleName) {
-        Set<ASTUserClass> implementors = new HashSet<>();
-        for (ASTUserClass clazz : classesBySimpleName.values()) {
-            if (directlyImplementsInterface(clazz, interfaceSimpleName)) {
-                implementors.add(clazz);
-            }
-        }
-        // Add classes that extend an implementor (transitive)
-        boolean changed;
-        do {
-            changed = false;
-            for (ASTUserClass clazz : classesBySimpleName.values()) {
-                if (implementors.contains(clazz)) {
-                    continue;
-                }
-                String superName = clazz.getSuperClassName();
-                String superSimple = Helper.getSimpleTypeName(superName);
-                ASTUserClass superClass = classesBySimpleName.get(superSimple);
-                if (superClass != null && implementors.contains(superClass)) {
-                    implementors.add(clazz);
-                    changed = true;
-                }
-            }
-        } while (changed);
-        return implementors;
-    }
-
-    private boolean directlyImplementsInterface(ASTUserClass clazz, String interfaceSimpleName) {
-        for (String iface : clazz.getInterfaceNames()) {
-            if (Helper.getSimpleTypeName(iface).equals(interfaceSimpleName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean hasAbstractImplementorWithEqualsOrHashCode(
-            Set<ASTUserClass> implementors,
-            Map<String, ASTUserClass> classesBySimpleName) {
-        for (ASTUserClass clazz : implementors) {
-            if (abstractClassDefinesEqualsOrHashCodeInChain(clazz, classesBySimpleName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Walk up the class chain; if any class in the chain is abstract and defines equals or hashCode, return true.
-     */
-    private boolean abstractClassDefinesEqualsOrHashCodeInChain(
-            ASTUserClass clazz,
-            Map<String, ASTUserClass> classesBySimpleName) {
-        ASTUserClass current = clazz;
-        Set<ASTUserClass> visited = new HashSet<>();
-        while (current != null && visited.add(current)) {
-            if (current.getModifiers() != null && current.getModifiers().isAbstract() && definesEqualsOrHashCode(current)) {
-                return true;
-            }
-            String superName = current.getSuperClassName();
-            if (superName.isEmpty()) {
-                break;
-            }
-            current = classesBySimpleName.get(Helper.getSimpleTypeName(superName));
-        }
-        return false;
-    }
-
-    private boolean definesEqualsOrHashCode(ASTUserClass clazz) {
-        for (ASTMethod method : clazz.children(ASTMethod.class)) {
-            if (isEquals(method) || isHashCode(method)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isEquals(ASTMethod method) {
-        if (!"equals".equalsIgnoreCase(method.getImage())) {
-            return false;
-        }
-        int paramCount = 0;
-        String paramType = null;
-        for (int i = 0; i < method.getNumChildren(); i++) {
-            ApexNode<?> child = method.getChild(i);
-            if (child instanceof ASTParameter) {
-                paramCount++;
-                paramType = ((ASTParameter) child).getType();
-            }
-        }
-        return paramCount == 1 && "Object".equalsIgnoreCase(Helper.getSimpleTypeName(paramType != null ? paramType : ""));
-    }
-
-    private boolean isHashCode(ASTMethod method) {
-        if (!"hashCode".equalsIgnoreCase(method.getImage())) {
-            return false;
-        }
-        int paramCount = 0;
-        for (int i = 0; i < method.getNumChildren(); i++) {
-            if (method.getChild(i) instanceof ASTParameter) {
-                paramCount++;
-            }
-        }
-        return paramCount == 0;
-    }
-
     private static final class MapKeyUsage {
         final String keyTypeSimpleName;
         final ApexNode<?> reportNode;
@@ -236,6 +106,144 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
         MapKeyUsage(String keyTypeSimpleName, ApexNode<?> reportNode) {
             this.keyTypeSimpleName = keyTypeSimpleName;
             this.reportNode = reportNode;
+        }
+    }
+
+    /**
+     * Checks if a given interface name triggers the Map key dispatch bug.
+     * The bug occurs when:
+     * 1. The key type is an interface
+     * 2. There's an abstract class implementing that interface
+     * 3. Either the abstract class OR any class extending it defines equals/hashCode
+     */
+    private static final class TypeHierarchyChecker {
+        private final String interfaceSimpleName;
+        private final List<TypeSummary> allTypes;
+
+        TypeHierarchyChecker(String interfaceSimpleName, List<TypeSummary> allTypes) {
+            this.interfaceSimpleName = interfaceSimpleName;
+            this.allTypes = allTypes;
+        }
+
+        /**
+         * Returns true if using this interface as a Map key would trigger the dispatch bug.
+         */
+        boolean isViolation() {
+            // Step 1: Verify it's actually an interface
+            if (!isInterfaceInOrg()) {
+                return false;
+            }
+
+            // Step 2: Find all abstract classes implementing this interface
+            List<TypeSummary> abstractImplementors = findAbstractImplementors();
+            if (abstractImplementors.isEmpty()) {
+                return false;
+            }
+
+            // Step 3: For each abstract implementor, check if it or any subclass defines equals/hashCode
+            for (TypeSummary abstractImpl : abstractImplementors) {
+                if (definesEqualsOrHashCode(abstractImpl)) {
+                    return true;
+                }
+                // Check all classes that extend this abstract class
+                if (anySubclassDefinesEqualsOrHashCode(abstractImpl)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isInterfaceInOrg() {
+            for (TypeSummary summary : allTypes) {
+                if ("interface".equalsIgnoreCase(summary.nature())
+                        && summary.typeName().name().value().equalsIgnoreCase(interfaceSimpleName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private List<TypeSummary> findAbstractImplementors() {
+            List<TypeSummary> result = new ArrayList<>();
+            for (TypeSummary summary : allTypes) {
+                if ("class".equalsIgnoreCase(summary.nature())
+                        && isAbstract(summary)
+                        && implementsInterface(summary)) {
+                    result.add(summary);
+                }
+            }
+            return result;
+        }
+
+        private boolean anySubclassDefinesEqualsOrHashCode(TypeSummary abstractClass) {
+            String abstractClassName = abstractClass.typeName().name().value();
+            for (TypeSummary summary : allTypes) {
+                if (!"class".equalsIgnoreCase(summary.nature())) {
+                    continue;
+                }
+                if (extendsClass(summary, abstractClassName) && definesEqualsOrHashCode(summary)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean extendsClass(TypeSummary summary, String superClassName) {
+            // Check direct superclass - superClass() returns Scala Option
+            scala.Option<TypeName> superTypeOpt = summary.superClass();
+            if (superTypeOpt.isDefined()) {
+                TypeName superType = superTypeOpt.get();
+                if (superType.name().value().equalsIgnoreCase(superClassName)) {
+                    return true;
+                }
+            }
+            // For transitive extends, we'd need to walk the hierarchy - for now check direct only
+            // This handles the common case of Interface -> Abstract -> Concrete
+            return false;
+        }
+
+        private static boolean isAbstract(TypeSummary summary) {
+            scala.collection.Iterator<Modifier> iter = summary.modifiers().iterator();
+            while (iter.hasNext()) {
+                if ("abstract".equalsIgnoreCase(iter.next().name())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean implementsInterface(TypeSummary summary) {
+            scala.collection.Iterator<TypeName> iter = summary.interfaces().iterator();
+            while (iter.hasNext()) {
+                if (iter.next().name().value().equalsIgnoreCase(interfaceSimpleName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static boolean definesEqualsOrHashCode(TypeSummary summary) {
+            scala.collection.Iterator<MethodSummary> iter = summary.methods().iterator();
+            while (iter.hasNext()) {
+                MethodSummary method = iter.next();
+                String methodName = method.name();
+                if ("hashCode".equalsIgnoreCase(methodName) && !method.parameters().iterator().hasNext()) {
+                    return true;
+                }
+                if ("equals".equalsIgnoreCase(methodName)) {
+                    scala.collection.Iterator<ParameterSummary> params = method.parameters().iterator();
+                    if (params.hasNext()) {
+                        ParameterSummary param = params.next();
+                        String paramTypeName = param.typeName().name().value();
+                        // ApexLink may report "Object$" for System.Object
+                        if (paramTypeName.toLowerCase(java.util.Locale.ROOT).startsWith("object")
+                                && !params.hasNext()) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
         }
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
@@ -5,7 +5,12 @@
 package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
@@ -43,6 +48,9 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
     private static final Logger LOG = LoggerFactory.getLogger(AvoidInterfaceAsMapKeyRule.class);
     private static boolean warnedAboutMissingOrg = false;
 
+    // Cached index - computed once per PMD run, reused across all file visits
+    private TypeHierarchyIndex cachedIndex;
+
     @Override
     protected @NonNull RuleTargetSelector buildTargetSelector() {
         return RuleTargetSelector.forTypes(ASTApexFile.class);
@@ -59,14 +67,22 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
             }
             return data;
         }
-        List<TypeSummary> allTypes = mfa.getTypeSummaries();
+
+        // Build index once per run (lazily on first file visit)
+        TypeHierarchyIndex index = getOrCreateIndex(mfa);
         for (MapKeyUsage usage : collectMapKeyUsages(node)) {
-            TypeHierarchyChecker checker = new TypeHierarchyChecker(usage.keyTypeSimpleName, allTypes);
-            if (checker.isViolation()) {
+            if (index.isProblematicInterfaceKey(usage.keyTypeSimpleName)) {
                 asCtx(data).addViolation(usage.reportNode);
             }
         }
         return data;
+    }
+
+    private TypeHierarchyIndex getOrCreateIndex(ApexMultifileAnalysis mfa) {
+        if (cachedIndex == null) {
+            cachedIndex = new TypeHierarchyIndex(mfa.getTypeSummaries());
+        }
+        return cachedIndex;
     }
 
     private List<MapKeyUsage> collectMapKeyUsages(ASTApexFile root) {
@@ -110,95 +126,104 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
     }
 
     /**
-     * Checks if a given interface name triggers the Map key dispatch bug.
-     * The bug occurs when:
-     * 1. The key type is an interface
-     * 2. There's an abstract class implementing that interface
-     * 3. Either the abstract class OR any class extending it defines equals/hashCode
+     * Pre-indexes the type hierarchy once to enable efficient queries.
+     * Builds lookup maps in a single O(N) pass for:
+     * - Interfaces in the org
+     * - Interface → abstract implementors
+     * - Class → direct subclasses
+     * - Types that define equals or hashCode
+     *
+     * <p>ApexLink's TypeSummary API provides "what this type extends/implements" (outgoing),
+     * but we need "what extends/implements this type" (incoming). This index inverts
+     * those relationships for efficient lookup.
      */
-    private static final class TypeHierarchyChecker {
-        private final String interfaceSimpleName;
-        private final List<TypeSummary> allTypes;
+    private static final class TypeHierarchyIndex {
+        // Interface name (lowercase) → set of abstract implementors
+        private final Map<String, Set<TypeSummary>> interfaceToAbstractImpls = new HashMap<>();
+        // Class name (lowercase) → set of direct subclasses
+        private final Map<String, Set<TypeSummary>> classToSubclasses = new HashMap<>();
+        // Set of types that define equals or hashCode (for quick lookup)
+        private final Set<TypeSummary> typesWithEqualsOrHashCode = new HashSet<>();
+        // All known interfaces
+        private final Set<String> knownInterfaces = new HashSet<>();
 
-        TypeHierarchyChecker(String interfaceSimpleName, List<TypeSummary> allTypes) {
-            this.interfaceSimpleName = interfaceSimpleName;
-            this.allTypes = allTypes;
+        TypeHierarchyIndex(List<TypeSummary> allTypes) {
+            // Single pass: build all indexes
+            for (TypeSummary summary : allTypes) {
+                String nature = summary.nature();
+                String typeName = summary.typeName().name().value().toLowerCase(Locale.ROOT);
+
+                if ("interface".equalsIgnoreCase(nature)) {
+                    knownInterfaces.add(typeName);
+                } else if ("class".equalsIgnoreCase(nature)) {
+                    // Index by superclass for subclass lookup
+                    scala.Option<TypeName> superOpt = summary.superClass();
+                    if (superOpt.isDefined()) {
+                        String superName = superOpt.get().name().value().toLowerCase(Locale.ROOT);
+                        classToSubclasses.computeIfAbsent(superName, k -> new HashSet<>()).add(summary);
+                    }
+
+                    // Index abstract implementors by interface
+                    if (isAbstract(summary)) {
+                        scala.collection.Iterator<TypeName> ifaces = summary.interfaces().iterator();
+                        while (ifaces.hasNext()) {
+                            String ifaceName = ifaces.next().name().value().toLowerCase(Locale.ROOT);
+                            interfaceToAbstractImpls.computeIfAbsent(ifaceName, k -> new HashSet<>())
+                                    .add(summary);
+                        }
+                    }
+
+                    // Track types with equals/hashCode
+                    if (definesEqualsOrHashCode(summary)) {
+                        typesWithEqualsOrHashCode.add(summary);
+                    }
+                }
+            }
         }
 
         /**
-         * Returns true if using this interface as a Map key would trigger the dispatch bug.
+         * Checks if using this interface as a Map key is problematic.
+         * O(1) interface lookup + O(abstract impls) + O(subclasses per impl)
          */
-        boolean isViolation() {
-            // Step 1: Verify it's actually an interface
-            if (!isInterfaceInOrg()) {
+        boolean isProblematicInterfaceKey(String interfaceSimpleName) {
+            String key = interfaceSimpleName.toLowerCase(Locale.ROOT);
+
+            // Must be a known interface
+            if (!knownInterfaces.contains(key)) {
                 return false;
             }
 
-            // Step 2: Find all abstract classes implementing this interface
-            List<TypeSummary> abstractImplementors = findAbstractImplementors();
-            if (abstractImplementors.isEmpty()) {
+            // Get abstract implementors
+            Set<TypeSummary> abstractImpls = interfaceToAbstractImpls.get(key);
+            if (abstractImpls == null || abstractImpls.isEmpty()) {
                 return false;
             }
 
-            // Step 3: For each abstract implementor, check if it or any subclass defines equals/hashCode
-            for (TypeSummary abstractImpl : abstractImplementors) {
-                if (definesEqualsOrHashCode(abstractImpl)) {
-                    return true;
-                }
-                // Check all classes that extend this abstract class
-                if (anySubclassDefinesEqualsOrHashCode(abstractImpl)) {
+            // Check each abstract implementor and its subclass tree
+            for (TypeSummary abstractImpl : abstractImpls) {
+                if (typeOrDescendantDefinesEqualsOrHashCode(abstractImpl)) {
                     return true;
                 }
             }
             return false;
         }
 
-        private boolean isInterfaceInOrg() {
-            for (TypeSummary summary : allTypes) {
-                if ("interface".equalsIgnoreCase(summary.nature())
-                        && summary.typeName().name().value().equalsIgnoreCase(interfaceSimpleName)) {
-                    return true;
+        /**
+         * Recursively checks if this type or any descendant defines equals/hashCode.
+         */
+        private boolean typeOrDescendantDefinesEqualsOrHashCode(TypeSummary type) {
+            if (typesWithEqualsOrHashCode.contains(type)) {
+                return true;
+            }
+            String typeName = type.typeName().name().value().toLowerCase(Locale.ROOT);
+            Set<TypeSummary> subclasses = classToSubclasses.get(typeName);
+            if (subclasses != null) {
+                for (TypeSummary subclass : subclasses) {
+                    if (typeOrDescendantDefinesEqualsOrHashCode(subclass)) {
+                        return true;
+                    }
                 }
             }
-            return false;
-        }
-
-        private List<TypeSummary> findAbstractImplementors() {
-            List<TypeSummary> result = new ArrayList<>();
-            for (TypeSummary summary : allTypes) {
-                if ("class".equalsIgnoreCase(summary.nature())
-                        && isAbstract(summary)
-                        && implementsInterface(summary)) {
-                    result.add(summary);
-                }
-            }
-            return result;
-        }
-
-        private boolean anySubclassDefinesEqualsOrHashCode(TypeSummary abstractClass) {
-            String abstractClassName = abstractClass.typeName().name().value();
-            for (TypeSummary summary : allTypes) {
-                if (!"class".equalsIgnoreCase(summary.nature())) {
-                    continue;
-                }
-                if (extendsClass(summary, abstractClassName) && definesEqualsOrHashCode(summary)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean extendsClass(TypeSummary summary, String superClassName) {
-            // Check direct superclass - superClass() returns Scala Option
-            scala.Option<TypeName> superTypeOpt = summary.superClass();
-            if (superTypeOpt.isDefined()) {
-                TypeName superType = superTypeOpt.get();
-                if (superType.name().value().equalsIgnoreCase(superClassName)) {
-                    return true;
-                }
-            }
-            // For transitive extends, we'd need to walk the hierarchy - for now check direct only
-            // This handles the common case of Interface -> Abstract -> Concrete
             return false;
         }
 
@@ -206,16 +231,6 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
             scala.collection.Iterator<Modifier> iter = summary.modifiers().iterator();
             while (iter.hasNext()) {
                 if ("abstract".equalsIgnoreCase(iter.next().name())) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private boolean implementsInterface(TypeSummary summary) {
-            scala.collection.Iterator<TypeName> iter = summary.interfaces().iterator();
-            while (iter.hasNext()) {
-                if (iter.next().name().value().equalsIgnoreCase(interfaceSimpleName)) {
                     return true;
                 }
             }
@@ -236,7 +251,7 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
                         ParameterSummary param = params.next();
                         String paramTypeName = param.typeName().name().value();
                         // ApexLink may report "Object$" for System.Object
-                        if (paramTypeName.toLowerCase(java.util.Locale.ROOT).startsWith("object")
+                        if (paramTypeName.toLowerCase(Locale.ROOT).startsWith("object")
                                 && !params.hasNext()) {
                             return true;
                         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
@@ -71,7 +71,7 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
         // Build index once per run (lazily on first file visit)
         TypeHierarchyIndex index = getOrCreateIndex(mfa);
         for (MapKeyUsage usage : collectMapKeyUsages(node)) {
-            if (index.isProblematicInterfaceKey(usage.keyTypeSimpleName)) {
+            if (index.isProblematicInterfaceKey(usage.keyTypeName)) {
                 asCtx(data).addViolation(usage.reportNode);
             }
         }
@@ -93,7 +93,7 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
             if (typeName != null && typeName.startsWith("Map<")) {
                 List<String> args = field.getTypeArguments();
                 if (args.size() >= 2) {
-                    usages.add(new MapKeyUsage(Helper.getSimpleTypeName(args.get(0)), field));
+                    usages.add(new MapKeyUsage(args.get(0), field));
                 }
             }
         }
@@ -101,14 +101,14 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
         for (ASTParameter param : root.descendants(ASTParameter.class).crossFindBoundaries()) {
             String keyType = Helper.getMapKeyType(param.getType());
             if (keyType != null) {
-                usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), param));
+                usages.add(new MapKeyUsage(keyType, param));
             }
         }
 
         for (ASTVariableDeclaration varDecl : root.descendants(ASTVariableDeclaration.class).crossFindBoundaries()) {
             String keyType = Helper.getMapKeyType(varDecl.getType());
             if (keyType != null) {
-                usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), varDecl));
+                usages.add(new MapKeyUsage(keyType, varDecl));
             }
         }
 
@@ -116,93 +116,255 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
     }
 
     private static final class MapKeyUsage {
-        final String keyTypeSimpleName;
+        final String keyTypeName;  // as written in source (may be simple or qualified)
         final ApexNode<?> reportNode;
 
-        MapKeyUsage(String keyTypeSimpleName, ApexNode<?> reportNode) {
-            this.keyTypeSimpleName = keyTypeSimpleName;
+        MapKeyUsage(String keyTypeName, ApexNode<?> reportNode) {
+            this.keyTypeName = keyTypeName;
             this.reportNode = reportNode;
         }
     }
 
     /**
-     * Pre-indexes the type hierarchy once to enable efficient queries.
-     * Builds lookup maps in a single O(N) pass for:
-     * - Interfaces in the org
-     * - Interface → abstract implementors
-     * - Class → direct subclasses
-     * - Types that define equals or hashCode
+     * Pre-indexes the type hierarchy to enable efficient queries.
+     * Handles:
+     * - Direct and transitive interface implementation (via superclass chain)
+     * - Interface inheritance (I extends J)
+     * - Abstract classes anywhere in the hierarchy with equals/hashCode
      *
      * <p>ApexLink's TypeSummary API provides "what this type extends/implements" (outgoing),
      * but we need "what extends/implements this type" (incoming). This index inverts
      * those relationships for efficient lookup.
      */
     private static final class TypeHierarchyIndex {
-        // Interface name (lowercase) → set of abstract implementors
-        private final Map<String, Set<TypeSummary>> interfaceToAbstractImpls = new HashMap<>();
+        // TypeSummary lookup by simple name (lowercase) - for resolving type references
+        private final Map<String, Set<TypeSummary>> typesBySimpleName = new HashMap<>();
+        // TypeSummary lookup by full name (lowercase) - for qualified references
+        private final Map<String, TypeSummary> typesByFullName = new HashMap<>();
         // Class name (lowercase) → set of direct subclasses
         private final Map<String, Set<TypeSummary>> classToSubclasses = new HashMap<>();
-        // Set of types that define equals or hashCode (for quick lookup)
-        private final Set<TypeSummary> typesWithEqualsOrHashCode = new HashSet<>();
-        // All known interfaces
-        private final Set<String> knownInterfaces = new HashSet<>();
+        // Interface name (lowercase) → set of interfaces that extend it
+        private final Map<String, Set<TypeSummary>> interfaceToSubInterfaces = new HashMap<>();
+        // Set of interfaces known to be problematic (pre-computed)
+        private final Set<String> problematicInterfaces = new HashSet<>();
 
         TypeHierarchyIndex(List<TypeSummary> allTypes) {
-            // Single pass: build all indexes
+            // Pass 1: Index all types by name and build direct relationships
+            Map<String, TypeSummary> interfaces = new HashMap<>();
+            Map<String, TypeSummary> classes = new HashMap<>();
+            Set<TypeSummary> abstractClasses = new HashSet<>();
+            Set<TypeSummary> typesWithEqualsOrHashCode = new HashSet<>();
+
             for (TypeSummary summary : allTypes) {
                 String nature = summary.nature();
-                String typeName = summary.typeName().name().value().toLowerCase(Locale.ROOT);
+                String simpleName = summary.typeName().name().value().toLowerCase(Locale.ROOT);
+                String fullName = getFullTypeName(summary).toLowerCase(Locale.ROOT);
+
+                typesBySimpleName.computeIfAbsent(simpleName, k -> new HashSet<>()).add(summary);
+                typesByFullName.put(fullName, summary);
 
                 if ("interface".equalsIgnoreCase(nature)) {
-                    knownInterfaces.add(typeName);
+                    interfaces.put(fullName, summary);
+                    // Track interface inheritance
+                    scala.collection.Iterator<TypeName> superIfaces = summary.interfaces().iterator();
+                    while (superIfaces.hasNext()) {
+                        String superIfaceName = superIfaces.next().name().value().toLowerCase(Locale.ROOT);
+                        interfaceToSubInterfaces.computeIfAbsent(superIfaceName, k -> new HashSet<>())
+                                .add(summary);
+                    }
                 } else if ("class".equalsIgnoreCase(nature)) {
+                    classes.put(fullName, summary);
                     // Index by superclass for subclass lookup
                     scala.Option<TypeName> superOpt = summary.superClass();
                     if (superOpt.isDefined()) {
                         String superName = superOpt.get().name().value().toLowerCase(Locale.ROOT);
                         classToSubclasses.computeIfAbsent(superName, k -> new HashSet<>()).add(summary);
                     }
-
-                    // Index abstract implementors by interface
                     if (isAbstract(summary)) {
-                        scala.collection.Iterator<TypeName> ifaces = summary.interfaces().iterator();
-                        while (ifaces.hasNext()) {
-                            String ifaceName = ifaces.next().name().value().toLowerCase(Locale.ROOT);
-                            interfaceToAbstractImpls.computeIfAbsent(ifaceName, k -> new HashSet<>())
-                                    .add(summary);
-                        }
+                        abstractClasses.add(summary);
                     }
-
-                    // Track types with equals/hashCode
                     if (definesEqualsOrHashCode(summary)) {
                         typesWithEqualsOrHashCode.add(summary);
                     }
                 }
             }
+
+            // Pass 2: For each interface, check if it's problematic
+            // An interface is problematic if there exists an abstract class in any
+            // implementation path that has equals/hashCode defined in its subtree
+            for (TypeSummary iface : interfaces.values()) {
+                if (isInterfaceProblematic(iface, abstractClasses, typesWithEqualsOrHashCode, new HashSet<>())) {
+                    // Mark this interface and all its simple name variants as problematic
+                    String simpleName = iface.typeName().name().value().toLowerCase(Locale.ROOT);
+                    String fullName = getFullTypeName(iface).toLowerCase(Locale.ROOT);
+                    problematicInterfaces.add(simpleName);
+                    problematicInterfaces.add(fullName);
+                }
+            }
         }
 
         /**
-         * Checks if using this interface as a Map key is problematic.
-         * O(1) interface lookup + O(abstract impls) + O(subclasses per impl)
+         * Checks if using this type name as a Map key is problematic.
+         * Accepts both simple names (IKey) and qualified names (OuterClass.IKey).
          */
-        boolean isProblematicInterfaceKey(String interfaceSimpleName) {
-            String key = interfaceSimpleName.toLowerCase(Locale.ROOT);
+        boolean isProblematicInterfaceKey(String typeName) {
+            String key = typeName.toLowerCase(Locale.ROOT);
+            // Try exact match first (handles qualified names)
+            if (problematicInterfaces.contains(key)) {
+                return true;
+            }
+            // Try simple name (last component)
+            String simpleName = getSimpleName(key);
+            return problematicInterfaces.contains(simpleName);
+        }
 
-            // Must be a known interface
-            if (!knownInterfaces.contains(key)) {
-                return false;
+        /**
+         * Checks if an interface is problematic by examining all classes that
+         * implement it (directly or transitively) for abstract classes with equals/hashCode.
+         */
+        private boolean isInterfaceProblematic(TypeSummary iface,
+                                               Set<TypeSummary> abstractClasses,
+                                               Set<TypeSummary> typesWithEqualsOrHashCode,
+                                               Set<String> visited) {
+            String ifaceName = iface.typeName().name().value().toLowerCase(Locale.ROOT);
+            if (!visited.add(ifaceName)) {
+                return false; // Already checked, avoid cycles
             }
 
-            // Get abstract implementors
-            Set<TypeSummary> abstractImpls = interfaceToAbstractImpls.get(key);
-            if (abstractImpls == null || abstractImpls.isEmpty()) {
-                return false;
+            // Find all classes and check their hierarchies
+            for (Set<TypeSummary> types : typesBySimpleName.values()) {
+                for (TypeSummary type : types) {
+                    if (!"class".equalsIgnoreCase(type.nature())) {
+                        continue;
+                    }
+                    if (classImplementsInterface(type, ifaceName, new HashSet<>())) {
+                        // Check if there's an abstract class in this type's hierarchy with equals/hashCode
+                        if (hasProblematicAbstractInHierarchy(type, abstractClasses, typesWithEqualsOrHashCode)) {
+                            return true;
+                        }
+                    }
+                }
             }
 
-            // Check each abstract implementor and its subclass tree
-            for (TypeSummary abstractImpl : abstractImpls) {
-                if (typeOrDescendantDefinesEqualsOrHashCode(abstractImpl)) {
+            // Check sub-interfaces (interface inheritance)
+            Set<TypeSummary> subInterfaces = interfaceToSubInterfaces.get(ifaceName);
+            if (subInterfaces != null) {
+                for (TypeSummary subIface : subInterfaces) {
+                    if (isInterfaceProblematic(subIface, abstractClasses, typesWithEqualsOrHashCode, visited)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks if a class implements an interface (directly or via superclass).
+         */
+        private boolean classImplementsInterface(TypeSummary cls, String ifaceName, Set<String> visited) {
+            String clsName = cls.typeName().name().value().toLowerCase(Locale.ROOT);
+            if (!visited.add(clsName)) {
+                return false; // Avoid cycles
+            }
+
+            // Check direct interfaces
+            scala.collection.Iterator<TypeName> ifaces = cls.interfaces().iterator();
+            while (ifaces.hasNext()) {
+                String directIface = ifaces.next().name().value().toLowerCase(Locale.ROOT);
+                if (directIface.equals(ifaceName)) {
                     return true;
+                }
+                // Check if directIface extends ifaceName
+                Set<TypeSummary> directIfaceTypes = typesBySimpleName.get(directIface);
+                if (directIfaceTypes != null) {
+                    for (TypeSummary directIfaceType : directIfaceTypes) {
+                        if ("interface".equalsIgnoreCase(directIfaceType.nature())
+                                && interfaceExtendsInterface(directIfaceType, ifaceName, new HashSet<>())) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            // Check superclass
+            scala.Option<TypeName> superOpt = cls.superClass();
+            if (superOpt.isDefined()) {
+                String superName = superOpt.get().name().value().toLowerCase(Locale.ROOT);
+                Set<TypeSummary> superTypes = typesBySimpleName.get(superName);
+                if (superTypes != null) {
+                    for (TypeSummary superType : superTypes) {
+                        if ("class".equalsIgnoreCase(superType.nature())
+                                && classImplementsInterface(superType, ifaceName, visited)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Checks if an interface extends another interface (directly or transitively).
+         */
+        private boolean interfaceExtendsInterface(TypeSummary iface, String targetIfaceName, Set<String> visited) {
+            String ifaceName = iface.typeName().name().value().toLowerCase(Locale.ROOT);
+            if (!visited.add(ifaceName)) {
+                return false;
+            }
+
+            scala.collection.Iterator<TypeName> superIfaces = iface.interfaces().iterator();
+            while (superIfaces.hasNext()) {
+                String superIfaceName = superIfaces.next().name().value().toLowerCase(Locale.ROOT);
+                if (superIfaceName.equals(targetIfaceName)) {
+                    return true;
+                }
+                Set<TypeSummary> superIfaceTypes = typesBySimpleName.get(superIfaceName);
+                if (superIfaceTypes != null) {
+                    for (TypeSummary superIfaceType : superIfaceTypes) {
+                        if ("interface".equalsIgnoreCase(superIfaceType.nature())
+                                && interfaceExtendsInterface(superIfaceType, targetIfaceName, visited)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Checks if there's an abstract class in this class's superclass chain
+         * that has equals/hashCode defined in its subtree.
+         */
+        private boolean hasProblematicAbstractInHierarchy(TypeSummary cls,
+                                                          Set<TypeSummary> abstractClasses,
+                                                          Set<TypeSummary> typesWithEqualsOrHashCode) {
+            // Walk up the class hierarchy
+            TypeSummary current = cls;
+            Set<String> visited = new HashSet<>();
+
+            while (current != null) {
+                String currentName = current.typeName().name().value().toLowerCase(Locale.ROOT);
+                if (!visited.add(currentName)) {
+                    break; // Cycle detection
+                }
+
+                if (abstractClasses.contains(current)) {
+                    // Found an abstract class - check if it or any descendant has equals/hashCode
+                    if (typeOrDescendantHasEqualsOrHashCode(current, typesWithEqualsOrHashCode, new HashSet<>())) {
+                        return true;
+                    }
+                }
+
+                // Move to superclass
+                scala.Option<TypeName> superOpt = current.superClass();
+                if (superOpt.isDefined()) {
+                    String superName = superOpt.get().name().value().toLowerCase(Locale.ROOT);
+                    Set<TypeSummary> superTypes = typesBySimpleName.get(superName);
+                    current = superTypes != null && !superTypes.isEmpty() ? superTypes.iterator().next() : null;
+                } else {
+                    current = null;
                 }
             }
             return false;
@@ -211,20 +373,37 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
         /**
          * Recursively checks if this type or any descendant defines equals/hashCode.
          */
-        private boolean typeOrDescendantDefinesEqualsOrHashCode(TypeSummary type) {
+        private boolean typeOrDescendantHasEqualsOrHashCode(TypeSummary type,
+                                                            Set<TypeSummary> typesWithEqualsOrHashCode,
+                                                            Set<String> visited) {
+            String typeName = type.typeName().name().value().toLowerCase(Locale.ROOT);
+            if (!visited.add(typeName)) {
+                return false;
+            }
+
             if (typesWithEqualsOrHashCode.contains(type)) {
                 return true;
             }
-            String typeName = type.typeName().name().value().toLowerCase(Locale.ROOT);
+
             Set<TypeSummary> subclasses = classToSubclasses.get(typeName);
             if (subclasses != null) {
                 for (TypeSummary subclass : subclasses) {
-                    if (typeOrDescendantDefinesEqualsOrHashCode(subclass)) {
+                    if (typeOrDescendantHasEqualsOrHashCode(subclass, typesWithEqualsOrHashCode, visited)) {
                         return true;
                     }
                 }
             }
             return false;
+        }
+
+        private static String getFullTypeName(TypeSummary summary) {
+            // For nested types, this returns the full path like "OuterClass.InnerClass"
+            return summary.typeName().toString();
+        }
+
+        private static String getSimpleName(String typeName) {
+            int lastDot = typeName.lastIndexOf('.');
+            return lastDot >= 0 ? typeName.substring(lastDot + 1) : typeName;
         }
 
         private static boolean isAbstract(TypeSummary summary) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
@@ -1,0 +1,241 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTApexFile;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclarationStatements;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileAnalysis;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+
+/**
+ * Flags use of an interface as Map key when that interface has an implementing class
+ * that is abstract and defines equals or hashCode. In Apex, Map operations like
+ * containsKey do not dispatch to the correct equals/hashCode in that case.
+ *
+ * @see <a href="https://github.com/pmd/pmd/issues/6492">Issue 6492</a>
+ */
+public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
+
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTApexFile.class);
+    }
+
+    @Override
+    public Object visit(ASTApexFile node, Object data) {
+        List<MapKeyUsage> mapKeyUsages = collectMapKeyUsages(node);
+        ApexMultifileAnalysis mfa = node.getMultifileAnalysis();
+
+        if (!mfa.isFailed()) {
+            // Org is loaded: use cross-file type hierarchy for accurate detection.
+            for (MapKeyUsage usage : mapKeyUsages) {
+                String keySimpleName = usage.keyTypeSimpleName;
+                if (mfa.isInterfaceInOrg(keySimpleName)
+                        && mfa.hasAbstractImplementorWithEqualsOrHashCode(keySimpleName)) {
+                    asCtx(data).addViolation(usage.reportNode);
+                }
+            }
+        } else {
+            // No org available: fall back to single-file analysis.
+            Set<String> interfaceSimpleNames = getInterfaceSimpleNamesInFile(node);
+            Map<String, ASTUserClass> classesBySimpleName = getClassesBySimpleName(node);
+
+            for (MapKeyUsage usage : mapKeyUsages) {
+                String keySimpleName = usage.keyTypeSimpleName;
+                if (!interfaceSimpleNames.contains(keySimpleName)) {
+                    continue;
+                }
+                Set<ASTUserClass> implementors = findImplementorsOf(keySimpleName, classesBySimpleName);
+                if (hasAbstractImplementorWithEqualsOrHashCode(implementors, classesBySimpleName)) {
+                    asCtx(data).addViolation(usage.reportNode);
+                }
+            }
+        }
+        return data;
+    }
+
+    private List<MapKeyUsage> collectMapKeyUsages(ASTApexFile root) {
+        List<MapKeyUsage> usages = new ArrayList<>();
+
+        for (ASTFieldDeclarationStatements field : root.descendants(ASTFieldDeclarationStatements.class).crossFindBoundaries()) {
+            String typeName = field.getTypeName();
+            if (typeName != null && typeName.startsWith("Map<")) {
+                List<String> args = field.getTypeArguments();
+                if (args.size() >= 2) {
+                    String keyType = args.get(0);
+                    usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), field));
+                }
+            }
+        }
+
+        for (ASTParameter param : root.descendants(ASTParameter.class).crossFindBoundaries()) {
+            String keyType = Helper.getMapKeyType(param.getType());
+            if (keyType != null) {
+                usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), param));
+            }
+        }
+
+        for (ASTVariableDeclaration varDecl : root.descendants(ASTVariableDeclaration.class).crossFindBoundaries()) {
+            String keyType = Helper.getMapKeyType(varDecl.getType());
+            if (keyType != null) {
+                usages.add(new MapKeyUsage(Helper.getSimpleTypeName(keyType), varDecl));
+            }
+        }
+
+        return usages;
+    }
+
+    private Set<String> getInterfaceSimpleNamesInFile(ASTApexFile root) {
+        Set<String> names = new HashSet<>();
+        for (ASTUserInterface iface : root.descendants(ASTUserInterface.class).crossFindBoundaries()) {
+            names.add(iface.getSimpleName());
+        }
+        return names;
+    }
+
+    private Map<String, ASTUserClass> getClassesBySimpleName(ASTApexFile root) {
+        Map<String, ASTUserClass> map = new HashMap<>();
+        for (ASTUserClass clazz : root.descendants(ASTUserClass.class).crossFindBoundaries()) {
+            map.put(clazz.getSimpleName(), clazz);
+        }
+        return map;
+    }
+
+    /**
+     * Find all classes in the file that implement the given interface (directly or via superclass).
+     */
+    private Set<ASTUserClass> findImplementorsOf(String interfaceSimpleName, Map<String, ASTUserClass> classesBySimpleName) {
+        Set<ASTUserClass> implementors = new HashSet<>();
+        for (ASTUserClass clazz : classesBySimpleName.values()) {
+            if (directlyImplementsInterface(clazz, interfaceSimpleName)) {
+                implementors.add(clazz);
+            }
+        }
+        // Add classes that extend an implementor (transitive)
+        boolean changed;
+        do {
+            changed = false;
+            for (ASTUserClass clazz : classesBySimpleName.values()) {
+                if (implementors.contains(clazz)) {
+                    continue;
+                }
+                String superName = clazz.getSuperClassName();
+                String superSimple = Helper.getSimpleTypeName(superName);
+                ASTUserClass superClass = classesBySimpleName.get(superSimple);
+                if (superClass != null && implementors.contains(superClass)) {
+                    implementors.add(clazz);
+                    changed = true;
+                }
+            }
+        } while (changed);
+        return implementors;
+    }
+
+    private boolean directlyImplementsInterface(ASTUserClass clazz, String interfaceSimpleName) {
+        for (String iface : clazz.getInterfaceNames()) {
+            if (Helper.getSimpleTypeName(iface).equals(interfaceSimpleName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasAbstractImplementorWithEqualsOrHashCode(
+            Set<ASTUserClass> implementors,
+            Map<String, ASTUserClass> classesBySimpleName) {
+        for (ASTUserClass clazz : implementors) {
+            if (abstractClassDefinesEqualsOrHashCodeInChain(clazz, classesBySimpleName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Walk up the class chain; if any class in the chain is abstract and defines equals or hashCode, return true.
+     */
+    private boolean abstractClassDefinesEqualsOrHashCodeInChain(
+            ASTUserClass clazz,
+            Map<String, ASTUserClass> classesBySimpleName) {
+        ASTUserClass current = clazz;
+        Set<ASTUserClass> visited = new HashSet<>();
+        while (current != null && visited.add(current)) {
+            if (current.getModifiers() != null && current.getModifiers().isAbstract() && definesEqualsOrHashCode(current)) {
+                return true;
+            }
+            String superName = current.getSuperClassName();
+            if (superName.isEmpty()) {
+                break;
+            }
+            current = classesBySimpleName.get(Helper.getSimpleTypeName(superName));
+        }
+        return false;
+    }
+
+    private boolean definesEqualsOrHashCode(ASTUserClass clazz) {
+        for (ASTMethod method : clazz.children(ASTMethod.class)) {
+            if (isEquals(method) || isHashCode(method)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isEquals(ASTMethod method) {
+        if (!"equals".equalsIgnoreCase(method.getImage())) {
+            return false;
+        }
+        int paramCount = 0;
+        String paramType = null;
+        for (int i = 0; i < method.getNumChildren(); i++) {
+            ApexNode<?> child = method.getChild(i);
+            if (child instanceof ASTParameter) {
+                paramCount++;
+                paramType = ((ASTParameter) child).getType();
+            }
+        }
+        return paramCount == 1 && "Object".equalsIgnoreCase(Helper.getSimpleTypeName(paramType != null ? paramType : ""));
+    }
+
+    private boolean isHashCode(ASTMethod method) {
+        if (!"hashCode".equalsIgnoreCase(method.getImage())) {
+            return false;
+        }
+        int paramCount = 0;
+        for (int i = 0; i < method.getNumChildren(); i++) {
+            if (method.getChild(i) instanceof ASTParameter) {
+                paramCount++;
+            }
+        }
+        return paramCount == 0;
+    }
+
+    private static final class MapKeyUsage {
+        final String keyTypeSimpleName;
+        final ApexNode<?> reportNode;
+
+        MapKeyUsage(String keyTypeSimpleName, ApexNode<?> reportNode) {
+            this.keyTypeSimpleName = keyTypeSimpleName;
+            this.reportNode = reportNode;
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
@@ -231,16 +231,4 @@ public final class Helper {
         }
         return null;
     }
-
-    /**
-     * Returns the simple name of a type (last segment after the last dot).
-     * E.g. {@code "MyNamespace.IKey"} returns {@code "IKey"}, {@code "IKey"} returns {@code "IKey"}.
-     */
-    public static String getSimpleTypeName(String typeName) {
-        if (typeName == null || typeName.isEmpty()) {
-            return typeName;
-        }
-        int dot = typeName.lastIndexOf('.');
-        return dot < 0 ? typeName : typeName.substring(dot + 1);
-    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
@@ -195,4 +195,52 @@ public final class Helper {
     public static boolean isAnyDatabaseMethodCall(ASTMethodCallExpression node) {
         return isMethodName(node, DATABASE_CLASS_NAME, ANY_METHOD);
     }
+
+    /**
+     * Extracts the key type from a Map type string, e.g. {@code "Map<IKey, String>"} returns {@code "IKey"}.
+     * Handles nested generics e.g. {@code "Map<List<A>, B>"} returns {@code "List<A>"}.
+     *
+     * @param typeName full type string (e.g. from {@link net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration#getType()})
+     * @return the key type, or null if the type is not Map&lt;K,V&gt; or malformed
+     */
+    public static String getMapKeyType(String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+        String t = typeName.trim();
+        if (!t.startsWith("Map<")) {
+            return null;
+        }
+        int start = t.indexOf('<');
+        if (start < 0) {
+            return null;
+        }
+        int depth = 1;
+        int i = start + 1;
+        int keyStart = i;
+        while (i < t.length() && depth > 0) {
+            char c = t.charAt(i);
+            if (c == '<') {
+                depth++;
+            } else if (c == '>') {
+                depth--;
+            } else if (c == ',' && depth == 1) {
+                return t.substring(keyStart, i).trim();
+            }
+            i++;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the simple name of a type (last segment after the last dot).
+     * E.g. {@code "MyNamespace.IKey"} returns {@code "IKey"}, {@code "IKey"} returns {@code "IKey"}.
+     */
+    public static String getSimpleTypeName(String typeName) {
+        if (typeName == null || typeName.isEmpty()) {
+            return typeName;
+        }
+        int dot = typeName.lastIndexOf('.');
+        return dot < 0 ? typeName : typeName.substring(dot + 1);
+    }
 }

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -120,7 +120,8 @@ public without sharing class Foo {
       In Apex, when a Map uses an interface as key and an abstract class implements that interface
       and defines equals/hashCode, methods like containsKey do not dispatch to the correct implementation.
       This rule reports Map declarations (fields, variables, parameters) whose key type is an interface
-      that has at least one abstract implementing class defining equals or hashCode (in the same file).
+      that has at least one abstract implementing class defining equals or hashCode (requires multi-file
+      analysis provided by apex-link).
     </description>
     <priority>3</priority>
     <example>

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -109,7 +109,34 @@ public without sharing class Foo {
 ]]>
     </example>
   </rule>
-  
+
+  <rule name="AvoidInterfaceAsMapKey"
+        language="apex"
+        since="7.24.0"
+        message="Avoid using an interface as Map key when an abstract implementing class defines equals or hashCode"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidInterfaceAsMapKeyRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidinterfaceasmapkey">
+    <description>
+      In Apex, when a Map uses an interface as key and an abstract class implements that interface
+      and defines equals/hashCode, methods like containsKey do not dispatch to the correct implementation.
+      This rule reports Map declarations (fields, variables, parameters) whose key type is an interface
+      that has at least one abstract implementing class defining equals or hashCode (in the same file).
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
+public class Outer {
+    public interface IKey { }
+    public abstract class AbstractKey implements IKey {
+        public Boolean equals(Object obj) { return false; }
+        public Integer hashCode() { return 0; }
+    }
+    Map<IKey, String> m; // violation: IKey has abstract implementor with equals/hashCode
+}
+]]>
+    </example>
+  </rule>
+
   <rule name="AvoidNonExistentAnnotations"
         language="apex"
         since="6.5.0"
@@ -499,7 +526,7 @@ public class MyClass {
 ]]>
     </example>
   </rule>
-  
+
   <rule name="OverrideBothEqualsAndHashcode"
         language="apex"
         since="6.31.0"

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
@@ -118,6 +118,46 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
         assertViolation(report.getViolations().get(0), "MapUser.cls", 7);
     }
 
+    /**
+     * project7: All types (interface, abstract, concrete) are INNER classes within a single outer class.
+     * Expected: 3 violations - multifile analysis should handle nested types.
+     */
+    @Test
+    void innerClassesViolation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project7"));
+        assertEquals(3, report.getViolations().size(),
+                "Expected 3 violations when interface and abstract implementor are inner classes");
+        assertViolation(report.getViolations().get(0), "OuterClass.cls", 29); // field
+        assertViolation(report.getViolations().get(1), "OuterClass.cls", 31); // parameter
+        assertViolation(report.getViolations().get(2), "OuterClass.cls", 32); // local variable
+    }
+
+    /**
+     * project8: Indirect implementation via superclass.
+     * Hierarchy: IKey <- BaseKey (virtual concrete) <- MidKey (abstract with equals)
+     * Expected: 1 violation - abstract class indirectly implements the interface.
+     */
+    @Test
+    void indirectImplementationViaSuperclassViolation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project8"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected 1 violation when abstract class indirectly implements interface via superclass");
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 3);
+    }
+
+    /**
+     * project9: Deep class hierarchy with abstract class far from interface.
+     * Hierarchy: IBaseKey <- ConcreteBase <- MidKey <- DeepAbstractKey (abstract with equals)
+     * Expected: 1 violation - abstract class is 3 levels removed from interface.
+     */
+    @Test
+    void deepHierarchyViolation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project9"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected 1 violation when abstract class is deep in hierarchy");
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 4);
+    }
+
     private void assertViolation(RuleViolation violation, String fileName, int lineNumber) {
         assertEquals(fileName, violation.getFileId().getFileName());
         assertEquals(lineNumber, violation.getBeginLine());

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
@@ -1,0 +1,151 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.PmdAnalysis;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
+import net.sourceforge.pmd.lang.apex.ApexLanguageProperties;
+import net.sourceforge.pmd.lang.rule.Rule;
+import net.sourceforge.pmd.lang.rule.RuleSet;
+import net.sourceforge.pmd.lang.rule.RuleSetLoader;
+import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
+import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleViolation;
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+import com.nawforce.pkgforce.path.PathLike;
+import com.nawforce.runtime.platform.Environment;
+import scala.Option;
+
+/**
+ * Tests for AvoidInterfaceAsMapKey rule. Extends PmdRuleTst for XML-based tests
+ * and adds integration tests that require multifile analysis.
+ */
+class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
+
+    private static final String TEST_RESOURCES_BASE =
+            "src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/";
+
+    @TempDir
+    private Path tempDir;
+
+    /**
+     * project1: Interface + abstract implementor with BOTH equals AND hashCode.
+     * Expected: 3 violations (field, parameter, local variable).
+     */
+    @Test
+    void project1_abstractImplementorWithBothEqualsAndHashCode_violations() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project1"));
+
+        assertEquals(3, report.getViolations().size(), "Expected 3 violations in MapUser.cls");
+        for (RuleViolation v : report.getViolations()) {
+            assertEquals("MapUser.cls", v.getFileId().getFileName());
+        }
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 7);  // field
+        assertViolation(report.getViolations().get(1), "MapUser.cls", 10); // parameter
+        assertViolation(report.getViolations().get(2), "MapUser.cls", 15); // local variable
+    }
+
+    /**
+     * project2: Interface with NO implementors at all.
+     * Expected: 0 violations.
+     */
+    @Test
+    void project2_noImplementors_noViolations() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project2"));
+        assertEquals(0, report.getViolations().size(), "Expected no violations when interface has no implementors");
+    }
+
+    /**
+     * project3: Abstract implementor WITHOUT equals or hashCode.
+     * Expected: 0 violations.
+     */
+    @Test
+    void project3_abstractImplementorWithoutEqualsOrHashCode_noViolations() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project3"));
+        assertEquals(0, report.getViolations().size(),
+                "Expected no violations when abstract implementor doesn't define equals/hashCode");
+    }
+
+    /**
+     * project4: Abstract implementor with ONLY equals (no hashCode).
+     * Expected: 1 violation - dispatch bug still occurs with just equals.
+     */
+    @Test
+    void project4_abstractImplementorWithOnlyEquals_violation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project4"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected 1 violation when abstract implementor defines only equals");
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 7);
+    }
+
+    /**
+     * project5: Abstract implementor with ONLY hashCode (no equals).
+     * Expected: 1 violation - dispatch bug still occurs with just hashCode.
+     */
+    @Test
+    void project5_abstractImplementorWithOnlyHashCode_violation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project5"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected 1 violation when abstract implementor defines only hashCode");
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 7);
+    }
+
+    /**
+     * project6: Abstract implementor WITHOUT equals/hashCode, but CONCRETE subclass defines them.
+     * Expected: 1 violation - dispatch bug occurs because abstract class is in the chain.
+     */
+    @Test
+    void project6_concreteSubclassDefinesEqualsHashCode_violation() throws Exception {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project6"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected 1 violation when concrete subclass of abstract implementor defines equals/hashCode");
+        assertViolation(report.getViolations().get(0), "MapUser.cls", 7);
+    }
+
+    private void assertViolation(RuleViolation violation, String fileName, int lineNumber) {
+        assertEquals(fileName, violation.getFileId().getFileName());
+        assertEquals(lineNumber, violation.getBeginLine());
+    }
+
+    private Report runRule(Path testProjectDir) throws IOException {
+        Option<PathLike> pathLikeOption = Option.apply(new com.nawforce.runtime.platform.Path(tempDir));
+        Option<Option<PathLike>> cacheDirOption = Option.apply(pathLikeOption);
+        Environment.setCacheDirOverride(cacheDirOption);
+
+        Language apexLanguage = ApexLanguageModule.getInstance();
+        LanguageVersion languageVersion = apexLanguage.getDefaultVersion();
+        PMDConfiguration configuration = new PMDConfiguration();
+        configuration.setIgnoreIncrementalAnalysis(true);
+        configuration.setDefaultLanguageVersion(languageVersion);
+        configuration.setThreads(0); // don't use separate threads
+
+        configuration.getLanguageProperties(apexLanguage)
+                .setProperty(ApexLanguageProperties.MULTIFILE_DIRECTORY, Optional.of(testProjectDir.toString()));
+
+        RuleSet parsedRset = new RuleSetLoader().warnDeprecated(false).loadFromResource("category/apex/errorprone.xml");
+        Rule rule = parsedRset.getRuleByName("AvoidInterfaceAsMapKey");
+
+        try (PmdAnalysis pmd = PmdAnalysis.create(configuration)) {
+            pmd.files().addDirectory(testProjectDir);
+            pmd.addRuleSet(RuleSet.forSingleRule(rule));
+            pmd.addListener(GlobalAnalysisListener.exceptionThrower());
+            return pmd.performAnalysisAndCollectReport();
+        }
+    }
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyTest.java
@@ -49,7 +49,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 3 violations (field, parameter, local variable).
      */
     @Test
-    void project1_abstractImplementorWithBothEqualsAndHashCode_violations() throws Exception {
+    void abstractImplementorWithBothEqualsAndHashCodeViolations() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project1"));
 
         assertEquals(3, report.getViolations().size(), "Expected 3 violations in MapUser.cls");
@@ -66,7 +66,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 0 violations.
      */
     @Test
-    void project2_noImplementors_noViolations() throws Exception {
+    void noImplementorsNoViolations() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project2"));
         assertEquals(0, report.getViolations().size(), "Expected no violations when interface has no implementors");
     }
@@ -76,7 +76,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 0 violations.
      */
     @Test
-    void project3_abstractImplementorWithoutEqualsOrHashCode_noViolations() throws Exception {
+    void abstractImplementorWithoutEqualsOrHashCodeNoViolations() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project3"));
         assertEquals(0, report.getViolations().size(),
                 "Expected no violations when abstract implementor doesn't define equals/hashCode");
@@ -87,7 +87,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 1 violation - dispatch bug still occurs with just equals.
      */
     @Test
-    void project4_abstractImplementorWithOnlyEquals_violation() throws Exception {
+    void abstractImplementorWithOnlyEqualsViolation() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project4"));
         assertEquals(1, report.getViolations().size(),
                 "Expected 1 violation when abstract implementor defines only equals");
@@ -99,7 +99,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 1 violation - dispatch bug still occurs with just hashCode.
      */
     @Test
-    void project5_abstractImplementorWithOnlyHashCode_violation() throws Exception {
+    void abstractImplementorWithOnlyHashCodeViolation() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project5"));
         assertEquals(1, report.getViolations().size(),
                 "Expected 1 violation when abstract implementor defines only hashCode");
@@ -111,7 +111,7 @@ class AvoidInterfaceAsMapKeyTest extends PmdRuleTst {
      * Expected: 1 violation - dispatch bug occurs because abstract class is in the chain.
      */
     @Test
-    void project6_concreteSubclassDefinesEqualsHashCode_violation() throws Exception {
+    void concreteSubclassDefinesEqualsHashCodeViolation() throws Exception {
         Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "project6"));
         assertEquals(1, report.getViolations().size(),
                 "Expected 1 violation when concrete subclass of abstract implementor defines equals/hashCode");

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/AbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/AbstractKey.cls
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public abstract class AbstractKey implements IKey {
+    public Boolean equals(Object obj) {
+        return false;
+    }
+
+    public Integer hashCode() {
+        return 0;
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/AbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/AbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/IKey.cls
@@ -1,0 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/MapUser.cls
@@ -1,0 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public class MapUser {
+    // Field declaration - should trigger violation
+    Map<IKey, String> fieldMap;
+
+    // Method parameter - should trigger violation
+    public void processMap(Map<IKey, String> paramMap) {
+    }
+
+    // Local variable - should trigger violation
+    public void createMap() {
+        Map<IKey, String> localMap = new Map<IKey, String>();
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project1/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/IKey.cls
@@ -1,0 +1,8 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Interface with no implementors at all
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/MapUser.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// No violation expected - interface has no implementors
+public class MapUser {
+    Map<IKey, String> fieldMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project2/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/AbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/AbstractKey.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Abstract class implementing interface but WITHOUT equals/hashCode
+public abstract class AbstractKey implements IKey {
+    // No equals or hashCode defined
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/AbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/AbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/IKey.cls
@@ -1,0 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/MapUser.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// No violation expected - abstract class doesn't define equals/hashCode
+public class MapUser {
+    Map<IKey, String> fieldMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project3/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/AbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/AbstractKey.cls
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Abstract class with ONLY equals (no hashCode)
+public abstract class AbstractKey implements IKey {
+    public Boolean equals(Object obj) {
+        return false;
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/AbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/AbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/IKey.cls
@@ -1,0 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/MapUser.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// VIOLATION expected - abstract class defines only equals (dispatch bug still occurs)
+public class MapUser {
+    Map<IKey, String> fieldMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project4/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/AbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/AbstractKey.cls
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Abstract class with ONLY hashCode (no equals)
+public abstract class AbstractKey implements IKey {
+    public Integer hashCode() {
+        return 0;
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/AbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/AbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/IKey.cls
@@ -1,0 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/MapUser.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// VIOLATION expected - abstract class defines only hashCode (dispatch bug still occurs)
+public class MapUser {
+    Map<IKey, String> fieldMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project5/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/AbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/AbstractKey.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Abstract class WITHOUT equals/hashCode - but ConcreteKey extends it and DOES define them
+public abstract class AbstractKey implements IKey {
+    // No equals or hashCode here
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/AbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/AbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/ConcreteKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/ConcreteKey.cls
@@ -1,0 +1,16 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// Concrete class that extends abstract, defines equals/hashCode
+// Dispatch bug still occurs because of abstract class in the chain
+public class ConcreteKey extends AbstractKey {
+    public Boolean equals(Object obj) {
+        return false;
+    }
+
+    public Integer hashCode() {
+        return 0;
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/ConcreteKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/ConcreteKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/IKey.cls
@@ -1,0 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public interface IKey {
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/MapUser.cls
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// VIOLATION expected - concrete subclass of abstract implementor defines equals/hashCode
+public class MapUser {
+    Map<IKey, String> fieldMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project6/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/sfdx-project.json
@@ -1,0 +1,7 @@
+{
+  "packageDirectories": [{ "path": "src", "default": true }],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "55.0"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/src/OuterClass.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/src/OuterClass.cls
@@ -1,0 +1,35 @@
+public class OuterClass {
+    // Inner interface
+    public interface IKey {
+        String getKey();
+    }
+
+    // Inner abstract class implementing the interface
+    public abstract class AbstractKey implements IKey {
+        public Boolean equals(Object other) {
+            return this === other;
+        }
+        public Integer hashCode() {
+            return System.identityHashCode(this);
+        }
+    }
+
+    // Inner concrete class
+    public class ConcreteKey extends AbstractKey {
+        private String key;
+        public ConcreteKey(String key) {
+            this.key = key;
+        }
+        public String getKey() {
+            return key;
+        }
+    }
+
+    // Map usage with inner interface as key - should trigger violation
+    private Map<IKey, String> keyMap;
+
+    public void doSomething(Map<IKey, Integer> paramMap) {
+        Map<IKey, Boolean> localMap = new Map<IKey, Boolean>();
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/src/OuterClass.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project7/src/OuterClass.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/sfdx-project.json
@@ -1,0 +1,7 @@
+{
+  "packageDirectories": [{ "path": "src", "default": true }],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "55.0"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/BaseKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/BaseKey.cls
@@ -1,0 +1,11 @@
+// Virtual concrete class that directly implements interface (virtual so it can be extended)
+public virtual class BaseKey implements IKey {
+    private String key;
+    public BaseKey(String key) {
+        this.key = key;
+    }
+    public virtual String getKey() {
+        return key;
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/BaseKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/BaseKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/IKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/IKey.cls
@@ -1,0 +1,5 @@
+// Interface
+public interface IKey {
+    String getKey();
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/IKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/IKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MapUser.cls
@@ -1,0 +1,5 @@
+public class MapUser {
+    // Should trigger violation - IKey has indirect abstract implementor with equals
+    private Map<IKey, String> keyMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MidKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MidKey.cls
@@ -1,0 +1,14 @@
+// Abstract class that EXTENDS concrete (indirectly implements IKey)
+// and defines equals - this should still trigger the bug
+public abstract class MidKey extends BaseKey {
+    public MidKey(String key) {
+        super(key);
+    }
+    public Boolean equals(Object other) {
+        return this === other;
+    }
+    public Integer hashCode() {
+        return System.identityHashCode(this);
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MidKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project8/src/MidKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/sfdx-project.json
@@ -1,0 +1,7 @@
+{
+  "packageDirectories": [{ "path": "src", "default": true }],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "55.0"
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/ConcreteBase.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/ConcreteBase.cls
@@ -1,0 +1,7 @@
+// Virtual concrete class that implements IBaseKey (virtual so it can be extended)
+public virtual class ConcreteBase implements IBaseKey {
+    public virtual String getKey() {
+        return 'key';
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/ConcreteBase.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/ConcreteBase.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/DeepAbstractKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/DeepAbstractKey.cls
@@ -1,0 +1,11 @@
+// Abstract class deep in hierarchy: IBaseKey <- ConcreteBase <- MidKey <- DeepAbstractKey
+// The abstract class is 3 levels removed from the interface but should still trigger
+public abstract class DeepAbstractKey extends MidKey {
+    public Boolean equals(Object other) {
+        return this === other;
+    }
+    public Integer hashCode() {
+        return System.identityHashCode(this);
+    }
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/DeepAbstractKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/DeepAbstractKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/IBaseKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/IBaseKey.cls
@@ -1,0 +1,5 @@
+// Base interface
+public interface IBaseKey {
+    String getKey();
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/IBaseKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/IBaseKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MapUser.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MapUser.cls
@@ -1,0 +1,6 @@
+public class MapUser {
+    // Should trigger violation - IBaseKey has a deep abstract implementor with equals
+    // Hierarchy: IBaseKey <- ConcreteBase <- MidKey <- DeepAbstractKey (abstract with equals)
+    private Map<IBaseKey, String> keyMap;
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MapUser.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MapUser.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MidKey.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MidKey.cls
@@ -1,0 +1,5 @@
+// Virtual concrete middle class - extends ConcreteBase (virtual so it can be extended)
+public virtual class MidKey extends ConcreteBase {
+    // No equals/hashCode here
+}
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MidKey.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKey/project9/src/MidKey.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>55.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidInterfaceAsMapKey.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidInterfaceAsMapKey.xml
@@ -4,20 +4,9 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
-    <test-code>
-        <description>Map with interface key and abstract implementor defining equals/hashCode - violation</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Outer {
-    public interface IKey { }
-    public abstract class AbstractKey implements IKey {
-        public Boolean equals(Object obj) { return false; }
-        public Integer hashCode() { return 0; }
-    }
-    Map<IKey, String> m;
-}
-        ]]></code>
-    </test-code>
+    <!-- Note: This rule requires multifile analysis (PMD_APEX_ROOT_DIRECTORY).
+         Positive violation tests are in AvoidInterfaceAsMapKeyTest.java as integration tests.
+         These XML tests verify no false positives when org is unavailable. -->
 
     <test-code>
         <description>Map with class key - no violation</description>
@@ -26,45 +15,6 @@ public class Outer {
 public class Outer {
     public class Key { }
     Map<Key, String> m;
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Map with interface key but no abstract implementor with equals/hashCode - no violation</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Outer {
-    public interface IKey { }
-    public class ConcreteKey implements IKey { }
-    Map<IKey, String> m;
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Interface as key, abstract implementor without equals/hashCode - no violation</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Outer {
-    public interface IKey { }
-    public abstract class AbstractKey implements IKey { }
-    Map<IKey, String> m;
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Map key type from parameter - violation when interface has abstract implementor with equals/hashCode</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Outer {
-    public interface IKey { }
-    public abstract class AbstractKey implements IKey {
-        public Boolean equals(Object obj) { return false; }
-        public Integer hashCode() { return 0; }
-    }
-    public void foo(Map<IKey, String> theMap) { }
 }
         ]]></code>
     </test-code>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidInterfaceAsMapKey.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidInterfaceAsMapKey.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Map with interface key and abstract implementor defining equals/hashCode - violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    public interface IKey { }
+    public abstract class AbstractKey implements IKey {
+        public Boolean equals(Object obj) { return false; }
+        public Integer hashCode() { return 0; }
+    }
+    Map<IKey, String> m;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Map with class key - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    public class Key { }
+    Map<Key, String> m;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Map with interface key but no abstract implementor with equals/hashCode - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    public interface IKey { }
+    public class ConcreteKey implements IKey { }
+    Map<IKey, String> m;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Interface as key, abstract implementor without equals/hashCode - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    public interface IKey { }
+    public abstract class AbstractKey implements IKey { }
+    Map<IKey, String> m;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Map key type from parameter - violation when interface has abstract implementor with equals/hashCode</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    public interface IKey { }
+    public abstract class AbstractKey implements IKey {
+        public Boolean equals(Object obj) { return false; }
+        public Integer hashCode() { return 0; }
+    }
+    public void foo(Map<IKey, String> theMap) { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Map with primitive-like key type String - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Outer {
+    Map<String, Integer> m;
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Apex has a dispatch bug in the implementation of `Map` that can result in difficult errors. This PMD rule looks for the structure that results in `Map`'s bad dispatch, when a Map is using an interface as a key, the rule uses `ApexLink` to find implementations of the interface, then checking if any implementation is abstract & overrides equals / hashCode - this will result in incorrect dispatching from Map's methods.

This was largely implemented with AI, confirmed resulting jar finds violations against https://github.com/Traction-Rec/map-eq-dispatch-bug but doesn't trigger violation just because an interface is being used. 

Ran this rule against relatively large internal project and it completed succesfully.

## Related issues

- Fix #6492

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

