### PR TITLE
[java] Fix #4272: False positive in UnitTestShouldIncludeAssert when using assertion in lambda

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
@@ -8,9 +8,11 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTClassLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
@@ -47,12 +49,16 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
         if (body != null
             && TestFrameworksUtil.isTestMethod(method)
             && !TestFrameworksUtil.isExpectAnnotated(method)
-            && body.descendants(ASTMethodCall.class)
+            && getAllMethodCallsFrom(body)
                 .none(isAssertCall
                         .or(call -> extraAsserts.contains(call.getMethodName())))) {
             asCtx(data).addViolation(method);
         }
         return data;
+    }
+
+    private static NodeStream<ASTMethodCall> getAllMethodCallsFrom(ASTBlock body) {
+        return NodeStream.union(body.descendants(ASTMethodCall.class), body.descendants(ASTLambdaExpression.class).descendants(ASTMethodCall.class));
     }
 
     private boolean usesSoftAssertExtension(ASTTypeDeclaration typeDeclaration) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
@@ -1037,4 +1037,22 @@ class ShouldIncludeAssertTest {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>#4272: False positive with assert in lambda</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FooTest {
+    @Test
+    void testWhenComplete() {
+        CompletableFuture<Object> future = CompletableFuture.completedFuture("foo");
+        future.whenComplete((data, exception) -> {
+            assertNotNull(data, "Data shouldn't be null");
+        });
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4272 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

