### PR TITLE
[java] Fix #6163: ConstructorCallsOverridableMethod: False positive with call to enclosing class

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -157,7 +157,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
         ASTExpression qualifier = call.getQualifier();
         JTypeMirror declaringType = call.getMethodType().getDeclaringType();
         JClassType typeOfThisInstance = call.getEnclosingType().getTypeMirror();
-        return declaringType.equals(typeOfThisInstance) && (qualifier == null || JavaAstUtils.isUnqualifiedThis(qualifier));
+        return typeOfThisInstance.isSubtypeOf(declaringType) && (qualifier == null || JavaAstUtils.isUnqualifiedThis(qualifier));
     }
 
     private static boolean isOverridable(JExecutableSymbol method) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -28,7 +28,9 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
+import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -153,7 +155,9 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
 
     private static boolean isCallOnThisInstance(ASTMethodCall call) {
         ASTExpression qualifier = call.getQualifier();
-        return qualifier == null || JavaAstUtils.isUnqualifiedThis(qualifier);
+        JTypeMirror declaringType = call.getMethodType().getDeclaringType();
+        JClassType typeOfThisInstance = call.getEnclosingType().getTypeMirror();
+        return declaringType.equals(typeOfThisInstance) && (qualifier == null || JavaAstUtils.isUnqualifiedThis(qualifier));
     }
 
     private static boolean isOverridable(JExecutableSymbol method) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
@@ -632,7 +632,7 @@ class Foo1 {
 ]]></code>
     </test-code>
     <test-code>
-        <description>[java] ConstructorCallsOverridableMethod: false positive with call to enclosing class</description>
+        <description>#6163 [java] ConstructorCallsOverridableMethod: false positive with call to enclosing class</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class TestOverridableNestedClass {
@@ -649,5 +649,22 @@ public class TestOverridableNestedClass {
     }
 }
 ]]></code>
+    </test-code>
+    <test-code>
+        <description>[java] ConstructorCallsOverridableMethod: flag implicit call to parent class</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+class SeniorClass {
+    public String toString(){
+        return "IAmSeniorClass";
+    }
+}
+
+class JuniorClass extends SeniorClass {
+    public SeniorClass(){
+        toString();
+    }
+}
+     ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
@@ -631,4 +631,23 @@ class Foo1 {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] ConstructorCallsOverridableMethod: false positive with call to enclosing class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class TestOverridableNestedClass {
+    public String value() {
+        return "42";
+    }
+
+    class Inner {
+        private final String value;
+
+        Inner() {
+            this.value = value();
+        }
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6163

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

