### PR TITLE
More restrictive check for violation location in tests

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -342,4 +342,9 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         // method only has a default implementation in the interface.
         return super.dysfunctionReason();
     }
+
+    @Override
+    public String toString() {
+        return getLanguage() + ":" + getName();
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -38,7 +38,7 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTIfStatement node, Object data) {
         if (depth + 1 == depthLimit) {
-            asCtx(data).addViolation(node);
+            asCtx(data).addViolation(node.getCondition());
             // return early so that if-else chains are only reported once
             return data;
         }

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.test.schema;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,6 +41,63 @@ import com.github.oowekyala.ooxml.messages.XmlPositioner;
  * @author Clément Fournier
  */
 class BaseTestParserImpl {
+    private static final List<String> RULES_WITH_MULTILINE_LOCATION = Arrays.asList(
+        "apex:ApexCRUDViolation",
+        "apex:ApexDoc",
+        "apex:ApexUnitTestClassShouldHaveAsserts",
+        "apex:ApexUnitTestClassShouldHaveRunAs",
+        "apex:ApexUnitTestMethodShouldHaveIsTestAnnotation",
+        "apex:ApexUnitTestShouldNotUseSeeAllDataTrue",
+        "apex:AvoidDeeplyNestedIfStmts",
+        "apex:AvoidGlobalModifier",
+        "apex:AvoidLogicInTrigger",
+        "apex:CognitiveComplexity",
+        "apex:EmptyCatchBlock",
+        "apex:EmptyIfStmt",
+        "apex:ExcessiveClassLength",
+        "apex:ExcessivePublicCount",
+        "apex:FieldDeclarationsShouldBeAtStart",
+        "apex:FieldNamingConventions",
+        "apex:QueueableWithoutFinalizer",
+        "apex:TestMethodsMustBeInTestClasses",
+        "apex:TooManyFields",
+        "apex:TypeShadowsBuiltInNamespace",
+        "ecmascript:UnnecessaryBlock",
+        "html:UseAltAttributeForImages",
+        "java:AvoidArrayLoops",
+        "java:AvoidRethrowingException",
+        "java:CommentSize",
+        "java:ControlStatementBraces",
+        "java:CouplingBetweenObjects",
+        "java:DanglingJavadoc",
+        "java:DoNotThrowExceptionInFinally",
+        "java:DoNotUseThreads",
+        "java:DontUseFloatTypeForLoopIndices",
+        "java:EmptyControlStatement",
+        "java:ExceptionAsFlowControl",
+        "java:ExcessiveParameterList",
+        "java:ExhaustiveSwitchHasDefault",
+        "java:ForLoopCanBeForeach",
+        "java:IdenticalCatchBranches",
+        "java:JumbledIncrementer",
+        "java:LabeledStatement",
+        "java:NonCaseLabelInSwitch",
+        "java:NonThreadSafeSingleton",
+        "java:PreserveStackTrace",
+        "java:SimplifyBooleanReturns",
+        "java:SwitchDensity",
+        "java:TooFewBranchesForSwitch",
+        "java:TooManyFields",
+        "java:TooManyMethods",
+        "java:UnnecessaryCast",
+        "java:UnusedLabel",
+        "java:UseTryWithResources",
+        "java:UselessParentheses",
+        "java:WhileLoopWithLiteralBoolean",
+        "kotlin:OverrideBothEqualsAndHashcode",
+        "modelica:ClassStartNameEqualsEndName",
+        "plsql:CodeFormat"
+    );
 
     static class ParserV1 extends BaseTestParserImpl {
 
@@ -181,7 +239,11 @@ class BaseTestParserImpl {
                         expectedLineNumbers.add(Integer.valueOf(beginAndEnd[0].trim()));
                         expectedEndLineNumbers.add(Integer.valueOf(beginAndEnd[1].trim()));
                     } else {
-                        expectedLineNumbers.add(Integer.valueOf(num.trim()));
+                        Integer singleLine = Integer.valueOf(num.trim());
+                        expectedLineNumbers.add(singleLine);
+                        if (!RULES_WITH_MULTILINE_LOCATION.contains(descriptor.getRule().toString())) {
+                            expectedEndLineNumbers.add(singleLine);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Describe the PR

Related to #6084, this changes the interpretation of  `expected-linenumbers` in tests to be more restrictive, making it easier to check that the location is specific enough

## Related issues

- #730 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

