### PR TITLE
[java] False positive in DontCallThreadRun with super.run()

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -273,7 +273,7 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodCall[ pmd-java:matchesSig("java.lang.Thread#run()") ]
+//MethodCall[ pmd-java:matchesSig("java.lang.Thread#run()") ][count(SuperExpression) = 0]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DontCallThreadRun.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DontCallThreadRun.xml
@@ -56,4 +56,18 @@ public class Foo {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>calling run on superclass #6528</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class TestThread extends Thread {
+
+                public void run() {
+                    super.run();
+                    TestThread.super.run();
+                }
+
+            }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Checks if the method call expression contains `super`. Since the method has no arguments, the only potential match is the receiver.

## Related issues

- Fix #6528 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

