### PR TITLE
[java] Fix #6531: False negative in InsecureCryptoIv with array initializers

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -78,6 +78,9 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
             if (arrayInit != null) {
                 asCtx(data).addViolation(arrayInit);
             }
+        } else if (firstArgumentExpression instanceof ASTArrayInitializer) {
+            // hard coded array
+            asCtx(data).addViolation(firstArgumentExpression);
         } else {
             // string literal
             ASTStringLiteral literal = firstArgumentExpression.descendantsOrSelf()

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
@@ -6,6 +6,9 @@ package net.sourceforge.pmd.lang.java.rule.security;
 
 import net.sourceforge.pmd.test.PmdRuleTst;
 
+/**
+ * Test for {@link InsecureCryptoIvRule}
+ */
 class InsecureCryptoIvTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
@@ -187,4 +187,19 @@ public class Foo {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>Array initializer - #6531</description>
+        <expected-problems>1</expected-problems>
+        <code>
+import javax.crypto.spec.IvParameterSpec;
+
+public class PosCase1 {
+    public void encrypt() throws Exception {
+        // Static byte array initialization with constants
+        byte[] iv = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        new IvParameterSpec(iv);
+    }
+}
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Array initializers were previously only handled as part of `new`, the rule should also check for the shorter syntax.

## Related issues

- Fixes #6531

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

