### PR TITLE
[core] Fix #6503: Don't escape externalInfoUrl in reports

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* core
+  * [#6503](https://github.com/pmd/pmd/issues/6503): \[core] Links in HTML report are broken
 
 ### 🚨️ API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.renderers;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.URLEncoder;
+import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -149,7 +149,8 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
 
             String infoUrl = rv.getRule().getExternalInfoUrl();
             if (StringUtils.isNotBlank(infoUrl)) {
-                d = "<a href=\"" + URLEncoder.encode(infoUrl, "UTF-8") + "\">" + d + "</a>";
+                URI uri = URI.create(infoUrl);
+                d = "<a href=\"" + uri + "\">" + d + "</a>";
             }
             buf.append("<td width=\"*\">")
                .append(d)

--- a/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
@@ -23,6 +23,7 @@ public class FooRule extends AbstractRule {
         setName("Foo");
         setDescription("Description with Unicode Character U+2013: \u2013 .");
         setLanguage(DummyLanguageModule.getInstance());
+        setExternalInfoUrl("https://example.org/rules/foo");
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
@@ -122,6 +122,7 @@ abstract class AbstractRendererTest {
         booRule.setName("Boo");
         booRule.setDescription("desc");
         booRule.setPriority(RulePriority.HIGH);
+        booRule.setExternalInfoUrl("https://example.org/rules/boo");
         return booRule;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -61,7 +61,8 @@ class HTMLRendererTest extends AbstractRendererTest {
         return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + EOL + "<td align=\"center\">1</td>" + EOL
                 + "<td width=\"*%\">" + filename + "</td>" + EOL + "<td align=\"center\" width=\"5%\">1</td>" + EOL
-                + "<td width=\"*\">" + getEscapedRuleMessage() + "</td>" + EOL + "</tr>" + EOL + "</table></body></html>" + EOL;
+                + "<td width=\"*\"><a href=\"https://example.org/rules/foo\">" + getEscapedRuleMessage() + "</a></td>" + EOL
+                + "</tr>" + EOL + "</table></body></html>" + EOL;
     }
 
     @Override
@@ -76,9 +77,10 @@ class HTMLRendererTest extends AbstractRendererTest {
         return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + EOL + "<td align=\"center\">1</td>" + EOL
                 + "<td width=\"*%\">" + getEscapedFilename() + "</td>" + EOL + "<td align=\"center\" width=\"5%\">1</td>" + EOL
-                + "<td width=\"*\">" + ruleDescription + "</td>" + EOL + "</tr>" + EOL + "<tr> " + EOL
+                + "<td width=\"*\"><a href=\"https://example.org/rules/foo\">" + ruleDescription + "</a></td>" + EOL + "</tr>" + EOL + "<tr> " + EOL
                 + "<td align=\"center\">2</td>" + EOL + "<td width=\"*%\">" + getEscapedFilename() + "</td>" + EOL
-                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\">" + ruleDescription + "</td>" + EOL + "</tr>"
+                + "<td align=\"center\" width=\"5%\">1</td>" + EOL
+                + "<td width=\"*\"><a href=\"https://example.org/rules/boo\">" + ruleDescription + "</a></td>" + EOL + "</tr>"
                 + EOL + "</table></body></html>" + EOL;
     }
 
@@ -89,7 +91,7 @@ class HTMLRendererTest extends AbstractRendererTest {
                 + "<tr bgcolor=\"lightgrey\"> " + EOL
                 + "<td align=\"left\">someFilename&nbsp;thatNeedsEscaping.ext</td>" + EOL
                 + "<td align=\"center\">1</td>" + EOL
-                + "<td align=\"center\">Foo</td>" + EOL
+                + "<td align=\"center\"><a href=\"https://example.org/rules/foo\">Foo</a></td>" + EOL
                 + "<td align=\"center\">//NOPMD</td>" + EOL
                 + "<td align=\"center\">userMessage should be &lt;script&gt;alert('escaped')&lt;/script&gt;</td>" + EOL
                 + "</tr>" + EOL
@@ -121,7 +123,8 @@ class HTMLRendererTest extends AbstractRendererTest {
         return getHeader()
                 + "</table><hr/><center><h3>Configuration errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + EOL + "<th>Rule</th><th>Problem</th></tr>" + EOL + "<tr bgcolor=\"lightgrey\"> " + EOL
-                + "<td>Foo</td>" + EOL + "<td>a configuration error</td>" + EOL + "</tr>" + EOL + "</table></body></html>"
+                + "<td><a href=\"https://example.org/rules/foo\">Foo</a></td>" + EOL + "<td>a configuration error</td>"
+                + EOL + "</tr>" + EOL + "</table></body></html>"
                 + EOL;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -48,7 +48,7 @@ class SummaryHTMLRendererTest extends AbstractRendererTest {
                 + EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + EOL
                 + "<tr bgcolor=\"lightgrey\"> " + EOL + "<td align=\"center\">1</td>" + EOL
                 + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + EOL
-                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\">blah</td>" + EOL + "</tr>"
+                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\"><a href=\"https://example.org/rules/foo\">blah</a></td>" + EOL + "</tr>"
                 + EOL + "</table></tr></table></body></html>" + EOL;
 
     }
@@ -78,10 +78,10 @@ class SummaryHTMLRendererTest extends AbstractRendererTest {
                 + EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + EOL
                 + "<tr bgcolor=\"lightgrey\"> " + EOL + "<td align=\"center\">1</td>" + EOL
                 + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + EOL
-                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\">blah</td>" + EOL + "</tr>"
+                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\"><a href=\"https://example.org/rules/foo\">blah</a></td>" + EOL + "</tr>"
                 + EOL + "<tr> " + EOL + "<td align=\"center\">2</td>" + EOL
                 + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + EOL
-                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\">blah</td>" + EOL + "</tr>"
+                + "<td align=\"center\" width=\"5%\">1</td>" + EOL + "<td width=\"*\"><a href=\"https://example.org/rules/boo\">blah</a></td>" + EOL + "</tr>"
                 + EOL + "</table></tr></table></body></html>" + EOL;
     }
 
@@ -111,7 +111,7 @@ class SummaryHTMLRendererTest extends AbstractRendererTest {
                 + EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + EOL
                 + "</table><hr/><center><h3>Configuration errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + EOL + "<th>Rule</th><th>Problem</th></tr>" + EOL + "<tr bgcolor=\"lightgrey\"> " + EOL
-                + "<td>Foo</td>" + EOL + "<td>a configuration error</td>" + EOL + "</tr>" + EOL
+                + "<td><a href=\"https://example.org/rules/foo\">Foo</a></td>" + EOL + "<td>a configuration error</td>" + EOL + "</tr>" + EOL
                 + "</table></tr></table></body></html>" + EOL;
     }
 
@@ -130,7 +130,7 @@ class SummaryHTMLRendererTest extends AbstractRendererTest {
                 + "</table><hr/><center><h3>Suppressed warnings</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + EOL + "<th>File</th><th>Line</th><th>Rule</th><th>NOPMD or Annotation</th><th>Reason</th></tr>"
                          + EOL + "<tr bgcolor=\"lightgrey\"> " + EOL + "<td align=\"left\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + EOL
-                + "<td align=\"center\">1</td>" + EOL + "<td align=\"center\">Foo</td>" + EOL
+                + "<td align=\"center\">1</td>" + EOL + "<td align=\"center\"><a href=\"https://example.org/rules/foo\">Foo</a></td>" + EOL
                          + "<td align=\"center\">//NOPMD</td>" + EOL + "<td align=\"center\">test</td>" + EOL
                          + "</tr>"
                 + EOL + "</table></tr></table></body></html>" + EOL, actual);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -52,7 +52,7 @@ class XMLRendererTest extends AbstractRendererTest {
     @Override
     String getExpected() {
         return getHeader() + "<file name=\"" + getSourceCodeFilename() + "\">" + EOL
-                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
+                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" externalInfoUrl=\"https://example.org/rules/foo\" priority=\"5\">"
                 + EOL + "blah" + EOL + "</violation>" + EOL + "</file>" + EOL + "</pmd>" + EOL;
     }
 
@@ -64,9 +64,9 @@ class XMLRendererTest extends AbstractRendererTest {
     @Override
     String getExpectedMultiple() {
         return getHeader() + "<file name=\"" + getSourceCodeFilename() + "\">" + EOL
-                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
+                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" externalInfoUrl=\"https://example.org/rules/foo\" priority=\"5\">"
                 + EOL + "blah" + EOL + "</violation>" + EOL
-                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"2\" rule=\"Boo\" ruleset=\"RuleSet\" priority=\"1\">"
+                + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"2\" rule=\"Boo\" ruleset=\"RuleSet\" externalInfoUrl=\"https://example.org/rules/boo\" priority=\"1\">"
                 + EOL + "blah" + EOL + "</violation>" + EOL + "</file>" + EOL + "</pmd>" + EOL;
     }
 

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected-multiple.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected-multiple.json
@@ -14,7 +14,8 @@
           "description": "blah",
           "rule": "Foo",
           "ruleset": "RuleSet",
-          "priority": 5
+          "priority": 5,
+          "externalInfoUrl": "https://example.org/rules/foo"
         },
         {
           "beginline": 1,
@@ -24,7 +25,8 @@
           "description": "blah",
           "rule": "Boo",
           "ruleset": "RuleSet",
-          "priority": 1
+          "priority": 1,
+          "externalInfoUrl": "https://example.org/rules/boo"
         }
       ]
     }

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected-suppressed.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected-suppressed.json
@@ -16,6 +16,7 @@
           "rule": "Foo",
           "ruleset": "RuleSet",
           "priority": 5,
+          "externalInfoUrl": "https://example.org/rules/foo",
           "suppressiontype": "nopmd",
           "usermsg": "test"
         }

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/json/expected.json
@@ -14,7 +14,8 @@
           "description": "blah",
           "rule": "Foo",
           "ruleset": "RuleSet",
-          "priority": 5
+          "priority": 5,
+          "externalInfoUrl": "https://example.org/rules/foo"
         }
       ]
     }

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple-locations.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple-locations.sarif.json
@@ -17,6 +17,7 @@
               "fullDescription": {
                 "text": "Description with Unicode Character U+2013: – ."
               },
+              "helpUri": "https://example.org/rules/foo",
               "help": {
                 "text": "Description with Unicode Character U+2013: – ."
               },
@@ -39,6 +40,7 @@
               "fullDescription": {
                 "text": "desc"
               },
+              "helpUri": "https://example.org/rules/boo",
               "help": {
                 "text": "desc"
               },

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
@@ -17,6 +17,7 @@
               "fullDescription": {
                 "text": "Description with Unicode Character U+2013: – ."
               },
+              "helpUri": "https://example.org/rules/foo",
               "help": {
                 "text": "Description with Unicode Character U+2013: – ."
               },
@@ -39,6 +40,7 @@
               "fullDescription": {
                 "text": "desc"
               },
+              "helpUri": "https://example.org/rules/boo",
               "help": {
                 "text": "desc"
               },

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
@@ -17,6 +17,7 @@
               "fullDescription": {
                 "text": "Description with Unicode Character U+2013: – ."
               },
+              "helpUri": "https://example.org/rules/foo",
               "help": {
                 "text": "Description with Unicode Character U+2013: – ."
               },

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/xslt/expected-multiple.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/xslt/expected-multiple.html
@@ -193,9 +193,10 @@
             <td>
 						[RuleSet.Foo]
 						 -
-						 
+						 <a href="https://example.org/rules/foo">
 blah
-</td>
+</a>
+            </td>
             <td>1 - 1</td>
          </tr>
          <tr class="b">
@@ -205,9 +206,10 @@ blah
             <td>
 						[RuleSet.Boo]
 						 -
-						 
+						 <a href="https://example.org/rules/boo">
 blah
-</td>
+</a>
+            </td>
             <td>1 - 1</td>
          </tr>
       </table>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/xslt/expected.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/xslt/expected.html
@@ -185,9 +185,10 @@
             <td>
 						[RuleSet.Foo]
 						 -
-						 
+						 <a href="https://example.org/rules/foo">
 blah
-</td>
+</a>
+            </td>
             <td>1 - 1</td>
          </tr>
       </table>


### PR DESCRIPTION
## Describe the PR

Regression introduced via #6475 

## Related issues

- Fix #6503

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

