### PR TITLE
[java] Fix #6495: Consider length/size in local var for ForLoopCanBeForeach

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -190,6 +190,25 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
             iterableExpr = ((ASTFieldAccess) sizeExpr).getQualifier();
         } else if (COLLECTION_SIZE.matchesCall(sizeExpr)) {
             iterableExpr = ((ASTMethodCall) sizeExpr).getQualifier();
+        } else if (sizeExpr instanceof ASTNamedReferenceExpr) {
+            // Handle case where array length is assigned to a pre-declared variable
+            // e.g., int len = array.length; for (int i = 0; i < len; i++)
+            ASTNamedReferenceExpr varRef = (ASTNamedReferenceExpr) sizeExpr;
+            JVariableSymbol sym = varRef.getReferencedSym();
+            if (sym != null) {
+                ASTVariableId varId = sym.tryGetNode();
+                if (varId != null) {
+                    ASTExpression init = varId.getInitializer();
+                    if (init != null) {
+                        // Check if the variable is initialized to array.length or collection.size()
+                        if (init instanceof ASTFieldAccess && "length".equals(((ASTFieldAccess) init).getName())) {
+                            iterableExpr = ((ASTFieldAccess) init).getQualifier();
+                        } else if (COLLECTION_SIZE.matchesCall(init)) {
+                            iterableExpr = ((ASTMethodCall) init).getQualifier();
+                        }
+                    }
+                }
+            }
         }
 
         if (!(iterableExpr instanceof ASTNamedReferenceExpr)

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ForLoopCanBeForeach.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ForLoopCanBeForeach.xml
@@ -452,4 +452,36 @@ public class Test {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6495 Array length assigned to pre-declared variable - should detect foreach candidate</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class PMD_FN_Demo {
+    public void testFalseNegative(long[] counts) {
+        double total = 0;
+        int len = counts.length;
+        for (int i = 0; i < len; i++) {
+            total += counts[i];
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6495 List size assigned to pre-declared variable - should detect foreach candidate</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+public class PMD_FN_Demo {
+    public void testFalseNegativeList(List<String> items) {
+        int size = items.size();
+        for (int i = 0; i < size; i++) {
+            System.out.println(items.get(i));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**Describe the PR**
This PR fixes a false negative in ForLoopCanBeForeach.

Previously, the rule only recognized loop conditions that directly used ```array.length``` or ```collection.size()``` in the for condition.
It missed equivalent cases where that value was first assigned to a local variable, for example:``` [int len = arr.length;``` ```for (int i = 0; i < len; i++)]```.

The fix extends condition analysis to resolve local variable references and inspect their initializer.
If the variable is initialized from ```array.length``` or ```collection.size()```, the loop is now correctly reported as replaceable by foreach.

Regression tests are added for both:

array length assigned to a local variable
list size assigned to a local variable


Fix #6495

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

