### PR TITLE
chore: bump json from 2.19.0 to 2.19.2

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.19.0)
+    json (2.19.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
- Fixes https://github.com/pmd/pmd/security/dependabot/97
- Fixes CVE-2026-33210
