### PR TITLE
[java] Fix #6427: Add bitwise and/or/xor to BINARY_PROMOTED_OPS

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.ADD;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.AND;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.DIV;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.GE;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.GT;
@@ -12,8 +13,10 @@ import static net.sourceforge.pmd.lang.java.ast.BinaryOp.LE;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.LT;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.MOD;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.MUL;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.OR;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.SHIFT_OPS;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.SUB;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.XOR;
 import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.isInfixExprWithOperator;
 
 import java.util.EnumSet;
@@ -53,7 +56,7 @@ import net.sourceforge.pmd.lang.java.types.ast.ExprContext.ExprContextKind;
 public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
 
     private static final Set<BinaryOp> BINARY_PROMOTED_OPS =
-        EnumSet.of(LE, GE, GT, LT, ADD, SUB, MUL, DIV, MOD);
+        EnumSet.of(LE, GE, GT, LT, ADD, SUB, MUL, DIV, MOD, AND, OR, XOR);
 
     public UnnecessaryCastRule() {
         super(ASTCastExpression.class);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -1175,6 +1175,7 @@ class Tester {
             }
             ]]></code>
     </test-code>
+
     <test-code>
         <description>#6237 Error with lambdas in switch expr</description>
         <expected-problems>1</expected-problems>
@@ -1198,6 +1199,22 @@ class Tester {
             interface Supplier<T> {
                 T get();
             }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6427 False positive with bitwise operators</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void testCastLongIsUseful() {
+        int someInt = 1;
+        long withCast = ((long) someInt & 0xFF) << 32;
+        long withCast2 = ((long) someInt | 0xFF) << 32;
+        long withCast3 = ((long) someInt ^ 0xFF) << 32;
+        long withoutCast = (someInt & 0xFF) << 32;
+    }
+}
             ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -1215,6 +1215,37 @@ public class Foo {
         long withoutCast = (someInt & 0xFF) << 32;
     }
 }
-            ]]></code>
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Overload resolution</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int someInt) {
+        bar((long) someInt & 0xFF);
+        bar((long) someInt | 0xFF);
+        bar((long) someInt ^ 0xFF);
+    }
+
+    public void bar(int x) {}
+    public void bar(long x) {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Type of 'var' variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int someInt) {
+        var x = (long) someInt & 0xFF;
+        var y = (long) someInt | 0xFF;
+        var z = (long) someInt ^ 0xFF;
+    }
+}
+        ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix false positive in UnnecessaryCast by adding bitwise and/or/xor to BINARY_PROMOTED_OPS

## Related issues

- Fix #6427 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- n/a Added (in-code) documentation (if needed)
