### PR TITLE
[java] New rule: OverridingThreadRun to prefer using Runnable

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -67,7 +67,7 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
     }
 
     private void renderMeasurement(final String label, final TimedResult timedResult,
-            final PrintWriter writer) throws IOException {
+            final PrintWriter writer) {
         writer.write(StringUtils.rightPad(label, LABEL_COLUMN_WIDTH));
 
         final String time = MessageFormat.format(TIME_FORMAT, timedResult.totalTimeNanos.get() / 1000000000.0);

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -371,6 +371,7 @@ public static Foo getFoo() {
             When you use lambdas, this also allows you to write more concise code,
             e.g. `new Thread(() -> System.out.println("Hello!")).start();`.
         </description>
+        <priority>3</priority>
         <properties>
             <property name="xpath">
                 <value>
@@ -381,6 +382,25 @@ public static Foo getFoo() {
                 </value>
             </property>
         </properties>
+        <example>
+<![CDATA[
+public class GreetingThread extends Thread {
+    @Override
+    public void run() {
+        System.out.println("Hello!");
+    }
+}
+new GreetingThread().start(); // not recommended, use Runnable instead
+
+public class GreetingRunnable implements Runnable {
+    @Override
+    public void run() {
+        System.out.println("Hello!");
+    }
+}
+new Thread(new GreetingRunnable()).start(); // preferred
+]]>
+        </example>
     </rule>
     <rule name="UnsynchronizedStaticFormatter"
           language="java"

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -358,6 +358,30 @@ public static Foo getFoo() {
         </example>
     </rule>
 
+    <rule name="OverridingThreadRun"
+          language="java"
+          since="7.24.0"
+          message="Don't override Thread.run() method, use Runnable instead"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#overridingthreadrun">
+        <description>
+            Overriding `Thread::run` method is not recommended. Instead, implement `Runnable`
+            and pass an instance to the thread constructor. Using `Runnable` to represent a task
+            makes it more reusable and allows your class to extend another class.
+            When you use lambdas, this also allows you to write more concise code,
+            e.g. `new Thread(() -> System.out.println("Hello!")).start();`.
+        </description>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//ClassDeclaration[ pmd-java:typeIs('java.lang.Thread') ]/ClassBody
+    /MethodDeclaration[@Name="run"][count(//FormalParameter)=0]
+]]>
+                </value>
+            </property>
+        </properties>
+    </rule>
     <rule name="UnsynchronizedStaticFormatter"
           language="java"
           since="6.11.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/OverridingThreadRunTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/OverridingThreadRunTest.java
@@ -7,4 +7,5 @@ package net.sourceforge.pmd.lang.java.rule.multithreading;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 public class OverridingThreadRunTest extends PmdRuleTst {
+    // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/OverridingThreadRunTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/OverridingThreadRunTest.java
@@ -1,0 +1,10 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.multithreading;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class OverridingThreadRunTest extends PmdRuleTst {
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Overriding run</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code>
+            public class Foo extends Thread {
+                @Override
+                public void run() {
+                }
+            }
+        </code>
+    </test-code>
+    <test-code>
+        <description>Not overriding run</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            public class Foo extends Thread {
+                public Foo(Runnable r) {
+                    super(r);
+                }
+
+                public void run(String s) {
+                    // unrelated method, not overriding Thread.run()
+                }
+            }
+
+            public class Bar implements Runnable {
+                @Override
+                public void run() {
+                }
+
+                public static void main(String[] args) {
+                    new Foo(new Bar()).run();
+                }
+            }
+        </code>
+    </test-code>
+</test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

The new rule suggests using `Runnable` instead of overriding `Thread.run`.

IntelliJ covers this by [AnonymousHasLambdaAlternative](https://www.jetbrains.com/help/inspectopedia/AnonymousHasLambdaAlternative.html)

## Related issues

- Fix #595

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

