### PR TITLE
[core][most languages] Fix #4814: deprecate AbstractRule#as ctx

### DIFF
--- a/docs/pages/pmd/devdocs/major_contributions/adding_a_new_javacc_based_language.md
+++ b/docs/pages/pmd/devdocs/major_contributions/adding_a_new_javacc_based_language.md
@@ -167,7 +167,8 @@ The Scala module also has a test, written in Kotlin instead of Java:
 
 
 ### 10. Create an abstract rule class for the language
-*   Extend `AbstractRule` and implement the parser visitor interface for your language *(see AbstractVmRule for example)*
+*   Extend `AbstractRule` and implement the parser visitor interface for your language *(see AbstractVfRule for example)*
+*   Make sure to apply the proper type arguments.
 *   All other rules for your language should extend this class. The purpose of this class is to implement visit
     methods for all AST types to simply delegate to default behavior. This is useful because most rules care only
     about specific AST nodes, but PMD needs to know what to do with each node - so this just lets you use default

--- a/docs/pages/pmd/userdocs/extending/writing_java_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_java_rules.md
@@ -72,24 +72,24 @@ corresponding `visit` method:
 public class MyRule extends AbstractJavaRule {
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext ctx) {
         // This method is called on each node of type ASTVariableId
         // in the AST
 
         if (node.getType() == short.class) {
             // reports a violation at the position of the node
-            // the "data" parameter is a context object handed to by your rule
+            // the "ctx" parameter is a context object handed to by your rule
             // the message for the violation is the message defined in the rule declaration XML element
-            asCtx(data).addViolation(node);
+            ctx.addViolation(node);
         }
 
         // this calls back to the default implementation, which recurses further down the subtree
-        return super.visit(node, data);
+        return super.visit(node, ctx);
     }
 }
 ```
 
-The `super.visit(node, data)` call is super common in rule implementations,
+The `super.visit(node, ctx)` call is super common in rule implementations,
 because it makes the traversal continue by visiting all the descendants of the
 current node.
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractApexRule extends AbstractRule implements ApexVisitor<Object, Object> {
+public abstract class AbstractApexRule extends AbstractRule implements ApexVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -17,7 +17,7 @@ public abstract class AbstractApexRule extends AbstractRule implements ApexVisit
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(n -> n.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AbstractApexUnitTestRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AbstractApexUnitTestRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Do special checks for apex unit test classes and methods
@@ -21,7 +22,7 @@ abstract class AbstractApexUnitTestRule extends AbstractApexRule {
      * newer than API v24 (V176 internal).
      */
     @Override
-    public Object visit(final ASTUserClass node, final Object data) {
+    public RuleContext visit(final ASTUserClass node, final RuleContext data) {
         if (!isTestMethodOrClass(node)) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ApexAssertionsShouldIncludeMessageRule extends AbstractApexUnitTestRule {
 
@@ -22,11 +23,11 @@ public class ApexAssertionsShouldIncludeMessageRule extends AbstractApexUnitTest
     private static final String IS_TRUE = "Assert.isTrue";
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         String methodName = node.getFullMethodName();
 
         if (FAIL.equalsIgnoreCase(methodName) && node.getNumChildren() == 1) {
-            asCtx(data).addViolationWithMessage(node,
+            data.addViolationWithMessage(node,
                     "''{0}'' should have 1 parameters.",
                     FAIL);
         } else if ((ASSERT.equalsIgnoreCase(methodName)
@@ -35,7 +36,7 @@ public class ApexAssertionsShouldIncludeMessageRule extends AbstractApexUnitTest
                 || IS_NULL.equalsIgnoreCase(methodName)
                 || IS_TRUE.equalsIgnoreCase(methodName))
                 && node.getNumChildren() == 2) {
-            asCtx(data).addViolationWithMessage(node,
+            data.addViolationWithMessage(node,
                     "''{0}'' should have 2 parameters.",
                     methodName);
         } else if ((ASSERT_EQUALS.equalsIgnoreCase(methodName)
@@ -45,7 +46,7 @@ public class ApexAssertionsShouldIncludeMessageRule extends AbstractApexUnitTest
                 || IS_INSTANCE_OF_TYPE.equalsIgnoreCase(methodName)
                 || IS_NOT_INSTANCE_OF_TYPE.equalsIgnoreCase(methodName))
                 && node.getNumChildren() == 3) {
-            asCtx(data).addViolationWithMessage(node,
+            data.addViolationWithMessage(node,
                     "''{0}'' should have 3 parameters.",
                     methodName);
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Apex unit tests should have System.assert methods in them
@@ -75,7 +76,7 @@ public class ApexUnitTestClassShouldHaveAssertsRule extends AbstractApexUnitTest
     }
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (!isTestMethodOrClass(node)) {
             return data;
         }
@@ -83,7 +84,7 @@ public class ApexUnitTestClassShouldHaveAssertsRule extends AbstractApexUnitTest
         return checkForAssertStatements(node, data);
     }
 
-    private Object checkForAssertStatements(ApexNode<?> node, Object data) {
+    private RuleContext checkForAssertStatements(ApexNode<?> node, RuleContext data) {
         final List<ASTBlockStatement> blockStatements = node.descendants(ASTBlockStatement.class).toList();
         final List<ASTMethodCallExpression> methodCalls = new ArrayList<>();
         for (ASTBlockStatement blockStatement : blockStatements) {
@@ -115,7 +116,7 @@ public class ApexUnitTestClassShouldHaveAssertsRule extends AbstractApexUnitTest
         }
 
         if (!isAssertFound) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunAsRule.java
@@ -9,6 +9,7 @@ import java.util.List;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTRunAsBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Apex unit tests should have System.runAs methods in them
@@ -18,7 +19,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 public class ApexUnitTestClassShouldHaveRunAsRule extends AbstractApexUnitTestRule {
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (!isTestMethodOrClass(node)) {
             return data;
         }
@@ -26,11 +27,11 @@ public class ApexUnitTestClassShouldHaveRunAsRule extends AbstractApexUnitTestRu
         return checkForRunAsStatements(node, data);
     }
 
-    private Object checkForRunAsStatements(ApexNode<?> node, Object data) {
+    private RuleContext checkForRunAsStatements(ApexNode<?> node, RuleContext data) {
         final List<ASTRunAsBlockStatement> runAsStatements = node.descendants(ASTRunAsBlockStatement.class).toList();
 
         if (runAsStatements.isEmpty()) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * <p>
@@ -22,7 +23,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnitTestRule {
 
     @Override
-    public Object visit(final ASTUserClass node, final Object data) {
+    public RuleContext visit(final ASTUserClass node, final RuleContext data) {
         if (!isTestMethodOrClass(node)) {
             return data;
         }
@@ -32,7 +33,7 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
     }
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (!isTestMethodOrClass(node)) {
             return data;
         }
@@ -40,14 +41,14 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
         return checkForSeeAllData(node, data);
     }
 
-    private Object checkForSeeAllData(final ApexNode<?> node, final Object data) {
+    private RuleContext checkForSeeAllData(final ApexNode<?> node, final RuleContext data) {
         final ASTModifierNode modifierNode = node.firstChild(ASTModifierNode.class);
 
         if (modifierNode != null) {
             for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
                 if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA)
                         && (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue()))) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                     return data;
                 }
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
@@ -11,24 +11,25 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidGlobalModifierRule extends AbstractApexRule {
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         return checkForGlobal(node, data);
     }
 
     @Override
-    public Object visit(ASTUserInterface node, Object data) {
+    public RuleContext visit(ASTUserInterface node, RuleContext data) {
         return checkForGlobal(node, data);
     }
 
-    private Object checkForGlobal(ApexNode<?> node, Object data) {
+    private RuleContext checkForGlobal(ApexNode<?> node, RuleContext data) {
         ASTModifierNode modifierNode = node.firstChild(ASTModifierNode.class);
 
         if (isGlobal(modifierNode) && !hasRestAnnotation(modifierNode) && !hasWebServices(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         // Note, the rule reports the whole class, since that's enough and stops to visit right here.

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidLogicInTriggerRule extends AbstractApexRule {
 
@@ -21,11 +22,11 @@ public class AvoidLogicInTriggerRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserTrigger node, Object data) {
+    public RuleContext visit(ASTUserTrigger node, RuleContext data) {
         List<ASTBlockStatement> blockStatements = node.descendants(ASTBlockStatement.class).toList();
 
         if (!blockStatements.isEmpty()) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Scans classes which implement the `Queueable` interface. If the `public void
@@ -41,14 +42,14 @@ public class QueueableWithoutFinalizerRule extends AbstractApexRule {
      * `System.attachFinalizer(Finalizer f)` method, then add a violation.
      */
     @Override
-    public Object visit(ASTUserClass theClass, Object data) {
+    public RuleContext visit(ASTUserClass theClass, RuleContext data) {
         if (!implementsTheQueueableInterface(theClass)) {
             return data;
         }
         for (ASTMethod theMethod : theClass.descendants(ASTMethod.class).toList()) {
             if (isTheExecuteMethodOfTheQueueableInterface(theMethod)
                     && !callsTheSystemAttachFinalizerMethod(theMethod)) {
-                asCtx(data).addViolation(theMethod);
+                data.addViolation(theMethod);
             }
         }
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedLocalVariableRule extends AbstractApexRule {
     private static final Set<String> DATABASE_QUERY_METHODS = new HashSet<>(Arrays.asList(
@@ -45,7 +46,7 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTVariableDeclaration node, RuleContext data) {
         String variableName = node.getImage();
 
         ASTBlockStatement variableContext = node.ancestors(ASTBlockStatement.class).first();
@@ -77,7 +78,7 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
             return data;
         }
 
-        asCtx(data).addViolation(node, variableName);
+        data.addViolation(node, variableName);
         return data;
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.properties.PropertyBuilder;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 abstract class AbstractNamingConventionsRule extends AbstractApexRule {
     protected static final Pattern CAMEL_CASE = Pattern.compile("[a-z][a-zA-Z0-9]*");
@@ -23,15 +24,15 @@ abstract class AbstractNamingConventionsRule extends AbstractApexRule {
 
     abstract String displayName(String name);
 
-    protected void checkMatches(PropertyDescriptor<Pattern> propertyDescriptor, ApexNode<?> node, Object data) {
+    protected void checkMatches(PropertyDescriptor<Pattern> propertyDescriptor, ApexNode<?> node, RuleContext data) {
         checkMatches(propertyDescriptor, getProperty(propertyDescriptor), node, data);
     }
 
-    protected void checkMatches(PropertyDescriptor<Pattern> propertyDescriptor, Pattern overridePattern, ApexNode<?> node, Object data) {
+    protected void checkMatches(PropertyDescriptor<Pattern> propertyDescriptor, Pattern overridePattern, ApexNode<?> node, RuleContext data) {
         String name = Objects.requireNonNull(node.getImage());
         if (!overridePattern.matcher(name).matches()) {
             String displayName = displayName(propertyDescriptor.name());
-            asCtx(data).addViolation(node, displayName, name, overridePattern.toString());
+            data.addViolation(node, displayName, name, overridePattern.toString());
         }
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AnnotationsNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AnnotationsNamingConventionsRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclarationStatements;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Rule that checks if Apex annotations are written in PascalCase. This rule
@@ -20,9 +21,9 @@ import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 public class AnnotationsNamingConventionsRule extends AbstractApexRule {
 
     @Override
-    public Object visit(ASTAnnotation annotation, Object data) {
+    public RuleContext visit(ASTAnnotation annotation, RuleContext data) {
         if (annotation.isResolved() && isNotField(annotation) && !isPascalCase(annotation)) {
-            asCtx(data).addViolation(annotation, annotation.getRawName(), annotation.getName());
+            data.addViolation(annotation, annotation.getRawName(), annotation.getName());
         }
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -56,7 +57,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (node.isNested()) {
             checkMatches(INNER_CLASS_REGEX, node, data);
         } else if (node.getModifiers().isTest()) {
@@ -71,7 +72,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
     }
 
     @Override
-    public Object visit(ASTUserInterface node, Object data) {
+    public RuleContext visit(ASTUserInterface node, RuleContext data) {
         if (node.isNested()) {
             checkMatches(INNER_INTERFACE_REGEX, node, data);
         } else {
@@ -82,7 +83,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
     }
 
     @Override
-    public Object visit(ASTUserEnum node, Object data) {
+    public RuleContext visit(ASTUserEnum node, RuleContext data) {
         checkMatches(ENUM_REGEX, node, data);
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
     private static final Comparator<ApexNode<?>> NODE_BY_SOURCE_LOCATION_COMPARATOR =
@@ -33,7 +34,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         // Unfortunately the parser re-orders the AST to put field declarations before method declarations
         // so we have to rely on line numbers / positions to work out where the first non-field declaration starts
         // so we can check if the fields are in acceptable places.
@@ -58,7 +59,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
 
         for (ASTFieldDeclaration field : fields) {
             if (NODE_BY_SOURCE_LOCATION_COMPARATOR.compare(field, firstNonFieldDeclaration.get()) > 0) {
-                asCtx(data).addViolation(field, field.getName());
+                data.addViolation(field, field.getName());
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldNamingConventionsRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class FieldNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -51,7 +52,7 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionsRule {
     }
 
     @Override
-    public Object visit(ASTField node, Object data) {
+    public RuleContext visit(ASTField node, RuleContext data) {
         if (node.ancestors(ASTProperty.class).first() != null) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FormalParameterNamingConventionsRule.java
@@ -13,6 +13,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class FormalParameterNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -34,7 +35,7 @@ public class FormalParameterNamingConventionsRule extends AbstractNamingConventi
     }
 
     @Override
-    public Object visit(ASTParameter node, Object data) {
+    public RuleContext visit(ASTParameter node, RuleContext data) {
         // classes that extend Exception will contains methods that have parameters with null names
         if (node.getImage() == null) {
             return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/LocalVariableNamingConventionsRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclarationStatements;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LocalVariableNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -37,7 +38,7 @@ public class LocalVariableNamingConventionsRule extends AbstractNamingConvention
 
 
     @Override
-    public Object visit(ASTVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTVariableDeclaration node, RuleContext data) {
         if (node.ancestors(ASTVariableDeclarationStatements.class).first().getModifiers().isFinal()) {
             checkMatches(FINAL_REGEX, node, data);
         } else {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class MethodNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -42,7 +43,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionsRule {
 
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (isOverriddenMethod(node) || isPropertyAccessor(node) || isConstructor(node)) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/PropertyNamingConventionsRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class PropertyNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
@@ -37,7 +38,7 @@ public class PropertyNamingConventionsRule extends AbstractNamingConventionsRule
 
 
     @Override
-    public Object visit(ASTField node, Object data) {
+    public RuleContext visit(ASTField node, RuleContext data) {
         if (node.ancestors(ASTProperty.class).first() == null) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Rule that detects boolean parameters in public and global Apex methods.
@@ -46,12 +47,12 @@ public class AvoidBooleanMethodParametersRule extends AbstractApexRule {
      * @return the rule context data
      */
     @Override
-    public Object visit(ASTMethod theMethod, Object data) {
+    public RuleContext visit(ASTMethod theMethod, RuleContext data) {
         if (!isPublicOrGlobal(theMethod)) {
             return data;
         }
         theMethod.descendants(ASTParameter.class).filter(parameter -> isBoolean(parameter))
-                .forEach(parameter -> asCtx(data).addViolation(parameter));
+                .forEach(parameter -> data.addViolation(parameter));
         return data;
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -34,12 +34,12 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTIfBlockStatement node, Object data) {
+    public RuleContext visit(ASTIfBlockStatement node, RuleContext data) {
         depth++;
 
         super.visit(node, data);
         if (depth == depthLimit) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         depth--;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class CognitiveComplexityRule extends AbstractApexRule {
 
@@ -45,7 +46,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserTrigger node, Object data) {
+    public RuleContext visit(ASTUserTrigger node, RuleContext data) {
         inTrigger = true;
         super.visit(node, data);
         inTrigger = false;
@@ -54,7 +55,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
 
         classNames.push(node.getSimpleName());
         super.visit(node, data);
@@ -75,7 +76,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
                     String.valueOf(classLevelThreshold),
                 };
 
-                asCtx(data).addViolation(node, (Object[]) messageParams);
+                data.addViolation(node, (Object[]) messageParams);
             }
         }
         return data;
@@ -83,7 +84,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public final Object visit(ASTMethod node, Object data) {
+    public final RuleContext visit(ASTMethod node, RuleContext data) {
 
         if (ApexMetrics.COGNITIVE_COMPLEXITY.supports(node)) {
             int cognitive = MetricsUtil.computeMetric(ApexMetrics.COGNITIVE_COMPLEXITY, node);
@@ -93,7 +94,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
                         : node.getImage().equals(classNames.peek()) ? "constructor"
                         : "method";
 
-                asCtx(data).addViolation(node, opType,
+                data.addViolation(node, opType,
                         node.getQualifiedName().getOperation(),
                         "",
                         "" + cognitive,

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -52,7 +53,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserTrigger node, Object data) {
+    public RuleContext visit(ASTUserTrigger node, RuleContext data) {
         inTrigger = true;
         super.visit(node, data);
         inTrigger = false;
@@ -61,7 +62,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
 
         classNames.push(node.getSimpleName());
         super.visit(node, data);
@@ -78,7 +79,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
                                           " total",
                                           classWmc + " (highest " + classHighest + ")", };
 
-                asCtx(data).addViolation(node, (Object[]) messageParams);
+                data.addViolation(node, (Object[]) messageParams);
             }
         }
         return data;
@@ -86,7 +87,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
 
 
     @Override
-    public final Object visit(ASTMethod node, Object data) {
+    public final RuleContext visit(ASTMethod node, RuleContext data) {
 
         if (ApexMetrics.CYCLO.supports(node)) {
             int cyclo = MetricsUtil.computeMetric(ApexMetrics.CYCLO, node);
@@ -95,7 +96,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
                                           : node.getImage().equals(classNames.peek()) ? "constructor"
                                                                                       : "method";
 
-                asCtx(data).addViolation(node, opType,
+                data.addViolation(node, opType,
                         node.getQualifiedName().getOperation(),
                         "",
                         "" + cyclo);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssCountRule.java
@@ -59,14 +59,14 @@ public final class NcssCountRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visitApexNode(ApexNode<?> node, Object data) {
+    public RuleContext visitApexNode(ApexNode<?> node, RuleContext data) {
         int methodReportLevel = getProperty(METHOD_REPORT_LEVEL_DESCRIPTOR);
         int classReportLevel = getProperty(CLASS_REPORT_LEVEL_DESCRIPTOR);
 
         if (node instanceof ASTUserClassOrInterface) {
-            visitTypeDecl((ASTUserClassOrInterface<?>) node, classReportLevel, (RuleContext) data);
+            visitTypeDecl((ASTUserClassOrInterface<?>) node, classReportLevel, data);
         } else if (node instanceof ASTMethod) {
-            visitMethod((ASTMethod) node, methodReportLevel, (RuleContext) data);
+            visitMethod((ASTMethod) node, methodReportLevel, data);
         } else {
             throw AssertionUtil.shouldNotReachHere("node is not handled: " + node);
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -94,13 +94,13 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
         if (showClassesComplexity) {
             if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node, "class", node.getSimpleName(),
+                data.addViolation(node, "class", node.getSimpleName(),
                     classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
             }
         }
@@ -108,13 +108,13 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserTrigger node, Object data) {
+    public RuleContext visit(ASTUserTrigger node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
         if (showClassesComplexity) {
             if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node, "trigger", node.getSimpleName(),
+                data.addViolation(node, "trigger", node.getSimpleName(),
                     classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
             }
         }
@@ -122,17 +122,17 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserInterface node, Object data) {
+    public RuleContext visit(ASTUserInterface node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTUserEnum node, Object data) {
+    public RuleContext visit(ASTUserEnum node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry methodEntry = entryStack.pop();
@@ -147,63 +147,63 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
 
         if (showMethodsComplexity && methodEntry.decisionPoints >= reportLevel) {
             String methodType = node.isConstructor() ? "constructor" : "method";
-            asCtx(data).addViolation(node,
+            data.addViolation(node,
                     methodType, node.getImage(), String.valueOf(methodEntry.decisionPoints));
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTIfBlockStatement node, Object data) {
+    public RuleContext visit(ASTIfBlockStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTTryCatchFinallyBlockStatement node, Object data) {
+    public RuleContext visit(ASTTryCatchFinallyBlockStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTForLoopStatement node, Object data) {
+    public RuleContext visit(ASTForLoopStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTForEachStatement node, Object data) {
+    public RuleContext visit(ASTForEachStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTWhileLoopStatement node, Object data) {
+    public RuleContext visit(ASTWhileLoopStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDoLoopStatement node, Object data) {
+    public RuleContext visit(ASTDoLoopStatement node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTTernaryExpression node, Object data) {
+    public RuleContext visit(ASTTernaryExpression node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTBooleanExpression node, Object data) {
+    public RuleContext visit(ASTBooleanExpression node, RuleContext data) {
         return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class TooManyFieldsRule extends AbstractApexRule {
 
@@ -41,7 +42,7 @@ public class TooManyFieldsRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
 
         List<ASTField> fields = node.children(ASTField.class).toList();
 
@@ -53,7 +54,7 @@ public class TooManyFieldsRule extends AbstractApexRule {
             val++;
         }
         if (val > getProperty(MAX_FIELDS_DESCRIPTOR)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
@@ -6,19 +6,20 @@ package net.sourceforge.pmd.lang.apex.rule.design;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 import com.nawforce.pkgforce.diagnostics.UNUSED_CATEGORY;
 
 public class UnusedMethodRule extends AbstractApexRule {
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         // Check if any 'Unused' Issues align with this method
         node.getRoot().getGlobalIssues().stream()
             .filter(issue -> issue.rule().name().equals(UNUSED_CATEGORY.name()))
             .filter(issue -> issue.fileLocation().startLineNumber() == node.getBeginLine())
             .filter(issue -> issue.fileLocation().endLineNumber() <= node.getBeginLine())
-            .forEach(issue -> asCtx(data).addViolation(node));
+            .forEach(issue -> data.addViolation(node));
         return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Validates ApexDoc comments according to the Salesforce ApexDoc specification.
@@ -73,19 +74,19 @@ public class ApexDocRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         handleClassOrInterface(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTUserInterface node, Object data) {
+    public RuleContext visit(ASTUserInterface node, RuleContext data) {
         handleClassOrInterface(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (node.getParent() instanceof ASTProperty) {
             // Skip property methods, doc is required on the property itself
             return data;
@@ -94,20 +95,20 @@ public class ApexDocRule extends AbstractApexRule {
         ApexDocComment comment = getApexDocComment(node);
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
 
             String returnType = node.getReturnType();
             boolean shouldHaveReturn = !(returnType.isEmpty() || "void".equalsIgnoreCase(returnType));
             if (comment.hasReturn != shouldHaveReturn) {
                 if (shouldHaveReturn) {
-                    asCtx(data).addViolationWithMessage(node, MISSING_RETURN_MESSAGE);
+                    data.addViolationWithMessage(node, MISSING_RETURN_MESSAGE);
                 } else {
-                    asCtx(data).addViolationWithMessage(node, UNEXPECTED_RETURN_MESSAGE);
+                    data.addViolationWithMessage(node, UNEXPECTED_RETURN_MESSAGE);
                 }
             }
 
@@ -116,7 +117,7 @@ public class ApexDocRule extends AbstractApexRule {
                     .collect(Collectors.toList());
 
             if (!comment.params.equals(params)) {
-                asCtx(data).addViolationWithMessage(node, MISMATCHED_PARAM_MESSAGE);
+                data.addViolationWithMessage(node, MISMATCHED_PARAM_MESSAGE);
             }
         }
 
@@ -124,31 +125,31 @@ public class ApexDocRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTProperty node, Object data) {
+    public RuleContext visit(ASTProperty node, RuleContext data) {
         ApexDocComment comment = getApexDocComment(node);
 
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
         }
 
         return data;
     }
 
-    private void handleClassOrInterface(ApexNode<?> node, Object data) {
+    private void handleClassOrInterface(ApexNode<?> node, RuleContext data) {
         ApexDocComment comment = getApexDocComment(node);
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
+                data.addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Constructor and init method might contain DML, which constitutes a CSRF
@@ -21,7 +22,7 @@ public class ApexCSRFRule extends AbstractApexRule {
     public static final String INIT = "init";
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
         }
@@ -30,7 +31,7 @@ public class ApexCSRFRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTMethod node, Object data) {
+    public RuleContext visit(ASTMethod node, RuleContext data) {
         if (!Helper.isTestMethodOrClass(node)) {
             checkForCSRF(node, data);
         }
@@ -38,21 +39,21 @@ public class ApexCSRFRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTBlockStatement node, Object data) {
+    public RuleContext visit(ASTBlockStatement node, RuleContext data) {
         if (node.getParent() instanceof ASTUserClass && Helper.foundAnyDML(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }
 
-    private void checkForCSRF(ASTMethod node, Object data) {
+    private void checkForCSRF(ASTMethod node, RuleContext data) {
         if (node.isConstructor() && Helper.foundAnyDML(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         String name = node.getImage();
         if ((node.isStaticInitializer() || isInitializerMethod(name)) && Helper.foundAnyDML(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
@@ -14,6 +14,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidHardcodingIdRule extends AbstractApexRule {
     private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9]{5}0[a-zA-Z0-9]{9}([a-zA-Z0-5]{3})?$");
@@ -37,7 +38,7 @@ public class AvoidHardcodingIdRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTLiteralExpression node, Object data) {
+    public RuleContext visit(ASTLiteralExpression node, RuleContext data) {
         if (node.isString()) {
             String literal = node.getImage();
             if (PATTERN.matcher(literal).matches()) {
@@ -45,7 +46,7 @@ public class AvoidHardcodingIdRule extends AbstractApexRule {
                 if (literal.length() == 18 && !validateChecksum(literal)) {
                     return data;
                 }
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidInterfaceAsMapKeyRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 import com.nawforce.apexlink.api.MethodSummary;
 import com.nawforce.apexlink.api.ParameterSummary;
@@ -51,12 +52,12 @@ public class AvoidInterfaceAsMapKeyRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTApexFile node, Object data) {
+    public RuleContext visit(ASTApexFile node, RuleContext data) {
         // Build index once per run (lazily on first file visit)
         TypeHierarchyIndex index = getOrCreateIndex(node.getTypeSummaries());
         for (MapKeyUsage usage : collectMapKeyUsages(node)) {
             if (index.isProblematicInterfaceKey(usage.keyTypeName)) {
-                asCtx(data).addViolation(usage.reportNode);
+                data.addViolation(usage.reportNode);
             }
         }
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Apex supported non existent annotations for legacy reasons.
@@ -25,46 +26,46 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
  */
 public class AvoidNonExistentAnnotationsRule extends AbstractApexRule {
     @Override
-    public Object visit(final ASTUserClass node, final Object data) {
+    public RuleContext visit(final ASTUserClass node, final RuleContext data) {
         checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTUserInterface node, final Object data) {
+    public RuleContext visit(final ASTUserInterface node, final RuleContext data) {
         checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTUserEnum node, final Object data) {
+    public RuleContext visit(final ASTUserEnum node, final RuleContext data) {
         checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTMethod node, final Object data) {
+    public RuleContext visit(final ASTMethod node, final RuleContext data) {
         return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
     @Override
-    public Object visit(final ASTProperty node, final Object data) {
+    public RuleContext visit(final ASTProperty node, final RuleContext data) {
         // may have nested methods, don't visit children
         return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
     @Override
-    public Object visit(final ASTField node, final Object data) {
+    public RuleContext visit(final ASTField node, final RuleContext data) {
         return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
-    private Object checkForNonExistentAnnotation(final ApexNode<?> node, final ASTModifierNode modifierNode, final Object data) {
+    private RuleContext checkForNonExistentAnnotation(final ApexNode<?> node, final ASTModifierNode modifierNode, final RuleContext data) {
         if (modifierNode == null) {
             return data;
         }
         for (ASTAnnotation annotation : modifierNode.children(ASTAnnotation.class)) {
             if (!annotation.isResolved()) {
-                asCtx(data).addViolationWithMessage(node, "Use of non existent annotations will lead to broken Apex code which will not compile in the future.");
+                data.addViolationWithMessage(node, "Use of non existent annotations will lead to broken Apex code which will not compile in the future.");
             }
         }
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
@@ -38,7 +39,7 @@ public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass theClass, Object data) {
+    public RuleContext visit(ASTUserClass theClass, RuleContext data) {
         if (!implementsDatabaseStateful(theClass)) {
             return data;
         }
@@ -46,7 +47,7 @@ public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
         // interface, so we only need to check the top level class
         for (ASTField theField : theClass.descendants(ASTField.class)) {
             if (isNonTransientInstanceDatabaseResultField(theField)) {
-                asCtx(data).addViolation(theField);
+                data.addViolation(theField);
             }
         }
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * In the Summer '21 release, a mandatory security update enforces access
@@ -29,7 +30,7 @@ public class InaccessibleAuraEnabledGetterRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTProperty node, Object data) {
+    public RuleContext visit(ASTProperty node, RuleContext data) {
         // Find @AuraEnabled property
         ASTModifierNode propModifiers = node.getModifiers();
         if (hasAuraEnabledAnnotation(propModifiers)) {
@@ -40,7 +41,7 @@ public class InaccessibleAuraEnabledGetterRule extends AbstractApexRule {
                     // Ensure getter is not private or protected
                     ASTModifierNode methodModifiers = method.getModifiers();
                     if (isPrivate(methodModifiers) || isProtected(methodModifiers)) {
-                        asCtx(data).addViolation(node);
+                        data.addViolation(node);
                     }
                 }
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class MethodWithSameNameAsEnclosingClassRule extends AbstractApexRule {
 
@@ -20,14 +21,14 @@ public class MethodWithSameNameAsEnclosingClassRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         String className = node.getSimpleName();
 
         for (ASTMethod m : node.descendants(ASTMethod.class)) {
             String methodName = m.getImage();
 
             if (!m.isConstructor() && methodName.equalsIgnoreCase(className)) {
-                asCtx(data).addViolation(m);
+                data.addViolation(m);
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
 
@@ -21,7 +22,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         ApexNode<?> equalsNode = null;
         ApexNode<?> hashNode = null;
         for (ASTMethod method : node.children(ASTMethod.class)) {
@@ -37,9 +38,9 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
         }
 
         if (equalsNode != null && hashNode == null) {
-            asCtx(data).addViolation(equalsNode);
+            data.addViolation(equalsNode);
         } else if (hashNode != null && equalsNode == null) {
-            asCtx(data).addViolation(hashNode);
+            data.addViolation(hashNode);
         }
 
         return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.document.FileLocation;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -66,7 +67,7 @@ public abstract class AbstractCounterCheckRule<T extends ApexNode<?>> extends Ab
     }
 
     @Override
-    public Object visitApexNode(ApexNode<?> node, Object data) {
+    public RuleContext visitApexNode(ApexNode<?> node, RuleContext data) {
         @SuppressWarnings("unchecked")
         T t = (T) node;
         // since we only visit this node, it's ok
@@ -75,7 +76,7 @@ public abstract class AbstractCounterCheckRule<T extends ApexNode<?>> extends Ab
             int metric = getMetric(t);
             int limit = getProperty(reportLevel);
             if (metric >= limit) {
-                asCtx(data).addViolationWithPosition(t, t.getAstInfo(), getReportLocation(t), getMessage(), getViolationParameters(t, metric, limit));
+                data.addViolationWithPosition(t, t.getAstInfo(), getReportLocation(t), getMessage(), getViolationParameters(t, metric, limit));
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AbstractAvoidNodeInLoopsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AbstractAvoidNodeInLoopsRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Base class for any rules that detect operations contained within a loop that could be more efficiently executed by
@@ -23,9 +24,9 @@ abstract class AbstractAvoidNodeInLoopsRule extends AbstractApexRule {
      * Adds a violation if any parent of {@code node} is a looping construct that would cause {@code node} to execute
      * multiple times and {@code node} is not part of a return statement that short circuits the loop.
      */
-    protected Object checkForViolation(ApexNode<?> node, Object data) {
+    protected RuleContext checkForViolation(ApexNode<?> node, RuleContext data) {
         if (insideLoop(node) && parentNotReturn(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesRule.java
@@ -34,14 +34,14 @@ public class AvoidNonRestrictiveQueriesRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTSoqlExpression node, Object data) {
-        visitSoqlOrSosl(node, "SOQL", node.getQuery(), asCtx(data));
+    public RuleContext visit(ASTSoqlExpression node, RuleContext data) {
+        visitSoqlOrSosl(node, "SOQL", node.getQuery(), data);
         return data;
     }
 
     @Override
-    public Object visit(ASTSoslExpression node, Object data) {
-        visitSoqlOrSosl(node, "SOSL", node.getQuery(), asCtx(data));
+    public RuleContext visit(ASTSoslExpression node, RuleContext data) {
+        visitSoqlOrSosl(node, "SOSL", node.getQuery(), data);
         return data;
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithHighCostInLoopRule.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
@@ -36,7 +37,7 @@ public class OperationWithHighCostInLoopRule extends AbstractAvoidNodeInLoopsRul
 
     // Begin general method invocations
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         if (checkHighCostClassMethods(node)) {
             return checkForViolation(node, data);
         } else {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/OperationWithLimitsInLoopRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTSoslExpression;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Warn users when code that could trigger governor limits is executing within a looping construct.
@@ -54,46 +55,46 @@ public class OperationWithLimitsInLoopRule extends AbstractAvoidNodeInLoopsRule 
 
     // Begin DML Statements
     @Override
-    public Object visit(ASTDmlDeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlDeleteStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTDmlInsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlInsertStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTDmlMergeStatement node, Object data) {
+    public RuleContext visit(ASTDmlMergeStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTDmlUndeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlUndeleteStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTDmlUpdateStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpdateStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTDmlUpsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpsertStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
     // End DML Statements
 
     // Begin SOQL method invocations
     @Override
-    public Object visit(ASTSoqlExpression node, Object data) {
+    public RuleContext visit(ASTSoqlExpression node, RuleContext data) {
         return checkForViolation(node, data);
     }
     // End SOQL method invocations
 
     // Begin SOSL method invocations
     @Override
-    public Object visit(ASTSoslExpression node, Object data) {
+    public RuleContext visit(ASTSoslExpression node, RuleContext data) {
         return checkForViolation(node, data);
     }
     // End SOSL method invocations
@@ -101,12 +102,12 @@ public class OperationWithLimitsInLoopRule extends AbstractAvoidNodeInLoopsRule 
     // Begin general method invocations
 
     @Override
-    public Object visit(ASTRunAsBlockStatement node, Object data) {
+    public RuleContext visit(ASTRunAsBlockStatement node, RuleContext data) {
         return checkForViolation(node, data);
     }
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         if (Helper.isAnyDatabaseMethodCall(node)
             || Helper.isMethodName(node, APPROVAL_CLASS_NAME, Helper.ANY_METHOD)
             || checkLimitClassMethods(node, MESSAGING_CLASS_NAME, MESSAGING_LIMIT_METHODS)

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Finds encryption schemes using hardcoded IV, hardcoded key
@@ -44,7 +45,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node)) {
             return data;
         }
@@ -84,7 +85,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
         }
     }
 
-    private void validateStaticIVOrKey(ASTMethodCallExpression methodCall, Object data) {
+    private void validateStaticIVOrKey(ASTMethodCallExpression methodCall, RuleContext data) {
         // .encrypt('AES128', key, exampleIv, data);
         int numberOfChildren = methodCall.getNumChildren();
         switch (numberOfChildren) {
@@ -108,7 +109,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
 
     }
 
-    private void reportIfHardCoded(Object data, Object potentialIV) {
+    private void reportIfHardCoded(RuleContext data, Object potentialIV) {
         if (potentialIV instanceof ASTMethodCallExpression) {
             ASTMethodCallExpression expression = (ASTMethodCallExpression) potentialIV;
             if (expression.getNumChildren() > 1) {
@@ -116,14 +117,14 @@ public class ApexBadCryptoRule extends AbstractApexRule {
                 if (potentialStaticIV instanceof ASTLiteralExpression) {
                     ASTLiteralExpression variable = (ASTLiteralExpression) potentialStaticIV;
                     if (variable.isString()) {
-                        asCtx(data).addViolation(variable);
+                        data.addViolation(variable);
                     }
                 }
             }
         } else if (potentialIV instanceof ASTVariableExpression) {
             ASTVariableExpression variable = (ASTVariableExpression) potentialIV;
             if (potentiallyStaticBlob.contains(Helper.getFQVariableName(variable))) {
-                asCtx(data).addViolation(variable);
+                data.addViolation(variable);
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -176,7 +176,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
         }
@@ -192,7 +192,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         if (Helper.isAnyDatabaseMethodCall(node)) {
 
             if (hasAccessLevelArgument(node)) {
@@ -265,7 +265,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlInsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlInsertStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -275,7 +275,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlDeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlDeleteStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -285,7 +285,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlUndeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlUndeleteStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -295,7 +295,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlUpdateStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpdateStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -305,7 +305,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlUpsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpsertStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -316,7 +316,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTDmlMergeStatement node, Object data) {
+    public RuleContext visit(ASTDmlMergeStatement node, RuleContext data) {
         if (hasRunAsMode(node)) {
             return data;
         }
@@ -326,7 +326,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(final ASTAssignmentExpression node, Object data) {
+    public RuleContext visit(final ASTAssignmentExpression node, RuleContext data) {
         final ASTSoqlExpression soql = node.descendants(ASTSoqlExpression.class).first();
         if (soql != null) {
             checkForAccessibility(soql, data);
@@ -336,7 +336,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(final ASTVariableDeclaration node, Object data) {
+    public RuleContext visit(final ASTVariableDeclaration node, RuleContext data) {
         String type = node.getType();
         addVariableToMapping(Helper.getFQVariableName(node), type);
 
@@ -350,14 +350,14 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTParameter node, Object data) {
+    public RuleContext visit(ASTParameter node, RuleContext data) {
         String type = node.getType();
         addVariableToMapping(Helper.getFQVariableName(node), type);
         return data;
     }
 
     @Override
-    public Object visit(final ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(final ASTFieldDeclaration node, RuleContext data) {
         ASTFieldDeclarationStatements field = node.ancestors(ASTFieldDeclarationStatements.class).first();
         if (field != null) {
             String namesString = field.getTypeName();
@@ -372,7 +372,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(final ASTReturnStatement node, Object data) {
+    public RuleContext visit(final ASTReturnStatement node, RuleContext data) {
         final ASTSoqlExpression soql = node.descendants(ASTSoqlExpression.class).first();
         if (soql != null) {
             checkForAccessibility(soql, data);
@@ -382,7 +382,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(final ASTForEachStatement node, Object data) {
+    public RuleContext visit(final ASTForEachStatement node, RuleContext data) {
         final ASTSoqlExpression soql = node.firstChild(ASTSoqlExpression.class);
         if (soql != null) {
             checkForAccessibility(soql, data);
@@ -412,7 +412,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(final ASTProperty node, Object data) {
+    public RuleContext visit(final ASTProperty node, RuleContext data) {
         ASTField field = node.firstChild(ASTField.class);
         if (field != null) {
             String fieldType = field.getType();
@@ -523,7 +523,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
     }
 
-    private void checkForCRUD(final ApexNode<?> node, final Object data, final String crudMethod) {
+    private void checkForCRUD(final ApexNode<?> node, final RuleContext data, final String crudMethod) {
         final Set<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
         for (ASTMethodCallExpression prevCall : prevCalls) {
             collectCRUDMethodLevelChecks(prevCall);
@@ -564,7 +564,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
     }
 
-    private void checkInlineObject(final ApexNode<?> node, final Object data, final String crudMethod) {
+    private void checkInlineObject(final ApexNode<?> node, final RuleContext data, final String crudMethod) {
 
         final ASTNewKeyValueObjectExpression newObj = node.firstChild(ASTNewKeyValueObjectExpression.class);
         if (newObj != null) {
@@ -573,7 +573,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
     }
 
-    private void checkInlineNonArgsObject(final ApexNode<?> node, final Object data, final String crudMethod) {
+    private void checkInlineNonArgsObject(final ApexNode<?> node, final RuleContext data, final String crudMethod) {
 
         final ASTNewObjectExpression newEmptyObj = node.firstChild(ASTNewObjectExpression.class);
         if (newEmptyObj != null) {
@@ -688,7 +688,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     }
 
-    private boolean validateCRUDCheckPresent(final ApexNode<?> node, final Object data, final String crudMethod,
+    private boolean validateCRUDCheckPresent(final ApexNode<?> node, final RuleContext data, final String crudMethod,
             final String typeCheck) {
         boolean missingKey = !typeToDMLOperationMapping.containsKey(typeCheck);
         boolean isImproperDMLCheck = !isProperESAPICheckForDML(typeCheck, crudMethod)
@@ -699,7 +699,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         if (missingKey) {
             if (isImproperDMLCheck) {
                 if (noSecurityEnforced && noUserMode && noSystemMode) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                     return true;
                 }
             }
@@ -719,14 +719,14 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             }
 
             if (!properChecksHappened) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
                 return true;
             }
         }
         return false;
     }
 
-    private void checkForAccessibility(final ASTSoqlExpression node, Object data) {
+    private void checkForAccessibility(final ASTSoqlExpression node, RuleContext data) {
         // TODO: This includes sub-relation queries which are incorrectly flagged because you authorize the type
         //  and not the sub-relation name. Should we (optionally) exclude sub-relations until/unless they can be
         //  resolved to the proper SObject type?

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Flags dangerous method calls, e.g. FinancialForce
@@ -49,7 +50,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
 
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node)) {
             return data;
         }
@@ -59,7 +60,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
         List<ASTMethodCallExpression> methodCalls = node.descendants(ASTMethodCallExpression.class).toList();
         for (ASTMethodCallExpression methodCall : methodCalls) {
             if (Helper.isMethodName(methodCall, CONFIGURATION, DISABLE_CRUD)) {
-                asCtx(data).addViolation(methodCall);
+                data.addViolation(methodCall);
             }
 
             if (Helper.isMethodName(methodCall, SYSTEM, DEBUG)) {
@@ -90,12 +91,12 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
 
     }
 
-    private void validateParameters(ASTMethodCallExpression methodCall, Object data) {
+    private void validateParameters(ASTMethodCallExpression methodCall, RuleContext data) {
         List<ASTVariableExpression> variables = methodCall.descendants(ASTVariableExpression.class).toList();
         for (ASTVariableExpression var : variables) {
             if (REGEXP.matcher(var.getImage()).matches()) {
                 if (!whiteListedVariables.contains(Helper.getFQVariableName(var))) {
-                    asCtx(data).addViolation(methodCall);
+                    data.addViolation(methodCall);
                 }
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Insecure HTTP endpoints passed to (req.setEndpoint)
@@ -33,19 +34,19 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
     private final Set<String> httpEndpointStrings = new HashSet<>();
 
     @Override
-    public Object visit(ASTAssignmentExpression node, Object data) {
+    public RuleContext visit(ASTAssignmentExpression node, RuleContext data) {
         findInsecureEndpoints(node);
         return data;
     }
 
     @Override
-    public Object visit(ASTVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTVariableDeclaration node, RuleContext data) {
         findInsecureEndpoints(node);
         return data;
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         findInsecureEndpoints(node);
         return data;
     }
@@ -75,12 +76,12 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         processInsecureEndpoint(node, data);
         return data;
     }
 
-    private void processInsecureEndpoint(ASTMethodCallExpression node, Object data) {
+    private void processInsecureEndpoint(ASTMethodCallExpression node, RuleContext data) {
         if (!Helper.isMethodName(node, SET_ENDPOINT)) {
             return;
         }
@@ -94,19 +95,19 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
 
     }
 
-    private void runChecks(ApexNode<?> node, Object data) {
+    private void runChecks(ApexNode<?> node, RuleContext data) {
         ASTLiteralExpression literalNode = node.firstChild(ASTLiteralExpression.class);
         if (literalNode != null && literalNode.isString()) {
             String literal = literalNode.getImage();
             if (PATTERN.matcher(literal).matches()) {
-                asCtx(data).addViolation(literalNode);
+                data.addViolation(literalNode);
             }
         }
 
         ASTVariableExpression variableNode = node.firstChild(ASTVariableExpression.class);
         if (variableNode != null) {
             if (httpEndpointStrings.contains(Helper.getFQVariableName(variableNode))) {
-                asCtx(data).addViolation(variableNode);
+                data.addViolation(variableNode);
             }
 
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Looking for potential Open redirect via PageReference variable input
@@ -39,7 +40,7 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
         }
@@ -122,7 +123,7 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
      * @param node
      * @param data
      */
-    private void checkNewObjects(ASTNewObjectExpression node, Object data) {
+    private void checkNewObjects(ASTNewObjectExpression node, RuleContext data) {
 
         ASTMethod method = node.ancestors(ASTMethod.class).first();
         if (method != null && Helper.isTestMethodOrClass(method)) {
@@ -142,12 +143,12 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
      * @param data
      *
      */
-    private void getObjectValue(ApexNode<?> node, Object data) {
+    private void getObjectValue(ApexNode<?> node, RuleContext data) {
         // PageReference(foo);
         for (ASTVariableExpression variable : node.children(ASTVariableExpression.class)) {
             if (variable.getIndexInParent() == 0
                     && !listOfStringLiteralVariables.contains(Helper.getFQVariableName(variable))) {
-                asCtx(data).addViolation(variable);
+                data.addViolation(variable);
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -32,6 +32,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects if variables in Database.query(variable) or Database.countQuery is escaped with
@@ -63,7 +64,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
 
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
@@ -208,7 +209,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
 
     }
 
-    private void reportStrings(ASTMethodCallExpression m, Object data) {
+    private void reportStrings(ASTMethodCallExpression m, RuleContext data) {
         final Set<ASTVariableExpression> setOfSafeVars = new HashSet<>();
         for (ASTStandardCondition c : m.descendants(ASTStandardCondition.class)) {
             List<ASTVariableExpression> vars = c.descendants(ASTVariableExpression.class).toList();
@@ -235,20 +236,20 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
                         || Helper.isMethodName(parentCall, STRING, JOIN);
 
                 if (!isSafeMethod) {
-                    asCtx(data).addViolation(v);
+                    data.addViolation(v);
                 }
             }
         }
     }
 
-    private void reportVariables(final ASTMethodCallExpression m, Object data) {
+    private void reportVariables(final ASTMethodCallExpression m, RuleContext data) {
         final ASTVariableExpression var = m.firstChild(ASTVariableExpression.class);
         if (var != null) {
             String nameFQ = Helper.getFQVariableName(var);
             if (selectContainingVariables.containsKey(nameFQ)) {
                 boolean isLiteral = selectContainingVariables.get(nameFQ);
                 if (!isLiteral) {
-                    asCtx(data).addViolation(var);
+                    data.addViolation(var);
                 }
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -60,55 +60,55 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTSoqlExpression node, Object data) {
+    public RuleContext visit(ASTSoqlExpression node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTSoslExpression node, Object data) {
+    public RuleContext visit(ASTSoslExpression node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlUpsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpsertStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlUpdateStatement node, Object data) {
+    public RuleContext visit(ASTDmlUpdateStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlUndeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlUndeleteStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlMergeStatement node, Object data) {
+    public RuleContext visit(ASTDmlMergeStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlInsertStatement node, Object data) {
+    public RuleContext visit(ASTDmlInsertStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTDmlDeleteStatement node, Object data) {
+    public RuleContext visit(ASTDmlDeleteStatement node, RuleContext data) {
         checkForViolation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         if (Helper.isAnyDatabaseMethodCall(node)) {
             checkForViolation(node, data);
         }
@@ -116,7 +116,7 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
         return data;
     }
 
-    private void checkForViolation(ApexNode<?> node, Object data) {
+    private void checkForViolation(ApexNode<?> node, RuleContext data) {
         // The closest ASTUserClass class in the tree hierarchy is the node that requires the sharing declaration
         ASTUserClass sharingDeclarationClass = node.ancestors(ASTUserClass.class).first();
 
@@ -134,15 +134,15 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
         }
     }
 
-    private void reportViolation(ApexNode<?> node, Object data) {
+    private void reportViolation(ApexNode<?> node, RuleContext data) {
         ASTModifierNode modifier = node.firstChild(ASTModifierNode.class);
         if (modifier != null) {
             if (localCacheOfReportedNodes.put(modifier, data) == null) {
-                asCtx(data).addViolation(modifier);
+                data.addViolation(modifier);
             }
         } else {
             if (localCacheOfReportedNodes.put(node, data) == null) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Flags usage of http request.setHeader('Authorization',..) and suggests using
@@ -43,7 +44,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node)) {
             return data;
         }
@@ -114,7 +115,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
         }
     }
 
-    private void flagAuthorizationHeaders(final ASTMethodCallExpression node, Object data) {
+    private void flagAuthorizationHeaders(final ASTMethodCallExpression node, RuleContext data) {
         if (!Helper.isMethodName(node, SET_HEADER)) {
             return;
         }
@@ -122,7 +123,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
         runChecks(node, data);
     }
 
-    private void runChecks(final ApexNode<?> node, Object data) {
+    private void runChecks(final ApexNode<?> node, RuleContext data) {
         ApexNode<?> keyNode = node.getChild(1);
         ApexNode<?> valueNode = node.getChild(2);
 
@@ -131,7 +132,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
         }
 
         if (valueNode == null || !isCredentialReference(valueNode)) {
-            asCtx(data).addViolation(keyNode);
+            data.addViolation(keyNode);
         }
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Finds all .addError method calls that are not HTML escaped on purpose
@@ -29,7 +30,7 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
         }
@@ -42,7 +43,7 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
         return data;
     }
 
-    private void validateBooleanParameter(ASTMethodCallExpression methodCall, Object data) {
+    private void validateBooleanParameter(ASTMethodCallExpression methodCall, RuleContext data) {
         int numberOfChildren = methodCall.getNumChildren();
         if (numberOfChildren == 3) { // addError('',false)
             Object potentialLiteral = methodCall.getChild(2);
@@ -58,9 +59,9 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
         }
     }
 
-    private void validateLiteralPresence(ASTMethodCallExpression methodCall, Object data) {
+    private void validateLiteralPresence(ASTMethodCallExpression methodCall, RuleContext data) {
         for (ASTVariableExpression v : methodCall.descendants(ASTVariableExpression.class)) {
-            asCtx(data).addViolation(v);
+            data.addViolation(v);
         }
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects potential XSS when controller extracts a variable from URL query and
@@ -50,7 +51,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
     private final Set<String> urlParameterStrings = new HashSet<>();
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
+    public RuleContext visit(ASTUserClass node, RuleContext data) {
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
         }
@@ -59,35 +60,35 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTAssignmentExpression node, Object data) {
+    public RuleContext visit(ASTAssignmentExpression node, RuleContext data) {
         findTaintedVariables(node, data);
         processVariableAssignments(node, data, false);
         return data;
     }
 
     @Override
-    public Object visit(ASTVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTVariableDeclaration node, RuleContext data) {
         findTaintedVariables(node, data);
         processVariableAssignments(node, data, true);
         return data;
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         findTaintedVariables(node, data);
         processVariableAssignments(node, data, true);
         return data;
     }
 
     @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
+    public RuleContext visit(ASTMethodCallExpression node, RuleContext data) {
         processEscapingMethodCalls(node, data);
         processInlineMethodCalls(node, data, false);
         return data;
     }
 
     @Override
-    public Object visit(ASTReturnStatement node, Object data) {
+    public RuleContext visit(ASTReturnStatement node, RuleContext data) {
         ASTBinaryExpression binaryExpression = node.firstChild(ASTBinaryExpression.class);
         if (binaryExpression != null) {
             processBinaryExpression(binaryExpression, data);
@@ -105,7 +106,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
         for (ASTVariableExpression varExpression : nodes) {
             if (urlParameterStrings.contains(Helper.getFQVariableName(varExpression))) {
-                asCtx(data).addViolation(nodes.get(0));
+                data.addViolation(nodes.get(0));
             }
         }
 
@@ -141,7 +142,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 || Helper.isMethodCallChain(methodNode, STRING_ISNOTBLANK);
     }
 
-    private void processInlineMethodCalls(ASTMethodCallExpression methodNode, Object data, final boolean isNested) {
+    private void processInlineMethodCalls(ASTMethodCallExpression methodNode, RuleContext data, final boolean isNested) {
         ASTMethodCallExpression nestedCall = methodNode.firstChild(ASTMethodCallExpression.class);
         if (nestedCall != null) {
 
@@ -152,13 +153,13 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
         if (Helper.isMethodCallChain(methodNode, URL_PARAMETER_METHOD)) {
             if (isNested) {
-                asCtx(data).addViolation(methodNode);
+                data.addViolation(methodNode);
             }
         }
 
     }
 
-    private void findTaintedVariables(ApexNode<?> node, Object data) {
+    private void findTaintedVariables(ApexNode<?> node, RuleContext data) {
         final ASTMethodCallExpression right = node.firstChild(ASTMethodCallExpression.class);
         // Looks for: (String) foo =
         // ApexPages.currentPage().getParameters().get(..)
@@ -185,7 +186,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
         }
     }
 
-    private void processEscapingMethodCalls(ASTMethodCallExpression methodNode, Object data) {
+    private void processEscapingMethodCalls(ASTMethodCallExpression methodNode, RuleContext data) {
         ASTMethodCallExpression nestedCall = methodNode.firstChild(ASTMethodCallExpression.class);
         if (nestedCall != null) {
             processEscapingMethodCalls(nestedCall, data);
@@ -196,14 +197,14 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
         if (variable != null) {
             if (urlParameterStrings.contains(Helper.getFQVariableName(variable))) {
                 if (!isEscapingMethod(methodNode)) {
-                    asCtx(data).addViolation(variable);
+                    data.addViolation(variable);
                 }
             }
         }
 
     }
 
-    private void processVariableAssignments(ApexNode<?> node, Object data, final boolean reverseOrder) {
+    private void processVariableAssignments(ApexNode<?> node, RuleContext data, final boolean reverseOrder) {
         ASTMethodCallExpression methodCallAssignment = node.firstChild(ASTMethodCallExpression.class);
         if (methodCallAssignment != null) {
 
@@ -236,7 +237,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
             final ASTVariableExpression right = reverseOrder ? nodes.get(0) : nodes.get(1);
 
             if (urlParameterStrings.contains(Helper.getFQVariableName(right))) {
-                asCtx(data).addViolation(right);
+                data.addViolation(right);
             }
         }
             break;
@@ -246,7 +247,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
     }
 
-    private void processBinaryExpression(ApexNode<?> node, Object data) {
+    private void processBinaryExpression(ApexNode<?> node, RuleContext data) {
         ASTBinaryExpression nestedBinaryExpression = node.firstChild(ASTBinaryExpression.class);
         if (nestedBinaryExpression != null) {
             processBinaryExpression(nestedBinaryExpression, data);
@@ -260,7 +261,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
         for (ASTVariableExpression n : node.children(ASTVariableExpression.class)) {
 
             if (urlParameterStrings.contains(Helper.getFQVariableName(n))) {
-                asCtx(data).addViolation(n);
+                data.addViolation(n);
             }
         }
     }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/FooRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Sample rule that detect any node with an image of "Foo". Used for testing.
@@ -20,33 +21,33 @@ public class FooRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserClass c, Object ctx) {
+    public RuleContext visit(ASTUserClass c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getSimpleName())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }
 
     @Override
-    public Object visit(ASTVariableDeclaration c, Object ctx) {
+    public RuleContext visit(ASTVariableDeclaration c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getImage())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }
 
     @Override
-    public Object visit(ASTField c, Object ctx) {
+    public RuleContext visit(ASTField c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getImage())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }
 
     @Override
-    public Object visit(ASTParameter c, Object ctx) {
+    public RuleContext visit(ASTParameter c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getImage())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserTestBase;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.reporting.ViolationSuppressor;
 
 class SuppressWarningsTest extends ApexParserTestBase {
@@ -32,9 +33,9 @@ class SuppressWarningsTest extends ApexParserTestBase {
         }
 
         @Override
-        public Object visit(ASTUserClass clazz, Object ctx) {
+        public RuleContext visit(ASTUserClass clazz, RuleContext ctx) {
             if ("bar".equalsIgnoreCase(clazz.getSimpleName())) {
-                asCtx(ctx).addViolation(clazz);
+                ctx.addViolation(clazz);
             }
             return super.visit(clazz, ctx);
         }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserTestBase;
 import net.sourceforge.pmd.lang.test.ast.TestUtilsKt;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 class AbstractApexRuleTest extends ApexParserTestBase {
 
@@ -52,32 +53,32 @@ class AbstractApexRuleTest extends ApexParserTestBase {
         }
 
         @Override
-        public Object visit(ASTUserClass node, Object data) {
-            asCtx(data).addViolation(node);
+        public RuleContext visit(ASTUserClass node, RuleContext data) {
+            data.addViolation(node);
             return data;
         }
 
         @Override
-        public Object visit(ASTUserInterface node, Object data) {
-            asCtx(data).addViolation(node);
+        public RuleContext visit(ASTUserInterface node, RuleContext data) {
+            data.addViolation(node);
             return data;
         }
 
         @Override
-        public Object visit(ASTUserTrigger node, Object data) {
-            asCtx(data).addViolation(node);
+        public RuleContext visit(ASTUserTrigger node, RuleContext data) {
+            data.addViolation(node);
             return data;
         }
 
         @Override
-        public Object visit(ASTUserEnum node, Object data) {
-            asCtx(data).addViolation(node);
+        public RuleContext visit(ASTUserEnum node, RuleContext data) {
+            data.addViolation(node);
             return data;
         }
 
         @Override
-        public Object visit(ASTAnonymousClass node, Object data) {
-            asCtx(data).addViolation(node);
+        public RuleContext visit(ASTAnonymousClass node, RuleContext data) {
+            data.addViolation(node);
             return data;
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -249,7 +249,10 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
      * rules use an appropriate visitor. Many rules have not been refactored yet.
      * Once this is done, this method will be deprecated as useless. Until then,
      * this is a way to hide the explicit cast to {@link RuleContext} in rules.
+     *
+     * @deprecated Don't use this. Make sure your rules are properly typed, instead.
      */
+    @Deprecated
     protected final RuleContext asCtx(Object ctx) {
         if (ctx instanceof RuleContext) {
             assert isThisRule(InternalApiBridge.getRule((RuleContext) ctx))

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/AbstractHtmlRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/AbstractHtmlRule.java
@@ -9,10 +9,10 @@ import net.sourceforge.pmd.lang.html.ast.HtmlVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractHtmlRule extends AbstractRule implements HtmlVisitor {
+public abstract class AbstractHtmlRule extends AbstractRule implements HtmlVisitor<RuleContext, RuleContext> {
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(c -> c.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeRule.java
@@ -11,7 +11,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
 public class UnnecessaryTypeAttributeRule extends AbstractHtmlRule {
 
     @Override
-    public Object visit(ASTHtmlElement node, Object data) {
+    public RuleContext visit(ASTHtmlElement node, RuleContext data) {
         if ("link".equalsIgnoreCase(node.getNodeName())) {
             checkLink(node, data);
         } else if ("script".equalsIgnoreCase(node.getNodeName())) {
@@ -20,13 +20,13 @@ public class UnnecessaryTypeAttributeRule extends AbstractHtmlRule {
         return super.visit(node, data);
     }
 
-    private void checkScript(ASTHtmlElement node, Object data) {
+    private void checkScript(ASTHtmlElement node, RuleContext data) {
         if (node.hasAttribute("type")) {
             addViolation(node, data);
         }
     }
 
-    private void checkLink(ASTHtmlElement node, Object data) {
+    private void checkLink(ASTHtmlElement node, RuleContext data) {
         String rel = node.getAttribute("rel");
         if (node.hasAttribute("type") && "stylesheet".equalsIgnoreCase(rel)) {
             addViolation(node, data);
@@ -34,8 +34,8 @@ public class UnnecessaryTypeAttributeRule extends AbstractHtmlRule {
     }
 
 
-    private void addViolation(ASTHtmlElement node, Object data) {
-        RuleContext ctx = (RuleContext) data;
+    private void addViolation(ASTHtmlElement node, RuleContext data) {
+        RuleContext ctx = data;
         ctx.addViolation(node);
     }
 }

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesRule.java
@@ -21,10 +21,9 @@ public class UseAltAttributeForImagesRule extends AbstractHtmlRule {
     }
 
     @Override
-    public Object visit(ASTHtmlElement node, Object data) {
+    public RuleContext visit(ASTHtmlElement node, RuleContext data) {
         if (!node.hasAttribute("alt")) {
-            RuleContext ctx = (RuleContext) data;
-            ctx.addViolation(node);
+            data.addViolation(node);
             return data;
         }
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlJavaRuleTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlJavaRuleTest.java
@@ -42,11 +42,10 @@ class HtmlJavaRuleTest {
             }
 
             @Override
-            public Object visit(ASTHtmlElement node, Object data) {
+            public RuleContext visit(ASTHtmlElement node, RuleContext data) {
                 for (Attribute attribute : node.getAttributes()) {
                     if ("{".equals(attribute.getValue())) {
-                        RuleContext ctx = (RuleContext) data;
-                        ctx.addViolation(node);
+                        data.addViolation(node);
                     }
                 }
                 return super.visit(node, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -17,10 +17,10 @@ import net.sourceforge.pmd.reporting.RuleContext;
  * TODO add documentation
  *
  */
-public abstract class AbstractJavaRule extends AbstractRule implements JavaVisitor {
+public abstract class AbstractJavaRule extends AbstractRule implements JavaVisitor<RuleContext, RuleContext> {
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(n -> n.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRulechainRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRulechainRule.java
@@ -8,6 +8,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Base class for rules using the rulechain. The visit methods don't
@@ -37,7 +38,7 @@ public abstract class AbstractJavaRulechainRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         return data;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
@@ -8,6 +8,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AbstractClassWithoutAbstractMethodRule extends AbstractJavaRulechainRule {
 
@@ -16,13 +17,13 @@ public class AbstractClassWithoutAbstractMethodRule extends AbstractJavaRulechai
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (node.isInterface() || !node.isAbstract() || doesExtend(node) || doesImplement(node)) {
             return data;
         }
 
         if (node.getDeclarations(ASTMethodDeclaration.class).none(ASTMethodDeclaration::isAbstract)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
@@ -43,17 +43,17 @@ public class AccessorClassGenerationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         if (!node.isAnonymousClass()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorMethodGenerationRule.checkMemberAccess(data, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTExplicitConstructorInvocation node, Object data) {
+    public RuleContext visit(ASTExplicitConstructorInvocation node, RuleContext data) {
         if (node.isSuper()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorMethodGenerationRule.checkMemberAccess(data, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -37,14 +37,14 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTFieldAccess node, Object data) {
-        checkMemberAccessIfConstValueIsNull(node, (RuleContext) data, node.getReferencedSym());
+    public RuleContext visit(ASTFieldAccess node, RuleContext data) {
+        checkMemberAccessIfConstValueIsNull(node, data, node.getReferencedSym());
         return null;
     }
 
     @Override
-    public Object visit(ASTVariableAccess node, Object data) {
-        checkMemberAccessIfConstValueIsNull(node, (RuleContext) data, node.getReferencedSym());
+    public RuleContext visit(ASTVariableAccess node, RuleContext data) {
+        checkMemberAccessIfConstValueIsNull(node, data, node.getReferencedSym());
         return null;
     }
 
@@ -55,8 +55,8 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
-        checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol());
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
+        checkMemberAccess(data, node, node.getMethodType().getSymbol());
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -38,14 +38,14 @@ public class ArrayIsStoredDirectlyRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
-        checkAssignments((RuleContext) data, node);
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
+        checkAssignments(data, node);
         return data;
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
-        checkAssignments((RuleContext) data, node);
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
+        checkAssignments(data, node);
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCatchParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidReassigningCatchVariablesRule extends AbstractJavaRule {
 
@@ -21,11 +22,11 @@ public class AvoidReassigningCatchVariablesRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTCatchParameter catchParam, Object data) {
+    public RuleContext visit(ASTCatchParameter catchParam, RuleContext data) {
         ASTVariableId caughtExceptionId = catchParam.getVarId();
         for (ASTNamedReferenceExpr usage : caughtExceptionId.getLocalUsages()) {
             if (usage.getAccessType() == AccessType.WRITE) {
-                asCtx(data).addViolation(usage, caughtExceptionId.getName());
+                data.addViolation(usage, caughtExceptionId.getName());
             }
 
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -59,7 +59,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTForeachStatement loopStmt, Object data) {
+    public RuleContext visit(ASTForeachStatement loopStmt, RuleContext data) {
         ForeachReassignOption behavior = getProperty(FOREACH_REASSIGN);
         if (behavior == ForeachReassignOption.ALLOW) {
             return data;
@@ -72,7 +72,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                     ignoreNext = false;
                     continue;
                 }
-                asCtx(data).addViolation(usage, loopVar.getName());
+                data.addViolation(usage, loopVar.getName());
             } else {
                 ignoreNext = false;
             }
@@ -81,7 +81,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTForStatement loopStmt, Object data) {
+    public RuleContext visit(ASTForStatement loopStmt, RuleContext data) {
         ForReassignOption behavior = getProperty(FOR_REASSIGN);
         if (behavior == ForReassignOption.ALLOW) {
             return data;
@@ -95,14 +95,14 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                         if (update != null && usage.ancestors(ASTForUpdate.class).first() == update) {
                             continue;
                         }
-                        asCtx(data).addViolation(usage, loopVar.getName());
+                        data.addViolation(usage, loopVar.getName());
                     }
                 }
             }
         } else {
             Set<String> loopVarNames = loopVars.collect(Collectors.mapping(ASTVariableId::getName, Collectors.toSet()));
             Set<String> labels = JavaAstUtils.getStatementLabels(loopStmt);
-            new ControlFlowCtx(false, loopVarNames, (RuleContext) data, labels, false, false).roamStatementsForExit(loopStmt.getBody());
+            new ControlFlowCtx(false, loopVarNames, data, labels, false, false).roamStatementsForExit(loopStmt.getBody());
         }
         return null;
     }
@@ -208,7 +208,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                 .filter(it -> loopVarNames.contains(it.getName()))
                 .filter(it -> onlyConsiderWrite ? it.getAccessType() == AccessType.WRITE && !isSimpleSkipOperation(it)
                                                 : JavaAstUtils.isVarAccessReadAndWrite(it))
-                .forEach(it -> asCtx(ruleCtx).addViolation(it, it.getName()));
+                .forEach(it -> ruleCtx.addViolation(it, it.getName()));
         }
 
         private boolean isSimpleSkipOperation(ASTNamedReferenceExpr expr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidReassigningParametersRule extends AbstractJavaRulechainRule {
 
@@ -20,24 +21,24 @@ public class AvoidReassigningParametersRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         lookForViolations(node, data);
         return data;
     }
 
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         lookForViolations(node, data);
         return data;
     }
 
-    private void lookForViolations(ASTExecutableDeclaration node, Object data) {
+    private void lookForViolations(ASTExecutableDeclaration node, RuleContext data) {
         for (ASTFormalParameter formal : node.getFormalParameters()) {
             ASTVariableId varId = formal.getVarId();
             for (ASTNamedReferenceExpr usage : varId.getLocalUsages()) {
                 if (usage.getAccessType() == AccessType.WRITE) {
-                    asCtx(data).addViolation(usage, varId.getName());
+                    data.addViolation(usage, varId.getName());
                     // only the first assignment should be reported
                     break;
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -67,7 +67,7 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTStringLiteral node, Object data) {
+    public RuleContext visit(ASTStringLiteral node, RuleContext data) {
         final String image = node.getConstValue();
 
         // Note: We used to check the addresses using
@@ -81,7 +81,7 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRulechainRule {
             boolean checkIPv4MappedIPv6 = kindsToCheck.contains(AddressKinds.IPV4_MAPPED_IPV6);
 
             if (checkIPv4 && isIPv4(firstChar, image) || isIPv6(firstChar, image, checkIPv6, checkIPv4MappedIPv6)) {
-                asCtx(data).addViolation(node, image);
+                data.addViolation(node, image);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.ReturnScopeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Rule that verifies, that the return values of next(), first(), last(), etc.
@@ -29,24 +30,24 @@ public class CheckResultSetRule extends AbstractJavaRule {
     private static final Set<String> METHODS = setOf("next", "previous", "last", "first");
 
     @Override
-    public Object visit(ASTWhileStatement node, Object data) {
+    public RuleContext visit(ASTWhileStatement node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTReturnStatement node, Object data) {
+    public RuleContext visit(ASTReturnStatement node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (isResultSetMethod(node) && !isCheckedIndirectly(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return super.visit(node, data);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -37,6 +37,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @author Clément Fournier
@@ -55,7 +56,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTForStatement forLoop, Object data) {
+    public RuleContext visit(ASTForStatement forLoop, RuleContext data) {
 
         final @Nullable ASTStatement init = forLoop.getInit();
         final @Nullable ASTStatementExpressionList update = forLoop.getUpdate();
@@ -77,12 +78,12 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
             if (iterable != null) {
                 if (isReplaceableArrayLoop(forLoop, index, iterable)
                     || isReplaceableListLoop(forLoop, index, iterable)) {
-                    asCtx(data).addViolation(forLoop);
+                    data.addViolation(forLoop);
                 }
             }
         } else if (TypeTestUtil.isA(Iterator.class, index.getTypeMirror())) {
             if (isReplaceableIteratorLoop(index, forLoop)) {
-                asCtx(data).addViolation(forLoop);
+                data.addViolation(forLoop);
             }
             return data;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -97,7 +97,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTExpressionStatement node, Object data) {
+    public RuleContext visit(ASTExpressionStatement node, RuleContext data) {
         ASTExpression expr = node.getExpr();
         if (!(expr instanceof ASTMethodCall)) {
             return null;
@@ -107,7 +107,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         String logLevel = getLogLevelName(methodCall);
         if (logLevel != null && guardStmtByLogLevel.containsKey(logLevel)) {
             if (needsGuard(methodCall) && !hasGuard(methodCall, logLevel)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ImplicitFunctionalInterfaceRule extends AbstractJavaRulechainRule {
     public ImplicitFunctionalInterfaceRule() {
@@ -16,13 +17,13 @@ public class ImplicitFunctionalInterfaceRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (node.isRegularInterface()
             && !node.isAnnotationPresent(FunctionalInterface.class)
             && !node.hasModifiers(JModifier.SEALED)) {
             JMethodSig fun = TypeOps.findFunctionalInterfaceMethod(node.getTypeMirror());
             if (fun != null) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule finds code like this:
@@ -44,12 +45,12 @@ public class JUnitUseExpectedRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         ASTBlock body = node.getBody();
         if (body != null && isJUnitMethod(node)) {
             body.descendants(ASTTryStatement.class)
                 .filter(this::isWeirdTry)
-                .forEach(it -> asCtx(data).addViolation(it));
+                .forEach(it -> data.addViolation(it));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -31,15 +31,15 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, RuleContext data) {
         if ("equals".equals(call.getMethodName())
             && call.getArguments().size() == 1
             && isEqualsObjectAndNotAnOverload(call)) {
-            checkArgs((RuleContext) data, call);
+            checkArgs(data, call);
         } else if (STRING_COMPARISONS.contains(call.getMethodName())
             && call.getArguments().size() == 1
             && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType())) {
-            checkArgs((RuleContext) data, call);
+            checkArgs(data, call);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LooseCouplingRule extends AbstractJavaRulechainRule {
 
@@ -42,13 +43,13 @@ public class LooseCouplingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassType node, Object data) {
+    public RuleContext visit(ASTClassType node, RuleContext data) {
         if (isConcreteCollectionType(node)
             && !isInOverriddenMethodSignature(node)
             && !isInAllowedSyntacticCtx(node)
             && !isAllowedType(node)
             && !isTypeParameter(node)) {
-            asCtx(data).addViolation(node, node.getSimpleName());
+            data.addViolation(node, node.getSimpleName());
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Implementation note: this rule currently ignores return types of y.x.z,
@@ -33,7 +34,7 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration method, Object data) {
+    public RuleContext visit(ASTMethodDeclaration method, RuleContext data) {
         if (!method.getResultTypeNode().getTypeMirror().isArray()
             || method.getVisibility() == Visibility.V_PRIVATE) {
             return data;
@@ -45,14 +46,14 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
                 ASTNamedReferenceExpr reference = (ASTNamedReferenceExpr) expr;
 
                 if (JavaAstUtils.isRefToFieldOfThisInstance(reference)) {
-                    asCtx(data).addViolation(returnStmt, reference.getName());
+                    data.addViolation(returnStmt, reference.getName());
                 } else {
                     // considers static, non-final fields
                     JVariableSymbol symbol = reference.getReferencedSym();
                     if (symbol instanceof JFieldSymbol) {
                         JFieldSymbol field = (JFieldSymbol) symbol;
                         if (field.isStatic() && isInternal(field) && !isZeroLengthArrayConstant(field)) {
-                            asCtx(data).addViolation(returnStmt, reference.getName());
+                            data.addViolation(returnStmt, reference.getName());
                         }
                     }
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -22,9 +23,9 @@ public class MissingOverrideRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (node.isOverridden() && !node.isAnnotationPresent(Override.class)) {
-            asCtx(data).addViolation(node, PrettyPrintingUtil.displaySignature(node));
+            data.addViolation(node, PrettyPrintingUtil.displaySignature(node));
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
     // todo dfa
@@ -56,7 +57,7 @@ public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTCatchClause catchStmt, Object data) {
+    public RuleContext visit(ASTCatchClause catchStmt, RuleContext data) {
         ASTVariableId exceptionParam = catchStmt.getParameter().getVarId();
         if (JavaRuleUtil.isExplicitUnusedVarName(exceptionParam.getName())) {
             // ignore those
@@ -68,7 +69,7 @@ public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
             ASTExpression thrownExpr = throwStatement.getExpr();
 
             if (!exprConsumesException(Collections.singleton(exceptionParam), thrownExpr, true)) {
-                asCtx(data).addViolation(thrownExpr, exceptionParam.getName());
+                data.addViolation(thrownExpr, exceptionParam.getName());
             }
         }
         recursingOnVars.clear();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule {
 
@@ -25,7 +26,7 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         ASTClassType type = node.firstChild(ASTClassType.class);
         if (type == null) {
             return data;
@@ -38,7 +39,7 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
                 || TypeTestUtil.isA(Short.class, type)
                 || TypeTestUtil.isA(Byte.class, type)
                 || TypeTestUtil.isA(Character.class, type)) {
-            asCtx(data).addViolation(node, type.getSimpleName());
+            data.addViolation(node, type.getSimpleName());
         } else if (TypeTestUtil.isA(Boolean.class, type)) {
             checkArguments(node.getArguments(), node, data);
         }
@@ -50,7 +51,7 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
      * Finds calls of "Boolean.valueOf".
      */
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (BOOLEAN_VALUEOF_MATCHER.matchesCall(node)) {
             checkArguments(node.getArguments(), node, data);
         }
@@ -58,7 +59,7 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
         return data;
     }
 
-    private void checkArguments(ASTArgumentList arguments, JavaNode node, Object data) {
+    private void checkArguments(ASTArgumentList arguments, JavaNode node, RuleContext data) {
         if (arguments == null || arguments.size() != 1) {
             return;
         }
@@ -70,21 +71,21 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
         ASTBooleanLiteral boolLiteral = getFirstArgBooleanLiteralOrNull(arguments);
         if (stringLiteral != null) {
             if ("\"true\"".equals(stringLiteral.getImage())) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"true\")`, prefer `Boolean.TRUE`");
+                data.addViolationWithMessage(node, messagePart + "(\"true\")`, prefer `Boolean.TRUE`");
             } else if ("\"false\"".equals(stringLiteral.getImage())) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"false\")`, prefer `Boolean.FALSE`");
+                data.addViolationWithMessage(node, messagePart + "(\"false\")`, prefer `Boolean.FALSE`");
             } else {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"...\")`, prefer `Boolean.valueOf`");
+                data.addViolationWithMessage(node, messagePart + "(\"...\")`, prefer `Boolean.valueOf`");
             }
         } else if (boolLiteral != null) {
             if (boolLiteral.isTrue()) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(true)`, prefer `Boolean.TRUE`");
+                data.addViolationWithMessage(node, messagePart + "(true)`, prefer `Boolean.TRUE`");
             } else {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(false)`, prefer `Boolean.FALSE`");
+                data.addViolationWithMessage(node, messagePart + "(false)`, prefer `Boolean.FALSE`");
             }
         } else if (isNewBoolean) {
             // any argument with "new Boolean", might be a variable access
-            asCtx(data).addViolationWithMessage(node, messagePart + "(...)`, prefer `Boolean.valueOf`");
+            data.addViolationWithMessage(node, messagePart + "(...)`, prefer `Boolean.valueOf`");
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/RelianceOnDefaultCharsetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/RelianceOnDefaultCharsetRule.java
@@ -9,8 +9,10 @@ import java.util.Map;
 
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects constructors and methods that use the JVM's default character set
@@ -80,25 +82,25 @@ public class RelianceOnDefaultCharsetRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         checkInvocation(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         checkInvocation(node, data);
         return data;
     }
 
-    private void checkInvocation(net.sourceforge.pmd.lang.java.ast.JavaNode node, Object data) {
+    private void checkInvocation(JavaNode node, RuleContext data) {
         for (Map.Entry<InvocationMatcher, String> entry : METHOD_TO_MIN_VERSION.entrySet()) {
             InvocationMatcher matcher = entry.getKey();
             String minVersion = entry.getValue();
             
             // Only flag violation if replacement method is available in current Java version
             if (node.getLanguageVersion().compareToVersion(minVersion) >= 0 && matcher.matchesCall(node)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  *
@@ -36,7 +37,7 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         final boolean isAssertTrue = isAssertionCall(node, "assertTrue");
         final boolean isAssertFalse = isAssertionCall(node, "assertFalse");
 
@@ -58,7 +59,7 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                         suggestion = isPositive ? "assertSame" : "assertNotSame";
                     }
                 }
-                asCtx(data).addViolation(node, suggestion);
+                data.addViolation(node, suggestion);
 
             } else {
                 @Nullable ASTExpression negatedExprOperand = getNegatedExprOperand(lastArg);
@@ -66,17 +67,17 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                 if (OBJECT_EQUALS.matchesCall(negatedExprOperand)) {
                     //assertTrue(!a.equals(b))
                     String suggestion = isAssertTrue ? "assertNotEquals" : "assertEquals";
-                    asCtx(data).addViolation(node, suggestion);
+                    data.addViolation(node, suggestion);
 
                 } else if (negatedExprOperand != null) {
                     //assertTrue(!something)
                     String suggestion = isAssertTrue ? "assertFalse" : "assertTrue";
-                    asCtx(data).addViolation(node, suggestion);
+                    data.addViolation(node, suggestion);
 
                 } else if (OBJECT_EQUALS.matchesCall(lastArg)) {
                     //assertTrue(a.equals(b))
                     String suggestion = isAssertTrue ? "assertEquals" : "assertNotEquals";
-                    asCtx(data).addViolation(node, suggestion);
+                    data.addViolation(node, suggestion);
                 }
             }
         }
@@ -99,7 +100,7 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                     if (comp1.getTypeMirror().isPrimitive(PrimitiveTypeKind.BOOLEAN)) {
                         ASTBooleanLiteral literal = (ASTBooleanLiteral) comp0;
                         String suggestion = literal.isTrue() == isAssertEquals ? "assertTrue" : "assertFalse";
-                        asCtx(data).addViolation(node, suggestion);
+                        data.addViolation(node, suggestion);
                     }
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestAssertionsShouldIncludeMessageRule extends AbstractJavaRulechainRule {
 
@@ -33,10 +34,10 @@ public class UnitTestAssertionsShouldIncludeMessageRule extends AbstractJavaRule
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (TestFrameworksUtil.isCallOnAssertionContainer(node)) {
             if (checks.anyMatch(node)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.NumericConstraints;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRule {
 
@@ -40,7 +41,7 @@ public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRul
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration method, Object data) {
+    public RuleContext visit(ASTMethodDeclaration method, RuleContext data) {
         ASTBlock body = method.getBody();
         if (body != null && TestFrameworksUtil.isTestMethod(method)) {
             Set<String> extraAsserts = getProperty(EXTRA_ASSERT_METHOD_NAMES);
@@ -49,7 +50,7 @@ public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRul
                                   || extraAsserts.contains(call.getMethodName()))
                                   .count();
             if (assertCount > getProperty(MAX_ASSERTS)) {
-                asCtx(data).addViolation(method);
+                data.addViolation(method);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
 
@@ -37,7 +38,7 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration method, Object data) {
+    public RuleContext visit(ASTMethodDeclaration method, RuleContext data) {
         boolean usesSoftAssertExtension = usesSoftAssertExtension(method.getEnclosingType());
         Set<String> extraAsserts = getProperty(EXTRA_ASSERT_METHOD_NAMES);
         Predicate<ASTMethodCall> isAssertCall = TestFrameworksUtil::isProbableAssertCall;
@@ -52,7 +53,7 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
             && getAllMethodCallsFrom(body)
                 .none(isAssertCall
                         .or(call -> extraAsserts.contains(call.getMethodName())))) {
-            asCtx(data).addViolation(method);
+            data.addViolation(method);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRule {
 
@@ -23,7 +24,7 @@ public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRu
     }
 
     @Override
-    public Object visit(ASTArrayAllocation array, Object data) {
+    public RuleContext visit(ASTArrayAllocation array, RuleContext data) {
         if (array.getArrayInitializer() == null) {
             return null;
         }
@@ -44,7 +45,7 @@ public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRu
             if (array.getTypeMirror().equals(lastFormal)) {
                 // If type not equal, then it would not actually be equivalent to remove the array creation.
                 // That case may be caught by ConfusingArgumentToVarargsMethod
-                asCtx(data).addViolation(array);
+                data.addViolation(array);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -103,9 +103,9 @@ public class UnusedAssignmentRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
         DataflowResult result = DataflowPass.getDataflowResult(node);
-        reportFinished(result, (RuleContext) data);
+        reportFinished(result, data);
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
@@ -29,7 +30,7 @@ public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         if (node.getVisibility() != Visibility.V_PRIVATE && !getProperty(CHECKALL_DESCRIPTOR)) {
             return data;
         }
@@ -38,7 +39,7 @@ public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (node.getVisibility() != Visibility.V_PRIVATE && !getProperty(CHECKALL_DESCRIPTOR)) {
             return data;
         }
@@ -51,11 +52,11 @@ public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
         return data;
     }
 
-    private void check(ASTExecutableDeclaration node, Object data) {
+    private void check(ASTExecutableDeclaration node, RuleContext data) {
         for (ASTFormalParameter formal : node.getFormalParameters()) {
             ASTVariableId varId = formal.getVarId();
             if (JavaAstUtils.isNeverUsed(varId) && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())) {
-                asCtx(data).addViolation(varId, node instanceof ASTMethodDeclaration ? "method" : "constructor", varId.getName());
+                data.addViolation(varId, node instanceof ASTMethodDeclaration ? "method" : "constructor", varId.getName());
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedLocalVariableRule extends AbstractJavaRule {
 
@@ -25,23 +26,23 @@ public class UnusedLocalVariableRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration decl, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration decl, RuleContext data) {
         for (ASTVariableId varId : decl.getVarIds()) {
             if (JavaAstUtils.isNeverUsed(varId)
                 && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())) {
-                asCtx(data).addViolation(varId, varId.getName());
+                data.addViolation(varId, varId.getName());
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTTypePattern pattern, Object data) {
+    public RuleContext visit(ASTTypePattern pattern, RuleContext data) {
         ASTVariableId varId = pattern.getVarId();
         if (JavaAstUtils.isNeverUsed(varId)
                 && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())
                 && !neededForSwitchOrRecord(pattern)) {
-            asCtx(data).addViolation(varId, varId.getName());
+            data.addViolation(varId, varId.getName());
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
 
@@ -44,7 +45,7 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         if (node instanceof ASTTypeDeclaration) {
             ASTTypeDeclaration type = (ASTTypeDeclaration) node;
             if (hasAnyAnnotation(type)) {
@@ -55,7 +56,7 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
                 if (!isIgnored(field)) {
                     for (ASTVariableId varId : field.getVarIds()) {
                         if (JavaAstUtils.isNeverUsed(varId)) {
-                            asCtx(data).addViolation(varId, varId.getName());
+                            data.addViolation(varId, varId.getName());
                         }
                     }
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -32,6 +32,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects private methods, that are not used and can therefore be
@@ -53,7 +54,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit file, Object param) {
+    public RuleContext visit(ASTCompilationUnit file, RuleContext param) {
         // this does a couple of traversals:
         // - one to find annotations that potentially reference a method
         // - one to collect candidates, that is, potentially unused methods
@@ -81,7 +82,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             });
 
         for (ASTMethodDeclaration unusedMethod : candidates.values()) {
-            asCtx(param).addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
+            param.addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detect structures like "foo.size() == 0" and suggest replacing them with
@@ -25,11 +26,11 @@ public class UseCollectionIsEmptyRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, RuleContext data) {
         if ((TypeTestUtil.isA(Collection.class, call.getQualifier())
             || TypeTestUtil.isA(Map.class, call.getQualifier()))
             && isSizeZeroCheck(call)) {
-            asCtx(data).addViolation(call);
+            data.addViolation(call);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detect cases where EnumSet and EnumMap can be used.
@@ -29,7 +30,7 @@ public class UseEnumCollectionsRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTConstructorCall call, Object data) {
+    public RuleContext visit(ASTConstructorCall call, RuleContext data) {
         JTypeMirror builtType = call.getTypeMirror();
 
         if (!builtType.isRaw()) {
@@ -41,7 +42,7 @@ public class UseEnumCollectionsRule extends AbstractJavaRulechainRule {
 
                 if (keySymbol instanceof JClassSymbol && ((JClassSymbol) keySymbol).isEnum()) {
                     String enumCollectionReplacement = isMap ? "EnumMap" : "EnumSet";
-                    asCtx(data).addViolation(call.getTypeNode(), enumCollectionReplacement);
+                    data.addViolation(call.getTypeNode(), enumCollectionReplacement);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
 
@@ -33,7 +34,7 @@ public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTTryStatement node, Object data) {
+    public RuleContext visit(ASTTryStatement node, RuleContext data) {
         boolean isJava9OrLater = node.getLanguageVersion().compareToVersion("9") >= 0;
 
         ASTFinallyClause finallyClause = node.getFinallyClause();
@@ -47,7 +48,7 @@ public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
                         && TypeTestUtil.isA(AutoCloseable.class, closeTarget)
                         && (isJava9OrLater || JavaAstUtils.isReferenceToLocal(closeTarget))
                         || hasAutoClosableArguments(method)) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                     break; // only report the first closeable
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyBuilder.RegexPropertyBuilder;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.StringUtil.CaseConvention;
 
 
@@ -57,12 +58,15 @@ abstract class AbstractNamingConventionRule<T extends JavaNode> extends Abstract
     abstract String nameExtractor(T node);
 
 
-    void checkMatches(T node, PropertyDescriptor<Pattern> regex, Object data) {
+    void checkMatches(T node, PropertyDescriptor<Pattern> regex, RuleContext data) {
         String name = nameExtractor(node);
         if (!getProperty(regex).matcher(name).matches()) {
-            asCtx(data).addViolation(node, kindDisplayName(node, regex),
-                                     name,
-                                     getProperty(regex).toString());
+            data.addViolation(
+                    node,
+                    kindDisplayName(node, regex),
+                    name,
+                    getProperty(regex).toString()
+            );
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
 import net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule;
 import net.sourceforge.pmd.lang.java.rule.internal.AbstractIgnoredAnnotationRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects non-static classes with no constructors;
@@ -43,7 +44,7 @@ public class AtLeastOneConstructorRule extends AbstractIgnoredAnnotationRule {
     }
 
     @Override
-    public Object visit(final ASTClassDeclaration node, final Object data) {
+    public RuleContext visit(final ASTClassDeclaration node, final RuleContext data) {
         // Ignore interfaces / static classes / classes that have a constructor / classes ignored through annotations
         if (!node.isRegularClass()
             || node.isStatic()
@@ -57,7 +58,7 @@ public class AtLeastOneConstructorRule extends AbstractIgnoredAnnotationRule {
                                              .filterNot(it -> it instanceof ASTTypeDeclaration);
         if (members.isEmpty() || members.any(it -> !it.hasModifiers(JModifier.STATIC))) {
             // Do we have any non-static members?
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -53,7 +54,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
 
         if (isTestClass(node)) {
             checkMatches(node, testClassRegex, data);
@@ -75,19 +76,19 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
 
 
     @Override
-    public Object visit(ASTEnumDeclaration node, Object data) {
+    public RuleContext visit(ASTEnumDeclaration node, RuleContext data) {
         checkMatches(node, enumerationRegex, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTRecordDeclaration node, Object data) {
+    public RuleContext visit(ASTRecordDeclaration node, RuleContext data) {
         checkMatches(node, classRegex, data); // property?
         return data;
     }
 
     @Override
-    public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
+    public RuleContext visit(ASTAnnotationTypeDeclaration node, RuleContext data) {
         checkMatches(node, annotationRegex, data);
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -85,50 +85,50 @@ public class CommentDefaultAccessModifierRule extends AbstractJavaRulechainRule 
     }
     
     @Override
-    public Object visit(final ASTMethodDeclaration decl, final Object data) {
+    public RuleContext visit(final ASTMethodDeclaration decl, final RuleContext data) {
         if (shouldReportNonTopLevel(decl)) {
-            report((RuleContext) data, decl, "method", PrettyPrintingUtil.displaySignature(decl));
+            report(data, decl, "method", PrettyPrintingUtil.displaySignature(decl));
         }
         return data;
     }
 
     @Override
-    public Object visit(final ASTFieldDeclaration decl, final Object data) {
+    public RuleContext visit(final ASTFieldDeclaration decl, final RuleContext data) {
         if (shouldReportNonTopLevel(decl)) {
-            report((RuleContext) data, decl, "field", decl.getVarIds().firstOrThrow().getName());
+            report(data, decl, "field", decl.getVarIds().firstOrThrow().getName());
         }
         return data;
     }
 
     @Override
-    public Object visit(final ASTConstructorDeclaration decl, Object data) {
+    public RuleContext visit(final ASTConstructorDeclaration decl, RuleContext data) {
         if (shouldReportNonTopLevel(decl)) {
-            report((RuleContext) data, decl, "constructor", PrettyPrintingUtil.displaySignature(decl));
+            report(data, decl, "constructor", PrettyPrintingUtil.displaySignature(decl));
         }
         return data;
     }
 
     @Override
-    public Object visit(final ASTAnnotationTypeDeclaration decl, final Object data) {
-        checkTypeDecl(decl, (RuleContext) data, "annotation");
+    public RuleContext visit(final ASTAnnotationTypeDeclaration decl, final RuleContext data) {
+        checkTypeDecl(decl, data, "annotation");
         return data;
     }
 
     @Override
-    public Object visit(final ASTEnumDeclaration decl, final Object data) {
-        checkTypeDecl(decl, (RuleContext) data, "enum");
+    public RuleContext visit(final ASTEnumDeclaration decl, final RuleContext data) {
+        checkTypeDecl(decl, data, "enum");
         return data;
     }
 
     @Override
-    public Object visit(final ASTRecordDeclaration decl, final Object data) {
-        checkTypeDecl(decl, (RuleContext) data, "record");
+    public RuleContext visit(final ASTRecordDeclaration decl, final RuleContext data) {
+        checkTypeDecl(decl, data, "record");
         return data;
     }
 
     @Override
-    public Object visit(final ASTClassDeclaration decl, final Object data) {
-        checkTypeDecl(decl, (RuleContext) data, "class");
+    public RuleContext visit(final ASTClassDeclaration decl, final RuleContext data) {
+        checkTypeDecl(decl, data, "class");
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.java.ast.BinaryOp;
 import net.sourceforge.pmd.lang.java.ast.UnaryOp;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 
@@ -79,24 +80,24 @@ public class ConfusingTernaryRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         // look for "if (match) ..; else .."
         if (node.hasElse()
             && isMatch(node.getCondition())) {
             if (!getProperty(IGNORE_ELSE_IF)
                 || !(node.getElseBranch() instanceof ASTIfStatement)
                 && !(node.getParent() instanceof ASTIfStatement)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTConditionalExpression node, Object data) {
+    public RuleContext visit(ASTConditionalExpression node, RuleContext data) {
         // look for "match ? .. : .."
         if (isMatch(node.getCondition())) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
@@ -31,6 +31,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
 
@@ -51,94 +52,94 @@ public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTFinallyClause node, Object data) {
+    public RuleContext visit(ASTFinallyClause node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty finally clause");
+            data.addViolationWithMessage(node, "Empty finally clause");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTSynchronizedStatement node, Object data) {
+    public RuleContext visit(ASTSynchronizedStatement node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty synchronized statement");
+            data.addViolationWithMessage(node, "Empty synchronized statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTSwitchStatement node, Object data) {
+    public RuleContext visit(ASTSwitchStatement node, RuleContext data) {
         if (node.getNumChildren() == 1) {
-            asCtx(data).addViolationWithMessage(node, "Empty switch statement");
+            data.addViolationWithMessage(node, "Empty switch statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTBlock node, Object data) {
+    public RuleContext visit(ASTBlock node, RuleContext data) {
         if (isEmpty(node) && node.getParent() instanceof ASTBlock) {
-            asCtx(data).addViolationWithMessage(node, "Empty block");
+            data.addViolationWithMessage(node, "Empty block");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         if (isEmpty(node.getThenBranch())) {
-            asCtx(data).addViolationWithMessage(node, "Empty if statement");
+            data.addViolationWithMessage(node, "Empty if statement");
         }
         if (node.hasElse() && isEmpty(node.getElseBranch())) {
-            asCtx(data).addViolationWithMessage(node.getElseBranch(), "Empty else statement");
+            data.addViolationWithMessage(node.getElseBranch(), "Empty else statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTWhileStatement node, Object data) {
+    public RuleContext visit(ASTWhileStatement node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty while statement");
+            data.addViolationWithMessage(node, "Empty while statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTForStatement node, Object data) {
+    public RuleContext visit(ASTForStatement node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty for statement");
+            data.addViolationWithMessage(node, "Empty for statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTForeachStatement node, Object data) {
+    public RuleContext visit(ASTForeachStatement node, RuleContext data) {
         if (JavaRuleUtil.isExplicitUnusedVarName(node.getVarId().getName())) {
             // allow `for (ignored : iterable) {}`
             return null;
         }
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty foreach statement");
+            data.addViolationWithMessage(node, "Empty foreach statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTDoStatement node, Object data) {
+    public RuleContext visit(ASTDoStatement node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty do..while statement");
+            data.addViolationWithMessage(node, "Empty do..while statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTInitializer node, Object data) {
+    public RuleContext visit(ASTInitializer node, RuleContext data) {
         if (isEmpty(node.getBody())) {
-            asCtx(data).addViolationWithMessage(node, "Empty initializer statement");
+            data.addViolationWithMessage(node, "Empty initializer statement");
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTTryStatement node, Object data) {
+    public RuleContext visit(ASTTryStatement node, RuleContext data) {
         if (isEmpty(node.getBody())) {
             // all resources must be explicitly ignored
             boolean hasResource = false;
@@ -153,7 +154,7 @@ public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
                         if (isSimpleExpression(init)) {
                             // The expression is simple enough, it should be just written this.close() or var.close(),
                             // so we report this case
-                            asCtx(data).addViolationWithMessage(node, "Empty try-with-resources statement. Should be written {0}.close()", PrettyPrintingUtil.prettyPrint(init));
+                            data.addViolationWithMessage(node, "Empty try-with-resources statement. Should be written {0}.close()", PrettyPrintingUtil.prettyPrint(init));
                             return null;
                         }
                         // Otherwise the expression is more complex and this is allowed, in order
@@ -169,14 +170,14 @@ public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
                     }
                     String name = varId.getName();
                     if (!JavaRuleUtil.isExplicitUnusedVarName(name)) {
-                        asCtx(data).addViolationWithMessage(node, "Empty try-with-resources statement. Rename the resource to `ignored`, `unused` or `_` (Java 22+).");
+                        data.addViolationWithMessage(node, "Empty try-with-resources statement. Rename the resource to `ignored`, `unused` or `_` (Java 22+).");
                         return null;
                     }
                 }
             }
 
             if (!hasResource) {
-                asCtx(data).addViolationWithMessage(node, "Empty try body");
+                data.addViolationWithMessage(node, "Empty try body");
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -49,12 +50,20 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         assert node instanceof ASTTypeDeclaration;
         return visit((ASTTypeDeclaration) node, data);
     }
 
+    /**
+     * @deprecated should have never been public
+     */
+    @Deprecated
     public Object visit(ASTTypeDeclaration node, Object data) {
+        return visit(node, (RuleContext) data);
+    }
+
+    private RuleContext visit(ASTTypeDeclaration node, RuleContext data) {
         boolean inStartOfClass = true;
         for (ASTBodyDeclaration declaration : node.getDeclarations()) {
             if (!isAllowedAtStartOfClass(declaration)) {
@@ -63,7 +72,7 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
             if (!inStartOfClass && declaration instanceof ASTFieldDeclaration) {
                 ASTFieldDeclaration field = (ASTFieldDeclaration) declaration;
                 if (!isInitializerOk(field)) {
-                    asCtx(data).addViolation(declaration);
+                    data.addViolation(declaration);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -63,7 +64,7 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         for (ASTVariableId id : node) {
             if (getProperty(EXCLUDED_NAMES).contains(id.getName())) {
                 continue;
@@ -86,13 +87,16 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
 
 
     @Override
-    public Object visit(ASTEnumConstant node, Object data) {
+    public RuleContext visit(ASTEnumConstant node, RuleContext data) {
         // This inlines checkMatches because there's no variable declarator id
 
         if (!getProperty(enumConstantRegex).matcher(node.getImage()).matches()) {
-            asCtx(data).addViolation(node, "enum constant",
-                                     node.getImage(),
-                                     getProperty(enumConstantRegex).toString());
+            data.addViolation(
+                    node,
+                    "enum constant",
+                    node.getImage(),
+                    getProperty(enumConstantRegex).toString()
+            );
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -38,7 +39,7 @@ public final class FormalParameterNamingConventionsRule extends AbstractNamingCo
     }
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         if (node.isUnnamed()) {
             // unnamed variables do not have to match the regexes.
             return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.OptionalBool;
 
 
@@ -118,7 +119,7 @@ public class IdenticalCatchBranchesRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTTryStatement node, Object data) {
+    public RuleContext visit(ASTTryStatement node, RuleContext data) {
 
         List<ASTCatchClause> catchStatements = node.getCatchClauses().toList();
         Set<List<ASTCatchClause>> equivClasses = equivalenceClasses(catchStatements);
@@ -130,7 +131,7 @@ public class IdenticalCatchBranchesRule extends AbstractJavaRulechainRule {
                 // By convention, lower catch blocks are collapsed into the highest one
                 // The first node of the equivalence class is thus the block that should be transformed
                 for (int i = 1; i < identicalStmts.size(); i++) {
-                    asCtx(data).addViolation(identicalStmts.get(i), identicalBranchName);
+                    data.addViolation(identicalStmts.get(i), identicalBranchName);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
@@ -81,14 +81,14 @@ public class LambdaCanBeMethodReferenceRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTLambdaExpression node, Object data) {
+    public RuleContext visit(ASTLambdaExpression node, RuleContext data) {
         if (node.isExpressionBody()) {
             ASTExpression expression = node.getExpressionBody();
-            processLambdaWithBody(node, asCtx(data), expression);
+            processLambdaWithBody(node, data, expression);
         } else {
             ASTStatement onlyStmt = ASTList.singleOrNull(node.getBlockBody());
             if (onlyStmt instanceof ASTReturnStatement) {
-                processLambdaWithBody(node, asCtx(data), ((ASTReturnStatement) onlyStmt).getExpr());
+                processLambdaWithBody(node, data, ((ASTReturnStatement) onlyStmt).getExpr());
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaPropertyUtil;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LinguisticNamingRule extends AbstractJavaRulechainRule {
     private static final PropertyDescriptor<List<String>> IGNORED_ANNOTS =
@@ -78,7 +79,7 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (!hasIgnoredAnnotation(node)) {
             String nameOfMethod = node.getName();
 
@@ -109,22 +110,22 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
         return node.isAnyAnnotationPresent(getProperty(IGNORED_ANNOTS));
     }
 
-    private void checkPrefixedTransformMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
+    private void checkPrefixedTransformMethods(ASTMethodDeclaration node, RuleContext data, String nameOfMethod) {
         List<String> prefixes = getProperty(TRANSFORM_METHOD_NAMES_PROPERTY);
         String[] splitMethodName = StringUtils.splitByCharacterTypeCamelCase(nameOfMethod);
         if (node.isVoid() && splitMethodName.length > 0
                 && prefixes.contains(splitMethodName[0].toLowerCase(Locale.ROOT))) {
             // "To" or any other configured prefix found
-            asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
+            data.addViolationWithMessage(node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
                                                 nameOfMethod);
         }
     }
 
-    private void checkTransformMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
+    private void checkTransformMethods(ASTMethodDeclaration node, RuleContext data, String nameOfMethod) {
         for (String infix : getProperty(TRANSFORM_METHOD_NAMES_PROPERTY)) {
             if (node.isVoid() && containsCamelCaseWord(nameOfMethod, StringUtils.capitalize(infix))) {
                 // "To" or any other configured infix in the middle somewhere
-                asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
+                data.addViolationWithMessage(node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
                                                     nameOfMethod);
                 // the first violation is sufficient - it is still the same method we are analyzing here
                 break;
@@ -132,16 +133,16 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
         }
     }
 
-    private void checkGetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
+    private void checkGetters(ASTMethodDeclaration node, RuleContext data, String nameOfMethod) {
         if (startsWithCamelCaseWord(nameOfMethod, "get") && node.isVoid()) {
-            asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The getter ''{0}'' should not return void linguistically",
+            data.addViolationWithMessage(node, "Linguistics Antipattern - The getter ''{0}'' should not return void linguistically",
                                                 nameOfMethod);
         }
     }
 
-    private void checkSetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
+    private void checkSetters(ASTMethodDeclaration node, RuleContext data, String nameOfMethod) {
         if (startsWithCamelCaseWord(nameOfMethod, "set") && !node.isVoid() && returnsEnclosingType(node)) {
-            asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
+            data.addViolationWithMessage(node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
                                                 nameOfMethod);
         }
     }
@@ -156,38 +157,38 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
                 || TypeTestUtil.isA("java.util.function.Predicate", node);
     }
 
-    private void checkBooleanMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
+    private void checkBooleanMethods(ASTMethodDeclaration node, RuleContext data, String nameOfMethod) {
         ASTType t = node.getResultTypeNode();
         if (!t.isVoid()) {
             for (String prefix : getProperty(BOOLEAN_METHOD_PREFIXES_PROPERTY)) {
                 if (startsWithCamelCaseWord(nameOfMethod, prefix) && !isBooleanType(t)) {
-                    asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The method ''{0}'' indicates linguistically it returns a boolean, but it returns ''{1}''",
+                    data.addViolationWithMessage(node, "Linguistics Antipattern - The method ''{0}'' indicates linguistically it returns a boolean, but it returns ''{1}''",
                                                         nameOfMethod, PrettyPrintingUtil.prettyPrintType(t));
                 }
             }
         }
     }
 
-    private void checkField(ASTType typeNode, ASTVariableDeclarator node, Object data) {
+    private void checkField(ASTType typeNode, ASTVariableDeclarator node, RuleContext data) {
         for (String prefix : getProperty(BOOLEAN_FIELD_PREFIXES_PROPERTY)) {
             if (startsWithCamelCaseWord(node.getName(), prefix) && !isBooleanType(typeNode)) {
-                asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The field ''{0}'' indicates linguistically it is a boolean, but it is ''{1}''",
-                                                    node.getName(), PrettyPrintingUtil.prettyPrintType(typeNode));
+                data.addViolationWithMessage(node, "Linguistics Antipattern - The field ''{0}'' indicates linguistically it is a boolean, but it is ''{1}''",
+                                             node.getName(), PrettyPrintingUtil.prettyPrintType(typeNode));
             }
         }
     }
 
-    private void checkVariable(ASTType typeNode, ASTVariableDeclarator node, Object data) {
+    private void checkVariable(ASTType typeNode, ASTVariableDeclarator node, RuleContext data) {
         for (String prefix : getProperty(BOOLEAN_FIELD_PREFIXES_PROPERTY)) {
             if (startsWithCamelCaseWord(node.getName(), prefix) && !isBooleanType(typeNode)) {
-                asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The variable ''{0}'' indicates linguistically it is a boolean, but it is ''{1}''",
-                                                    node.getName(), PrettyPrintingUtil.prettyPrintType(typeNode));
+                data.addViolationWithMessage(node, "Linguistics Antipattern - The variable ''{0}'' indicates linguistically it is a boolean, but it is ''{1}''",
+                                             node.getName(), PrettyPrintingUtil.prettyPrintType(typeNode));
             }
         }
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         ASTType type = node.getTypeNode();
         if (type != null && getProperty(CHECK_FIELDS)) {
             for (ASTVariableDeclarator field : node.children(ASTVariableDeclarator.class)) {
@@ -198,7 +199,7 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, RuleContext data) {
         ASTType type = node.getTypeNode();
         if (type != null && getProperty(CHECK_VARIABLES)) {
             for (ASTVariableDeclarator variable : node.children(ASTVariableDeclarator.class)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
 
@@ -24,7 +25,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, RuleContext data) {
         if (node.isFinal()) { // also for implicit finals, like resources, or lombok.val
             return data;
         }
@@ -37,7 +38,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
             for (ASTVariableId vid : node.getVarIds()) {
                 if (!JavaAstUtils.isNeverUsed(vid)) {
                     // filter out unused variables
-                    asCtx(data).addViolation(vid, vid.getName());
+                    data.addViolation(vid, vid.getName());
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -37,7 +38,7 @@ public final class LocalVariableNamingConventionsRule extends AbstractNamingConv
 
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         if (node.isUnnamed()) {
             // unnamed variables do not have to match the regexes.
             return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class MethodArgumentCouldBeFinalRule extends AbstractJavaRulechainRule {
 
@@ -19,7 +20,7 @@ public class MethodArgumentCouldBeFinalRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration meth, Object data) {
+    public RuleContext visit(ASTMethodDeclaration meth, RuleContext data) {
         if (meth.getBody() == null) {
             return data;
         }
@@ -28,18 +29,18 @@ public class MethodArgumentCouldBeFinalRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration constructor, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration constructor, RuleContext data) {
         lookForViolation(constructor, data);
         return data;
     }
 
-    private void lookForViolation(ASTExecutableDeclaration node, Object data) {
+    private void lookForViolation(ASTExecutableDeclaration node, RuleContext data) {
         for (ASTFormalParameter param : node.getFormalParameters()) {
             ASTVariableId varId = param.getVarId();
             if (!param.isFinal()
                 && !JavaAstUtils.isNeverUsed(varId)
                 && JavaAstUtils.isEffectivelyFinal(varId)) {
-                asCtx(data).addViolation(varId, varId.getName());
+                data.addViolation(varId, varId.getName());
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.PropertyBuilder.RegexPropertyBuilder;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class MethodNamingConventionsRule extends AbstractNamingConventionRule<ASTMethodDeclaration> {
@@ -38,7 +39,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
 
         if (node.isOverridden()) {
             return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
@@ -218,8 +218,8 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTModifierList modList, Object data) {
-        RuleContext ctx = asCtx(data);
+    public RuleContext visit(ASTModifierList modList, RuleContext data) {
+        RuleContext ctx = data;
         boolean acceptsTypeAnnot = contextCanHaveTypeAnnots(modList);
         ModifierOrderEvents eventHandler = new ModifierOrderEvents() {
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
 
@@ -27,7 +28,7 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (node.getBody() == null || isIgnoredMethod(node)) {
             return null;
         }
@@ -36,7 +37,7 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
             node.getBody().descendants(ASTReturnStatement.class).dropLast(1);
 
         for (ASTReturnStatement returnStmt : returnsExceptLast) {
-            asCtx(data).addViolation(returnStmt);
+            data.addViolation(returnStmt);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Checks for variables in methods that are defined before they are really
@@ -49,7 +50,7 @@ public class PrematureDeclarationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, RuleContext data) {
         if (node.getParent() instanceof ASTForInit
             || node.getParent() instanceof ASTResource) {
             // those don't count
@@ -76,7 +77,7 @@ public class PrematureDeclarationRule extends AbstractJavaRulechainRule {
                 }
 
                 if (hasExit(stmt)) {
-                    asCtx(data).addViolation(node, id.getName());
+                    data.addViolation(node, id.getName());
                     break;
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/TypeParameterNamingConventionsRule.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTTypeParameter;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -23,7 +24,7 @@ public class TypeParameterNamingConventionsRule extends AbstractNamingConvention
     }
 
     @Override
-    public Object visit(ASTTypeParameter node, Object data) {
+    public RuleContext visit(ASTTypeParameter node, RuleContext data) {
         checkMatches(node, typeParameterRegex, data);
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingRule.java
@@ -55,7 +55,7 @@ public class UnnecessaryBoxingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         if (node.getTypeMirror().isBoxedPrimitive()) {
             ASTExpression arg = ASTList.singleOrNull(node.getArguments());
             if (arg == null) {
@@ -63,7 +63,7 @@ public class UnnecessaryBoxingRule extends AbstractJavaRulechainRule {
             }
             JTypeMirror argT = arg.getTypeMirror();
             if (argT.isPrimitive()) {
-                checkBox((RuleContext) data, node, arg);
+                checkBox(data, node, arg);
             }
         }
         return null;
@@ -71,7 +71,7 @@ public class UnnecessaryBoxingRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (INTERESTING_NAMES.contains(node.getMethodName())) {
             OverloadSelectionResult overload = node.getOverloadSelectionInfo();
             if (overload.isFailed()) {
@@ -82,11 +82,11 @@ public class UnnecessaryBoxingRule extends AbstractJavaRulechainRule {
             ASTExpression qualifier = node.getQualifier();
 
             if (isValueOf && isWrapperValueOf(m)) {
-                checkBox((RuleContext) data, node, node.getArguments().get(0));
+                checkBox(data, node, node.getArguments().get(0));
             } else if (isValueOf && isBoxValueOfString(m)) {
-                checkUnboxing((RuleContext) data, node, m.getDeclaringType());
+                checkUnboxing(data, node, m.getDeclaringType());
             } else if (!isValueOf && qualifier != null && isUnboxingCall(m)) {
-                checkBox((RuleContext) data, node, qualifier);
+                checkBox(data, node, qualifier);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -45,6 +45,7 @@ import net.sourceforge.pmd.lang.java.types.TypeOps.Convertibility;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.java.types.ast.ExprContext;
 import net.sourceforge.pmd.lang.java.types.ast.ExprContext.ExprContextKind;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects casts where the operand is already a subtype of the context
@@ -60,7 +61,7 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTCastExpression castExpr, Object data) {
+    public RuleContext visit(ASTCastExpression castExpr, RuleContext data) {
         ASTExpression operand = castExpr.getOperand();
 
         // eg in
@@ -110,7 +111,7 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
     }
 
     private void handleMethodCall(ASTCastExpression castExpr, JMethodSig methodType,
-            JTypeMirror operandType, Object data) {
+            JTypeMirror operandType, RuleContext data) {
         boolean generic = methodType.getSymbol().getFormalParameters().stream()
             .anyMatch(fp -> isTypeExpression(fp.getTypeMirror(Substitution.EMPTY)));
         if (!generic) {
@@ -161,8 +162,8 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
         return coercionType.isRaw() && !operandType.isRaw();
     }
 
-    private void reportCast(ASTCastExpression castExpr, Object data) {
-        asCtx(data).addViolation(castExpr, PrettyPrintingUtil.prettyPrintType(castExpr.getCastType()));
+    private void reportCast(ASTCastExpression castExpr, RuleContext data) {
+        data.addViolation(castExpr, PrettyPrintingUtil.prettyPrintType(castExpr.getCastType()));
     }
 
     private static boolean castIsUnnecessaryToMatchContext(ExprContext context,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.rule.internal.AbstractIgnoredAnnotationRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects when a constructor is not necessary;
@@ -41,7 +42,7 @@ public class UnnecessaryConstructorRule extends AbstractIgnoredAnnotationRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (node.isRegularClass()) {
             checkClassOrEnum(node, data);
         }
@@ -49,19 +50,19 @@ public class UnnecessaryConstructorRule extends AbstractIgnoredAnnotationRule {
     }
 
     @Override
-    public Object visit(ASTEnumDeclaration node, Object data) {
+    public RuleContext visit(ASTEnumDeclaration node, RuleContext data) {
         checkClassOrEnum(node, data);
         return data;
     }
 
-    private void checkClassOrEnum(ASTTypeDeclaration node, Object data) {
+    private void checkClassOrEnum(ASTTypeDeclaration node, RuleContext data) {
         List<ASTConstructorDeclaration> ctors = node.getDeclarations(ASTConstructorDeclaration.class).take(2).toList();
         if (ctors.size() != 1) {
             return;
         }
         ASTConstructorDeclaration ctor = ctors.get(0);
         if (isExplicitDefaultConstructor(node, ctor) && ctor.getJavadocComment() == null) {
-            asCtx(data).addViolation(ctor);
+            data.addViolation(ctor);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -37,6 +37,7 @@ import net.sourceforge.pmd.lang.java.symbols.table.coreimpl.ShadowChain;
 import net.sourceforge.pmd.lang.java.symbols.table.coreimpl.ShadowChainIterator;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.AssertionUtil;
 
 public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule {
@@ -60,7 +61,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(final ASTClassType deepest, Object data) {
+    public RuleContext visit(final ASTClassType deepest, RuleContext data) {
         if (deepest.getQualifier() != null) {
             // the child will be visited instead
             return data;
@@ -95,7 +96,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
                     // we don't actually know where the method came from
                     String simpleName = formatMemberName(next, methodCall.getMethodType().getSymbol());
                     String unnecessary = produceQualifier(deepest, next, true);
-                    asCtx(data).addViolation(next, unnecessary, simpleName, "");
+                    data.addViolation(next, unnecessary, simpleName, "");
                     return null;
                 }
             } else if (getProperty(REPORT_FIELDS) && opa instanceof ASTFieldAccess) {
@@ -105,7 +106,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
                     String simpleName = formatMemberName(next, fieldAccess.getReferencedSym());
                     String reasonToString = unnecessaryReasonWrapper(reasonForFieldInScope);
                     String unnecessary = produceQualifier(deepest, next, true);
-                    asCtx(data).addViolation(next, unnecessary, simpleName, reasonToString);
+                    data.addViolation(next, unnecessary, simpleName, reasonToString);
                     return null;
                 }
             }
@@ -115,7 +116,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
             String simpleName = next.getSimpleName();
             String reasonToString = unnecessaryReasonWrapper(bestReason);
             String unnecessary = produceQualifier(deepest, next, false);
-            asCtx(data).addViolation(next, unnecessary, simpleName, reasonToString);
+            data.addViolation(next, unnecessary, simpleName, reasonToString);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -46,6 +46,7 @@ import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.java.types.TypesFromReflection;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 import net.sourceforge.pmd.util.IteratorUtil;
 
@@ -122,7 +123,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
                                                 EXCEPTION_PATTERN, LINK_IN_SNIPPET, MARKDOWN_PATTERN };
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
         this.moduleImports.clear();
         this.allSingleNameImports.clear();
         this.staticImportsOnDemand.clear();
@@ -152,7 +153,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
         return data;
     }
 
-    private void doReporting(Object data) {
+    private void doReporting(RuleContext data) {
         for (ImportWrapper wrapper : allSingleNameImports) {
             String message = wrapper.isStatic() ? UNUSED_STATIC_IMPORT_MESSAGE : UNUSED_IMPORT_MESSAGE;
             reportWithMessage(wrapper.node, data, message);
@@ -236,7 +237,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
         }
     }
 
-    private void visitImport(ASTImportDeclaration node, Object data, String thisPackageName) {
+    private void visitImport(ASTImportDeclaration node, RuleContext data, String thisPackageName) {
         if (thisPackageName.equals(node.getPackageName())) {
             unnecessaryImportsFromSamePackage.add(new ImportWrapper(node));
         }
@@ -262,12 +263,12 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
         return allSingleNameImports;
     }
 
-    private void reportWithMessage(ASTImportDeclaration node, Object data, String message) {
-        asCtx(data).addViolationWithMessage(node, message, PrettyPrintingUtil.prettyImport(node));
+    private void reportWithMessage(ASTImportDeclaration node, RuleContext data, String message) {
+        data.addViolationWithMessage(node, message, PrettyPrintingUtil.prettyImport(node));
     }
 
     @Override
-    public Object visit(ASTClassType node, Object data) {
+    public RuleContext visit(ASTClassType node, RuleContext data) {
         if (node.getQualifier() == null
             && !node.isFullyQualified()
             && node.getTypeMirror().isClassOrInterface()) {
@@ -281,7 +282,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTAmbiguousName node, Object data) {
+    public RuleContext visit(ASTAmbiguousName node, RuleContext data) {
         // ambiguous name means the symbol table could not resolve the first name
 
         // only consider static imports
@@ -308,7 +309,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (node.getQualifier() == null) {
             OverloadSelectionResult overload = node.getOverloadSelectionInfo();
             if (overload.isFailed()) {
@@ -332,7 +333,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTVariableAccess node, Object data) {
+    public RuleContext visit(ASTVariableAccess node, RuleContext data) {
         JVariableSymbol sym = node.getReferencedSym();
         if (sym != null
             && sym.isField()

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryInterfaceDeclarationRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @since 7.22.0
@@ -39,7 +40,7 @@ public class UnnecessaryInterfaceDeclarationRule extends AbstractJavaRulechainRu
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object context) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext context) {
         Map<JTypeMirror, JavaNode> directSupertypes = new HashMap<>();
         ASTList<?> ext = node.children(ASTExtendsList.class).first();
         ASTList<?> impl = node.children(ASTImplementsList.class).first();
@@ -57,13 +58,13 @@ public class UnnecessaryInterfaceDeclarationRule extends AbstractJavaRulechainRu
     }
 
     private void checkRelated(JavaNode supertypeNode, JTypeMirror supertype, JTypeMirror supertype1,
-                              Object context) {
+                              RuleContext context) {
         List<String> allowed = getProperty(ALLOWED_INTERFACES);
         if (allowed.contains(supertype.toString())) {
             return;
         }
         if (TypeTestUtil.isA(supertype, supertype1)) {
-            asCtx(context).addViolation(supertypeNode, supertype, supertype1);
+            context.addViolation(supertypeNode, supertype, supertype1);
         }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @deprecated Since 7.17.0. This rule is replaced by {@link VariableCanBeInlinedRule}.
@@ -28,7 +29,7 @@ public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRulechainRule 
     }
 
     @Override
-    public Object visit(ASTReturnStatement returnStmt, Object data) {
+    public RuleContext visit(ASTReturnStatement returnStmt, RuleContext data) {
         if (!(returnStmt.getExpr() instanceof ASTVariableAccess)) {
             return null;
         }
@@ -50,7 +51,7 @@ public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRulechainRule 
 
         if (!getProperty(STATEMENT_ORDER_MATTERS)
             || varDecl.ancestors(ASTLocalVariableDeclaration.class).firstOrThrow().getNextSibling() == returnStmt) {
-            asCtx(data).addViolation(varDecl, varDecl.getName());
+            data.addViolation(varDecl, varDecl.getName());
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
@@ -43,18 +44,18 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
 
-    private void reportUnnecessaryModifiers(Object data, JavaNode node,
+    private void reportUnnecessaryModifiers(RuleContext data, JavaNode node,
                                             JModifier unnecessaryModifier, String explanation) {
         reportUnnecessaryModifiers(data, node, EnumSet.of(unnecessaryModifier), explanation);
     }
 
 
-    private void reportUnnecessaryModifiers(Object data, JavaNode node,
+    private void reportUnnecessaryModifiers(RuleContext data, JavaNode node,
                                             Set<JModifier> unnecessaryModifiers, String explanation) {
         if (unnecessaryModifiers.isEmpty()) {
             return;
         }
-        asCtx(data).addViolation(node, formatUnnecessaryModifiers(unnecessaryModifiers),
+        data.addViolation(node, formatUnnecessaryModifiers(unnecessaryModifiers),
                                  PrettyPrintingUtil.getPrintableNodeKind(node),
                                  PrettyPrintingUtil.getNodeName(node),
                                  explanation.isEmpty() ? "" : ": " + explanation);
@@ -69,7 +70,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTEnumDeclaration node, Object data) {
+    public RuleContext visit(ASTEnumDeclaration node, RuleContext data) {
 
         if (node.hasExplicitModifiers(PUBLIC)) {
             checkDeclarationInInterfaceType(data, node, EnumSet.of(PUBLIC));
@@ -85,7 +86,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
+    public RuleContext visit(ASTAnnotationTypeDeclaration node, RuleContext data) {
         if (node.hasExplicitModifiers(ABSTRACT)) {
             // may have several violations, with different explanations
             reportUnnecessaryModifiers(data, node, ABSTRACT, "annotations types are implicitly abstract");
@@ -115,7 +116,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
 
         if (node.isInterface() && node.hasExplicitModifiers(ABSTRACT)) {
             // an abstract interface
@@ -137,7 +138,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(final ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(final ASTMethodDeclaration node, RuleContext data) {
 
         checkDeclarationInInterfaceType(data, node, EnumSet.of(PUBLIC, ABSTRACT));
 
@@ -163,7 +164,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(final ASTResource node, final Object data) {
+    public RuleContext visit(final ASTResource node, final RuleContext data) {
         if (!node.isConciseResource() && node.asLocalVariableDeclaration().hasExplicitModifiers(FINAL)) {
             reportUnnecessaryModifiers(data, node, FINAL, "resource specifications are implicitly final");
         }
@@ -172,13 +173,13 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         checkDeclarationInInterfaceType(data, node, EnumSet.of(PUBLIC, STATIC, FINAL));
         return data;
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         if (node.getEnclosingType().isEnum() && node.hasExplicitModifiers(PRIVATE)) {
             reportUnnecessaryModifiers(data, node, PRIVATE, "enum constructors are implicitly private");
         }
@@ -186,7 +187,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTRecordDeclaration node, Object data) {
+    public RuleContext visit(ASTRecordDeclaration node, RuleContext data) {
         if (node.hasExplicitModifiers(STATIC)) {
             reportUnnecessaryModifiers(data, node, STATIC, "records are implicitly static");
         }
@@ -202,7 +203,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRulechainRule {
     }
 
 
-    private void checkDeclarationInInterfaceType(Object data, ModifierOwner member, Set<JModifier> unnecessary) {
+    private void checkDeclarationInInterfaceType(RuleContext data, ModifierOwner member, Set<JModifier> unnecessary) {
         // third ancestor could be an AllocationExpression
         // if this is a method in an anonymous inner class
         ASTTypeDeclaration parent = member.getEnclosingType();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnnecessaryReturnRule extends AbstractJavaRulechainRule {
 
@@ -29,7 +30,7 @@ public class UnnecessaryReturnRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTReturnStatement node, Object data) {
+    public RuleContext visit(ASTReturnStatement node, RuleContext data) {
         if (node.getNumChildren() > 0) {
             return null;
         }
@@ -39,7 +40,7 @@ public class UnnecessaryReturnRule extends AbstractJavaRulechainRule {
                 .filterIs(ASTStatement.class);
 
         if (enclosingStatements.all(UnnecessaryReturnRule::isLastStatementOfParent)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -33,6 +33,7 @@ import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.InvocationM
 import net.sourceforge.pmd.lang.java.types.internal.infer.Infer;
 import net.sourceforge.pmd.lang.java.types.internal.infer.MethodCallSite;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ast.JavaExprMirrors;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Checks usages of explicit type arguments in a constructor call that
@@ -64,7 +65,7 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall ctorCall, Object data) {
+    public RuleContext visit(ASTConstructorCall ctorCall, RuleContext data) {
         ASTClassType newTypeNode = ctorCall.getTypeNode();
         JTypeMirror newType = newTypeNode.getTypeMirror();
 
@@ -85,7 +86,7 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
             JavaNode reportNode = targs == null ? newTypeNode : targs;
             String message = targs == null ? RAW_TYPE_MESSAGE : REPLACE_TYPE_ARGS_MESSAGE;
             String replaceWith = produceSuggestedExprImage(ctorCall);
-            asCtx(data).addViolationWithMessage(reportNode, message, replaceWith);
+            data.addViolationWithMessage(reportNode, message, replaceWith);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.AssertionUtil;
 
 
@@ -65,7 +66,7 @@ public final class UselessParenthesesRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         if (node instanceof ASTExpression) {
             checkExpr((ASTExpression) node, data);
         } else {
@@ -74,7 +75,7 @@ public final class UselessParenthesesRule extends AbstractJavaRulechainRule {
         return null;
     }
 
-    private void checkExpr(ASTExpression e, Object data) {
+    private void checkExpr(ASTExpression e, RuleContext data) {
         if (!e.isParenthesized()) {
             return;
         }
@@ -91,9 +92,7 @@ public final class UselessParenthesesRule extends AbstractJavaRulechainRule {
             if (snippet.length() > MAX_SNIPPET_LENGTH) {
                 snippet = snippet.subSequence(0, MAX_SNIPPET_LENGTH - dots.length()) + dots;
             }
-            asCtx(data).addViolationWithMessage(e, template,
-                snippet);
-
+            data.addViolationWithMessage(e, template, snippet);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @since 7.17.0
@@ -34,24 +35,24 @@ public class VariableCanBeInlinedRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTReturnStatement statement, Object data) {
+    public RuleContext visit(ASTReturnStatement statement, RuleContext data) {
         checkUnnecessaryLocal(statement, statement.getExpr(), data);
         return null;
     }
 
     @Override
-    public Object visit(ASTYieldStatement statement, Object data) {
+    public RuleContext visit(ASTYieldStatement statement, RuleContext data) {
         checkUnnecessaryLocal(statement, statement.getExpr(), data);
         return null;
     }
 
     @Override
-    public Object visit(ASTThrowStatement statement, Object data) {
+    public RuleContext visit(ASTThrowStatement statement, RuleContext data) {
         checkUnnecessaryLocal(statement, statement.getExpr(), data);
         return null;
     }
 
-    private void checkUnnecessaryLocal(JavaNode statement, ASTExpression expr, Object data) {
+    private void checkUnnecessaryLocal(JavaNode statement, ASTExpression expr, RuleContext data) {
         if (!(expr instanceof ASTVariableAccess)) {
             return;
         }
@@ -72,7 +73,7 @@ public class VariableCanBeInlinedRule extends AbstractJavaRulechainRule {
 
         if (!getProperty(STATEMENT_ORDER_MATTERS)
                 || varDecl.ancestors(ASTLocalVariableDeclaration.class).firstOrThrow().getNextSibling() == statement) {
-            asCtx(data).addViolation(varDecl, varDecl.getName());
+            data.addViolation(varDecl, varDecl.getName());
         }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class AvoidDeeplyNestedIfStmtsRule extends AbstractJavaRule {
@@ -29,16 +30,16 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
         depth = 0;
         depthLimit = getProperty(PROBLEM_DEPTH_DESCRIPTOR);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         if (depth + 1 == depthLimit) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
             // return early so that if-else chains are only reported once
             return data;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidRethrowingExceptionRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCatchClause;
 import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Avoid rethrowing exceptions unless there's a subsequent catch clause
@@ -22,7 +23,7 @@ public class AvoidRethrowingExceptionRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTTryStatement tryStmt, Object data) {
+    public RuleContext visit(ASTTryStatement tryStmt, RuleContext data) {
         List<ASTCatchClause> catchClauses = tryStmt.getCatchClauses().toList();
         
         for (int i = 0; i < catchClauses.size(); i++) {
@@ -34,7 +35,7 @@ public class AvoidRethrowingExceptionRule extends AbstractJavaRulechainRule {
 
             List<ASTCatchClause> subsequentCatches = catchClauses.subList(i + 1, catchClauses.size());
             if (!hasSubsequentSuperclassCatch(currentCatch, subsequentCatches)) {
-                asCtx(data).addViolation(currentCatch);
+                data.addViolation(currentCatch);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.ReachingDefiniti
 import net.sourceforge.pmd.lang.java.symbols.JLocalVariableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Finds <code>throw</code> statements containing <code>NullPointerException</code>
@@ -29,14 +30,14 @@ public class AvoidThrowingNullPointerExceptionRule extends AbstractJavaRulechain
     }
 
     @Override
-    public Object visit(ASTThrowStatement throwStmt, Object data) {
+    public RuleContext visit(ASTThrowStatement throwStmt, RuleContext data) {
         ASTExpression thrown = throwStmt.getExpr();
         if (TypeTestUtil.isA(NullPointerException.class, thrown)) {
-            asCtx(data).addViolation(throwStmt);
+            data.addViolation(throwStmt);
         } else if (thrown instanceof ASTVariableAccess) {
             JVariableSymbol sym = ((ASTVariableAccess) thrown).getReferencedSym();
             if (sym instanceof JLocalVariableSymbol && hasNpeValue((ASTVariableAccess) thrown)) {
-                asCtx(data).addViolation(throwStmt);
+                data.addViolation(throwStmt);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ClassWithOnlyPrivateConstructorsShouldBeFinalRule extends AbstractJavaRulechainRule {
 
@@ -21,14 +22,14 @@ public class ClassWithOnlyPrivateConstructorsShouldBeFinalRule extends AbstractJ
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (node.isRegularClass()
             && !node.hasModifiers(JModifier.FINAL)
             && !node.isAnnotationPresent("lombok.Value")
             && !hasPublicLombokConstructors(node)
             && hasOnlyPrivateCtors(node)
             && hasNoSubclasses(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Cognitive complexity rule.
@@ -39,16 +40,16 @@ public class CognitiveComplexityRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public final Object visit(ASTMethodDeclaration node, Object data) {
+    public final RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         return visitMethod(node, data);
     }
 
     @Override
-    public final Object visit(ASTConstructorDeclaration node, Object data) {
+    public final RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         return visitMethod(node, data);
     }
 
-    private Object visitMethod(ASTExecutableDeclaration node, Object data) {
+    private RuleContext visitMethod(ASTExecutableDeclaration node, RuleContext data) {
         if (!COGNITIVE_COMPLEXITY.supports(node)) {
             return data;
         }
@@ -56,7 +57,7 @@ public class CognitiveComplexityRule extends AbstractJavaRulechainRule {
         int cognitive = MetricsUtil.computeMetric(COGNITIVE_COMPLEXITY, node);
         final int reportLevel = getReportLevel();
         if (cognitive >= reportLevel) {
-            asCtx(data).addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
+            data.addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
                                      PrettyPrintingUtil.displaySignature(node),
                                      String.valueOf(cognitive),
                                      String.valueOf(reportLevel));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -49,12 +50,12 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit cu, Object data) {
+    public RuleContext visit(ASTCompilationUnit cu, RuleContext data) {
         super.visit(cu, data);
 
         Integer threshold = getProperty(THRESHOLD_DESCRIPTOR);
         if (couplingCount > threshold) {
-            asCtx(data).addViolation(cu, couplingCount, threshold);
+            data.addViolation(cu, couplingCount, threshold);
         }
 
         couplingCount = 0;
@@ -63,7 +64,7 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         boolean prev = inInterface;
         inInterface = node.isInterface();
         super.visit(node, data);
@@ -72,28 +73,28 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         ASTType type = node.getResultTypeNode();
         checkVariableType(type);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, RuleContext data) {
         ASTType type = node.getTypeNode();
         checkVariableType(type);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTFormalParameter node, Object data) {
+    public RuleContext visit(ASTFormalParameter node, RuleContext data) {
         ASTType type = node.getTypeNode();
         checkVariableType(type);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         ASTType type = node.getTypeNode();
         checkVariableType(type);
         return super.visit(node, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -57,14 +58,23 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object param) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext param) {
         if (node instanceof ASTTypeDeclaration) {
             visitTypeDecl((ASTTypeDeclaration) node, param);
         }
         return null;
     }
 
+    /**
+     * @deprecated should have never been public
+     */
+    @Deprecated
     public Object visitTypeDecl(ASTTypeDeclaration node, Object data) {
+        visitTypeDecl(node, (RuleContext) data);
+        return null;
+    }
+
+    private void visitTypeDecl(ASTTypeDeclaration node, RuleContext data) {
 
         MetricOptions cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
@@ -79,26 +89,25 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
                                           " total",
                                           classWmc + " (highest " + classHighest + ")", };
 
-                asCtx(data).addViolation(node, (Object[]) messageParams);
+                data.addViolation(node, (Object[]) messageParams);
             }
         }
-        return data;
     }
 
 
     @Override
-    public final Object visit(ASTMethodDeclaration node, Object data) {
+    public final RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         visitMethodLike(node, data);
         return data;
     }
 
     @Override
-    public final Object visit(ASTConstructorDeclaration node, Object data) {
+    public final RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         visitMethodLike(node, data);
         return data;
     }
 
-    private void visitMethodLike(ASTExecutableDeclaration node, Object data) {
+    private void visitMethodLike(ASTExecutableDeclaration node, RuleContext data) {
         MetricOptions cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
         if (JavaMetrics.CYCLO.supports(node)) {
@@ -110,7 +119,7 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
 
                 String kindname = node instanceof ASTConstructorDeclaration ? "constructor" : "method";
 
-                asCtx(data).addViolation(node, kindname, opname, "", "" + cyclo);
+                data.addViolation(node, kindname, opname, "", "" + cyclo);
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
@@ -34,8 +34,8 @@ public class DataClassRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
-        visitTypeDecl((ASTTypeDeclaration) node, (RuleContext) data);
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
+        visitTypeDecl((ASTTypeDeclaration) node, data);
         return null;
     }
 
@@ -53,9 +53,9 @@ public class DataClassRule extends AbstractJavaRulechainRule {
             int noam = MetricsUtil.computeMetric(NUMBER_OF_ACCESSORS, node);
             int wmc = MetricsUtil.computeMetric(WEIGHED_METHOD_COUNT, node);
 
-            asCtx(data).addViolation(node, node.getSimpleName(),
-                                     StringUtil.percentageString(woc, 3),
-                                     nopa, noam, wmc);
+            data.addViolation(node, node.getSimpleName(),
+                              StringUtil.percentageString(woc, 3),
+                              nopa, noam, wmc);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Catches the use of exception statements as a flow control device.
@@ -28,7 +29,7 @@ public class ExceptionAsFlowControlRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTThrowStatement node, Object data) {
+    public RuleContext visit(ASTThrowStatement node, RuleContext data) {
         JTypeMirror thrownType = node.getExpr().getTypeMirror();
         JavaNode parent = node.getParent();
         while (!(parent instanceof ASTBodyDeclaration)) {
@@ -43,7 +44,7 @@ public class ExceptionAsFlowControlRule extends AbstractJavaRulechainRule {
                 for (ASTCatchClause catchClause : ((ASTTryStatement) parent).getCatchClauses()) {
                     if (catchClause.getParameter().getAllExceptionTypes().any(it -> thrownType.isSubtypeOf(it.getTypeMirror()))) {
                         if (!JavaAstUtils.isJustRethrowException(catchClause)) {
-                            asCtx(data).addViolation(catchClause, node.getReportLocation().getStartLine());
+                            data.addViolation(catchClause, node.getReportLocation().getStartLine());
                             return null;
                         } else {
                             break;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FinalFieldCouldBeStaticRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class FinalFieldCouldBeStaticRule extends AbstractJavaRulechainRule {
 
@@ -34,7 +35,7 @@ public class FinalFieldCouldBeStaticRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         if (node.hasModifiers(JModifier.FINAL)
             && !node.isStatic()
             && !node.getEnclosingType().isAnnotationPresent("lombok.experimental.UtilityClass")
@@ -43,7 +44,7 @@ public class FinalFieldCouldBeStaticRule extends AbstractJavaRulechainRule {
             for (ASTVariableId field : node) {
                 ASTExpression init = field.getInitializer();
                 if (init != null && isAllowedExpression(init) && !isUsedForSynchronization(field)) {
-                    asCtx(data).addViolation(field, field.getName());
+                    data.addViolation(field, field.getName());
                 }
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GodClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GodClassRule.java
@@ -12,6 +12,7 @@ import static net.sourceforge.pmd.lang.java.metrics.JavaMetrics.WEIGHED_METHOD_C
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.StringUtil;
 
 
@@ -48,7 +49,7 @@ public class GodClassRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (!MetricsUtil.supportsAll(node, WEIGHED_METHOD_COUNT, TIGHT_CLASS_COHESION, ACCESS_TO_FOREIGN_DATA)) {
             return data;
         }
@@ -59,9 +60,9 @@ public class GodClassRule extends AbstractJavaRulechainRule {
 
         if (wmc >= WMC_VERY_HIGH && atfd > FEW_ATFD_THRESHOLD && tcc < TCC_THRESHOLD) {
 
-            asCtx(data).addViolation(node, wmc,
-                                     StringUtil.percentageString(tcc, 3),
-                                     atfd);
+            data.addViolation(node, wmc,
+                              StringUtil.percentageString(tcc, 3),
+                              atfd);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -25,6 +25,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.AssignmentEntry;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.DataflowResult;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 public class ImmutableFieldRule extends AbstractJavaRulechainRule {
@@ -52,7 +53,7 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTFieldDeclaration field, Object data) {
+    public RuleContext visit(ASTFieldDeclaration field, RuleContext data) {
         ASTTypeDeclaration enclosingType = field.getEnclosingType();
         if (field.getEffectiveVisibility().isAtMost(Visibility.V_PRIVATE)
             && !field.getModifiers().hasAny(JModifier.VOLATILE, JModifier.STATIC, JModifier.FINAL)
@@ -84,9 +85,9 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
 
                 if (!hasWrite && !isBlank) {
                     //todo this case may also handle static fields easily.
-                    asCtx(data).addViolation(varId, varId.getName());
+                    data.addViolation(varId, varId.getName());
                 } else if (hasWrite && defaultValueDoesNotReachEndOfCtor(dataflow, varId)) {
-                    asCtx(data).addViolation(varId, varId.getName());
+                    data.addViolation(varId, varId.getName());
                 }
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanRule.java
@@ -31,6 +31,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.StringUtil;
 
 public class InvalidJavaBeanRule extends AbstractJavaRulechainRule {
@@ -58,7 +59,7 @@ public class InvalidJavaBeanRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         String packageName = "";
         ASTPackageDeclaration packageDeclaration = node.getRoot().getPackageDeclaration();
         if (packageDeclaration != null) {
@@ -73,12 +74,12 @@ public class InvalidJavaBeanRule extends AbstractJavaRulechainRule {
         String beanName = node.getSimpleName();
 
         if (getProperty(ENSURE_SERIALIZATION) && !TypeTestUtil.isA(Serializable.class, node)) {
-            asCtx(data).addViolationWithMessage(node, "The bean ''{0}'' does not implement java.io.Serializable.",
+            data.addViolationWithMessage(node, "The bean ''{0}'' does not implement java.io.Serializable.",
                     beanName);
         }
 
         if (!hasNoArgConstructor(node)) {
-            asCtx(data).addViolationWithMessage(node, "The bean ''{0}'' is missing a no-arg constructor.",
+            data.addViolationWithMessage(node, "The bean ''{0}'' is missing a no-arg constructor.",
                     beanName);
         }
 
@@ -94,43 +95,43 @@ public class InvalidJavaBeanRule extends AbstractJavaRulechainRule {
         for (PropertyInfo propertyInfo : properties.values()) {
             if (!hasLombokGetterAnnotation(node) && !hasLombokSetterAnnotation(node)
                 && propertyInfo.hasMissingGetter() && propertyInfo.hasMissingSetter()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getDeclaratorId(),
+                data.addViolationWithMessage(propertyInfo.getDeclaratorId(),
                         "The bean ''{0}'' is missing a getter and a setter for property ''{1}''.",
                         beanName, propertyInfo.getName());
             } else if (!hasLombokGetterAnnotation(node) && propertyInfo.hasMissingGetter()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getDeclaratorId(),
+                data.addViolationWithMessage(propertyInfo.getDeclaratorId(),
                         "The bean ''{0}'' is missing a getter for property ''{1}''.",
                         beanName, propertyInfo.getName());
 
             } else if (!hasLombokSetterAnnotation(node) && propertyInfo.hasMissingSetter()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getDeclaratorId(),
+                data.addViolationWithMessage(propertyInfo.getDeclaratorId(),
                         "The bean ''{0}'' is missing a setter for property ''{1}''.",
                         beanName, propertyInfo.getName());
 
             }
 
             if (propertyInfo.hasWrongGetterType()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getGetter(),
+                data.addViolationWithMessage(propertyInfo.getGetter(),
                         "The bean ''{0}'' should return a ''{1}'' in getter of property ''{2}''.",
                         beanName, propertyInfo.getTypeName(), propertyInfo.getName());
             }
             if (propertyInfo.hasWrongBooleanGetterName()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getGetter(),
+                data.addViolationWithMessage(propertyInfo.getGetter(),
                         "The bean ''{0}'' should use the method name ''is{1}'' for the getter of property ''{2}''.",
                         beanName, propertyInfo.getName(), propertyInfo.getName());
             }
             if (propertyInfo.hasWrongTypeGetterAndSetter()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.getGetter(),
+                data.addViolationWithMessage(propertyInfo.getGetter(),
                         "The bean ''{0}'' has a property ''{1}'' with getter and setter that don''t have the same type.",
                         beanName, propertyInfo.getName());
             }
             if (propertyInfo.hasWrongIndexedGetterType()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.indexedGetter,
+                data.addViolationWithMessage(propertyInfo.indexedGetter,
                         "The bean ''{0}'' has a property ''{1}'' with an indexed getter using the wrong type.",
                         beanName, propertyInfo.getName());
             }
             if (propertyInfo.hasWrongIndexedSetterType()) {
-                asCtx(data).addViolationWithMessage(propertyInfo.indexedSetter,
+                data.addViolationWithMessage(propertyInfo.indexedSetter,
                         "The bean ''{0}'' has a property ''{1}'' with an indexed setter using the wrong type.",
                         beanName, propertyInfo.getName());
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -127,9 +127,9 @@ public class LawOfDemeterRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTFieldAccess node, Object data) {
+    public RuleContext visit(ASTFieldAccess node, RuleContext data) {
         if (shouldReport(node)) {
-            asCtx(data).addViolationWithMessage(
+            data.addViolationWithMessage(
                 node,
                 FIELD_ACCESS_ON_FOREIGN_VALUE,
                 node.getName(),
@@ -140,9 +140,9 @@ public class LawOfDemeterRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (shouldReport(node)) {
-            asCtx(data).addViolationWithMessage(
+            data.addViolationWithMessage(
                 node,
                 METHOD_CALL_ON_FOREIGN_VALUE,
                 node.getMethodName(),

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * The loose package coupling Rule can be used to ensure coupling outside of a
@@ -55,7 +56,7 @@ public class LoosePackageCouplingRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
         // Sort the restricted packages in reverse order. This will ensure the
         // child packages are in the list before their parent packages.
         this.restrictedPackages = new ArrayList<>(super.getProperty(PACKAGES_DESCRIPTOR));
@@ -69,7 +70,7 @@ public class LoosePackageCouplingRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTImportDeclaration node, Object data) {
+    public RuleContext visit(ASTImportDeclaration node, RuleContext data) {
 
         String importPackage = node.getPackageName();
 
@@ -86,11 +87,11 @@ public class LoosePackageCouplingRule extends AbstractJavaRule {
                     // On demand imports automatically fail because they include
                     // everything
                     if (node.isImportOnDemand()) {
-                        asCtx(data).addViolation(node, node.getImportedName(), pkg);
+                        data.addViolation(node, node.getImportedName(), pkg);
                         break;
                     } else {
                         if (!isAllowedClass(node)) {
-                            asCtx(data).addViolation(node, node.getImportedName(), pkg);
+                            data.addViolation(node, node.getImportedName(), pkg);
                             break;
                         }
                     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -37,11 +37,11 @@ public class NPathComplexityRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
-        return visitMethod((ASTExecutableDeclaration) node, (RuleContext) data);
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
+        return visitMethod((ASTExecutableDeclaration) node, data);
     }
 
-    private Object visitMethod(ASTExecutableDeclaration node, RuleContext data) {
+    private RuleContext visitMethod(ASTExecutableDeclaration node, RuleContext data) {
         int reportLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
         if (!JavaMetrics.NPATH_COMP.supports(node)) {
             return data;
@@ -49,10 +49,10 @@ public class NPathComplexityRule extends AbstractJavaRulechainRule {
 
         long npath = MetricsUtil.computeMetric(JavaMetrics.NPATH_COMP, node);
         if (npath >= reportLevel) {
-            asCtx(data).addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
-                                     PrettyPrintingUtil.displaySignature(node),
-                                     String.valueOf(npath),
-                                     String.valueOf(reportLevel));
+            data.addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
+                              PrettyPrintingUtil.displaySignature(node),
+                              String.valueOf(npath),
+                              String.valueOf(reportLevel));
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -62,15 +62,15 @@ public final class NcssCountRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         int methodReportLevel = getProperty(METHOD_REPORT_LEVEL_DESCRIPTOR);
         int classReportLevel = getProperty(CLASS_REPORT_LEVEL_DESCRIPTOR);
         MetricOptions ncssOptions = MetricOptions.ofOptions(getProperty(NCSS_OPTIONS_DESCRIPTOR));
 
         if (node instanceof ASTTypeDeclaration) {
-            visitTypeDecl((ASTTypeDeclaration) node, classReportLevel, ncssOptions, (RuleContext) data);
+            visitTypeDecl((ASTTypeDeclaration) node, classReportLevel, ncssOptions, data);
         } else if (node instanceof ASTExecutableDeclaration) {
-            visitMethod((ASTExecutableDeclaration) node, methodReportLevel, ncssOptions, (RuleContext) data);
+            visitMethod((ASTExecutableDeclaration) node, methodReportLevel, ncssOptions, data);
         } else {
             throw AssertionUtil.shouldNotReachHere("node is not handled: " + node);
         }
@@ -92,7 +92,7 @@ public final class NcssCountRule extends AbstractJavaRulechainRule {
                                           node.getSimpleName(),
                                           classSize + " (Highest = " + classHighest + ")", };
 
-                asCtx(data).addViolation(node, (Object[]) messageParams);
+                data.addViolation(node, (Object[]) messageParams);
             }
         }
     }
@@ -106,7 +106,7 @@ public final class NcssCountRule extends AbstractJavaRulechainRule {
         if (JavaMetrics.NCSS.supports(node)) {
             int methodSize = MetricsUtil.computeMetric(JavaMetrics.NCSS, node, ncssOptions);
             if (methodSize >= level) {
-                asCtx(data).addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
+                data.addViolation(node, node instanceof ASTMethodDeclaration ? "method" : "constructor",
                                          PrettyPrintingUtil.displaySignature(node), "" + methodSize);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -41,10 +42,10 @@ public class SignatureDeclareThrowsExceptionRule extends AbstractJavaRulechainRu
     }
 
     @Override
-    public Object visit(ASTThrowsList throwsList, Object o) {
+    public RuleContext visit(ASTThrowsList throwsList, RuleContext o) {
         if (!isIgnored(throwsList.getOwner())
             && throwsList.toStream().any(it -> TypeTestUtil.isExactlyA(Exception.class, it))) {
-            asCtx(o).addViolation(throwsList);
+            o.addViolation(throwsList);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
@@ -46,14 +46,14 @@ public class SimplifyBooleanReturnsRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTReturnStatement node, Object data) {
+    public RuleContext visit(ASTReturnStatement node, RuleContext data) {
         ASTExpression expr = node.getExpr();
         if (expr == null
             || !expr.getTypeMirror().isPrimitive(PrimitiveTypeKind.BOOLEAN)
             || !isThenBranchOfSomeIf(node)) {
             return null;
         }
-        checkIf(node.ancestors(ASTIfStatement.class).firstOrThrow(), asCtx(data), expr);
+        checkIf(node.ancestors(ASTIfStatement.class).firstOrThrow(), data, expr);
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.StablePathMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class SimplifyConditionalRule extends AbstractJavaRulechainRule {
@@ -27,7 +28,7 @@ public class SimplifyConditionalRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTInfixExpression node, Object data) {
+    public RuleContext visit(ASTInfixExpression node, RuleContext data) {
         if (node.getOperator() == INSTANCEOF) {
 
             StablePathMatcher instanceOfSubject = StablePathMatcher.matching(node.getLeftOperand());
@@ -55,7 +56,7 @@ public class SimplifyConditionalRule extends AbstractJavaRulechainRule {
             }
 
             if (negated != isInfixExprWithOperator(nullCheckExpr, NE)) {
-                asCtx(data).addViolation(nullCheckExpr);
+                data.addViolation(nullCheckExpr);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -32,6 +32,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.DataflowResult;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.ReachingDefinitionSet;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaPropertyUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -71,7 +72,7 @@ public class SingularFieldRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         ASTTypeDeclaration enclosingType = (ASTTypeDeclaration) node;
         if (JavaAstUtils.hasAnyAnnotation(enclosingType, INVALIDATING_CLASS_ANNOT)) {
             return null;
@@ -88,7 +89,7 @@ public class SingularFieldRule extends AbstractJavaRulechainRule {
                     dataflow = DataflowPass.getDataflowResult(node.getRoot());
                 }
                 if (isSingularField(enclosingType, varId, dataflow)) {
-                    asCtx(data).addViolation(varId, varId.getName());
+                    data.addViolation(varId, varId.getName());
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Switch Density - This is the number of statements over the number of
@@ -41,16 +42,25 @@ public class SwitchDensityRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTSwitchStatement node, Object data) {
+    public RuleContext visit(ASTSwitchStatement node, RuleContext data) {
         return visitSwitchLike(node, data);
     }
 
     @Override
-    public Object visit(ASTSwitchExpression node, Object data) {
+    public RuleContext visit(ASTSwitchExpression node, RuleContext data) {
         return visitSwitchLike(node, data);
     }
 
+    /**
+     * @deprecated should have never been public
+     */
+    @Deprecated
     public Void visitSwitchLike(ASTSwitchLike node, Object data) {
+        visitSwitchLike(node, (RuleContext) data);
+        return null;
+    }
+
+    private RuleContext visitSwitchLike(ASTSwitchLike node, RuleContext data) {
         // note: this does not cross find boundaries.
         int stmtCount = node.descendants(ASTStatement.class).count();
         int labelCount = node.getBranches()
@@ -60,7 +70,7 @@ public class SwitchDensityRule extends AbstractJavaRulechainRule {
         // note: if labelCount is zero, double division will produce +Infinity or NaN, not ArithmeticException
         double density = stmtCount / (double) labelCount;
         if (density >= getProperty(REPORT_LEVEL)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
@@ -34,7 +35,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration klass, Object data) {
+    public RuleContext visit(ASTClassDeclaration klass, RuleContext data) {
         if (JavaAstUtils.hasAnyAnnotation(klass, IGNORED_CLASS_ANNOT)
             || TypeTestUtil.isA("junit.framework.TestSuite", klass) // suite method is ok
             || klass.isInterface()
@@ -77,7 +78,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
 
         if (hasAnyMethods && hasNonPrivateCtor) {
-            asCtx(data).addViolation(klass);
+            data.addViolation(klass);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UselessOverridingMethodRule extends AbstractJavaRulechainRule {
 
@@ -46,7 +47,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (!node.isOverridden()
             || node.getBody() == null
             // Can skip methods which are final or have new behavior (synchronized, native)
@@ -90,7 +91,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRulechainRule {
                     && overload.getMethodType().equals(node.getOverriddenMethod())
                     && sameModifiers(node.getOverriddenMethod().getSymbol(), node.getSymbol())
                     && argumentsAreUnchanged(node, methodCall)) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -36,12 +36,12 @@ public class CommentContentRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
 
         Pattern pattern = getProperty(DISALLOWED_TERMS_DESCRIPTOR);
 
         for (JavaComment comment : node.getComments()) {
-            reportIllegalTerms(asCtx(data), comment, pattern, node);
+            reportIllegalTerms(data, comment, pattern, node);
         }
 
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -92,7 +92,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
         propertyValues.put(CLASS_CMT_REQUIREMENT_DESCRIPTOR, getProperty(CLASS_CMT_REQUIREMENT_DESCRIPTOR));
     }
 
-    private void checkCommentMeetsRequirement(Object data, JavadocCommentOwner node,
+    private void checkCommentMeetsRequirement(RuleContext data, JavadocCommentOwner node,
                                               PropertyDescriptor<CommentRequirement> descriptor) {
         switch (propertyValues.get(descriptor)) {
         case IGNORED:
@@ -112,11 +112,11 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
 
 
     // Adds a violation
-    private void commentRequiredViolation(Object data, JavaNode node,
+    private void commentRequiredViolation(RuleContext data, JavaNode node,
                                           PropertyDescriptor<CommentRequirement> descriptor) {
 
 
-        asCtx(data).addViolationWithMessage(node,
+        data.addViolationWithMessage(node,
             DESCRIPTOR_NAME_TO_COMMENT_TYPE.get(descriptor.name())
             + " are "
             + getProperty(descriptor).name().toLowerCase(Locale.ROOT));
@@ -124,21 +124,21 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTClassDeclaration decl, Object data) {
+    public RuleContext visit(ASTClassDeclaration decl, RuleContext data) {
         checkCommentMeetsRequirement(data, decl, CLASS_CMT_REQUIREMENT_DESCRIPTOR);
         return data;
     }
 
 
     @Override
-    public Object visit(ASTConstructorDeclaration decl, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration decl, RuleContext data) {
         checkMethodOrConstructorComment(decl, data);
         return data;
     }
 
 
     @Override
-    public Object visit(ASTMethodDeclaration decl, Object data) {
+    public RuleContext visit(ASTMethodDeclaration decl, RuleContext data) {
         if (decl.isOverridden()) {
             checkCommentMeetsRequirement(data, decl, OVERRIDE_CMT_DESCRIPTOR);
         } else if (JavaRuleUtil.isGetterOrSetter(decl)) {
@@ -150,7 +150,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
     }
 
 
-    private void checkMethodOrConstructorComment(ASTExecutableDeclaration decl, Object data) {
+    private void checkMethodOrConstructorComment(ASTExecutableDeclaration decl, RuleContext data) {
         if (decl.getVisibility() == Visibility.V_PUBLIC) {
             checkCommentMeetsRequirement(data, decl, PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
         } else if (decl.getVisibility() == Visibility.V_PROTECTED) {
@@ -160,7 +160,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTFieldDeclaration decl, Object data) {
+    public RuleContext visit(ASTFieldDeclaration decl, RuleContext data) {
         if (JavaRuleUtil.isSerialVersionUID(decl)) {
             checkCommentMeetsRequirement(data, decl, SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR);
         } else if (JavaRuleUtil.isSerialPersistentFields(decl)) {
@@ -174,7 +174,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTEnumDeclaration decl, Object data) {
+    public RuleContext visit(ASTEnumDeclaration decl, RuleContext data) {
         checkCommentMeetsRequirement(data, decl, ENUM_CMT_REQUIREMENT_DESCRIPTOR);
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -40,18 +40,18 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTCompilationUnit cUnit, Object data) {
+    public RuleContext visit(ASTCompilationUnit cUnit, RuleContext data) {
 
         for (JavaComment comment : cUnit.getComments()) {
             if (hasTooManyLines(comment)) {
-                asCtx(data).addViolationWithPosition(
+                data.addViolationWithPosition(
                     comment.getToken(),
                     cUnit.getAstInfo(),
                     comment.getReportLocation(),
                     getMessage() + ": Too many lines");
             }
 
-            reportLinesTooLong(cUnit, asCtx(data), comment);
+            reportLinesTooLong(cUnit, data, comment);
         }
 
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/DanglingJavadocRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/DanglingJavadocRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.JavaComment;
 import net.sourceforge.pmd.lang.java.ast.JavadocComment;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Looks for Javadoc that doesn't belong to any particular class, method or field.
@@ -20,10 +21,10 @@ public class DanglingJavadocRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTCompilationUnit unit, Object data) {
+    public RuleContext visit(ASTCompilationUnit unit, RuleContext data) {
         for (JavaComment comment: unit.getComments()) {
             if (comment instanceof JavadocComment && ((JavadocComment) comment).getOwner() == null) {
-                asCtx(data).addViolationWithPosition(comment.getToken(),
+                data.addViolationWithPosition(comment.getToken(),
                     unit.getAstInfo(),
                     comment.getReportLocation(), getMessage());
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -72,15 +72,15 @@ public class AssignmentInOperandRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTAssignmentExpression node, Object data) {
-        checkAssignment(node, (RuleContext) data);
+    public RuleContext visit(ASTAssignmentExpression node, RuleContext data) {
+        checkAssignment(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTUnaryExpression node, Object data) {
+    public RuleContext visit(ASTUnaryExpression node, RuleContext data) {
         if (!getProperty(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR) && !node.getOperator().isPure()) {
-            checkAssignment(node, (RuleContext) data);
+            checkAssignment(node, data);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @author Eric Olander
@@ -26,25 +27,25 @@ public class AssignmentToNonFinalStaticRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTVariableAccess node, Object data) {
+    public RuleContext visit(ASTVariableAccess node, RuleContext data) {
         checkAccess(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTFieldAccess node, Object data) {
+    public RuleContext visit(ASTFieldAccess node, RuleContext data) {
         checkAccess(node, data);
         return null;
     }
 
-    private void checkAccess(ASTNamedReferenceExpr node, Object data) {
+    private void checkAccess(ASTNamedReferenceExpr node, RuleContext data) {
         if (isInsideConstructor(node) && node.getAccessType() == AccessType.WRITE) {
             @Nullable
             JVariableSymbol symbol = node.getReferencedSym();
             if (symbol != null && symbol.isField()) {
                 JFieldSymbol field = (JFieldSymbol) symbol;
                 if (field.isStatic() && !field.isFinal()) {
-                    asCtx(data).addViolation(node, field.getSimpleName());
+                    data.addViolation(node, field.getSimpleName());
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.StringUtil;
 
 public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRulechainRule {
@@ -92,7 +93,7 @@ public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRulecha
 
 
     @Override
-    public Object visit(ASTBreakStatement node, Object data) {
+    public RuleContext visit(ASTBreakStatement node, RuleContext data) {
         // skip breaks, that are within a switch statement
         if (node.ancestors().get(1) instanceof ASTSwitchStatement) {
             return data;
@@ -106,10 +107,14 @@ public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRulecha
      */
     @Deprecated
     protected Object check(PropertyDescriptor<List<LoopTypes>> property, Node node, Object data) {
+        return null;
+    }
+
+    private RuleContext check(PropertyDescriptor<List<LoopTypes>> property, Node node, RuleContext data) {
         return checkInternal(property, node, data);
     }
 
-    private Object checkInternal(PropertyDescriptor<List<LoopTypes>> property, Node node, Object data) {
+    private RuleContext checkInternal(PropertyDescriptor<List<LoopTypes>> property, Node node, RuleContext data) {
         Node parent = node.getParent();
         if (parent instanceof ASTBlock) {
             parent = parent.getParent();
@@ -121,15 +126,15 @@ public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRulecha
         }
         if (parent instanceof ASTForStatement || parent instanceof ASTForeachStatement) {
             if (hasPropertyValue(property, LoopTypes.FOR)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         } else if (parent instanceof ASTWhileStatement) {
             if (hasPropertyValue(property, LoopTypes.WHILE)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         } else if (parent instanceof ASTDoStatement) {
             if (hasPropertyValue(property, LoopTypes.DO)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;
@@ -150,13 +155,13 @@ public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRulecha
 
 
     @Override
-    public Object visit(ASTContinueStatement node, Object data) {
+    public RuleContext visit(ASTContinueStatement node, RuleContext data) {
         return check(CHECK_CONTINUE_LOOP_TYPES_PROPERTY, node, data);
     }
 
 
     @Override
-    public Object visit(ASTReturnStatement node, Object data) {
+    public RuleContext visit(ASTReturnStatement node, RuleContext data) {
         return check(CHECK_RETURN_LOOP_TYPES_PROPERTY, node, data);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -80,7 +80,7 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRulechainRule {
         super.end(ctx);
     }
 
-    private void processResults(Object data) {
+    private void processResults(RuleContext data) {
 
         int threshold = getProperty(THRESHOLD_DESCRIPTOR);
 
@@ -89,13 +89,13 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRulechainRule {
             if (occurrences.size() >= threshold) {
                 ASTStringLiteral first = occurrences.first();
                 Object[] args = { first.toPrintableString(), occurrences.size(), first.getBeginLine(), };
-                asCtx(data).addViolation(first, args);
+                data.addViolation(first, args);
             }
         }
     }
 
     @Override
-    public Object visit(ASTStringLiteral node, Object data) {
+    public RuleContext visit(ASTStringLiteral node, RuleContext data) {
         String image = node.getImage();
 
         // just catching strings of 'minLength' chars or more (including the

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
@@ -9,6 +9,7 @@ import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 import net.sourceforge.pmd.lang.java.ast.ASTNumericLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class AvoidUsingOctalValuesRule extends AbstractJavaRulechainRule {
@@ -25,10 +26,10 @@ public class AvoidUsingOctalValuesRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTNumericLiteral node, Object data) {
+    public RuleContext visit(ASTNumericLiteral node, RuleContext data) {
         if (node.getBase() == 8) {
             if (getProperty(STRICT_METHODS_DESCRIPTOR) || !isBetweenZeroAnd7(node)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
@@ -22,8 +22,8 @@ public class BrokenNullCheckRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTInfixExpression node, Object data) {
-        checkBrokenNullCheck(node, (RuleContext) data);
+    public RuleContext visit(ASTInfixExpression node, RuleContext data) {
+        checkBrokenNullCheck(node, data);
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class CheckSkipResultRule extends AbstractJavaRulechainRule {
 
@@ -18,9 +19,9 @@ public class CheckSkipResultRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, RuleContext data) {
         if (SKIP_METHOD.matchesCall(call) && !isResultUsed(call)) {
-            asCtx(data).addViolation(call);
+            data.addViolation(call);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * The method clone() should only be implemented if the class implements the
@@ -29,7 +30,7 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRulechain
     }
 
     @Override
-    public Object visit(final ASTMethodDeclaration node, final Object data) {
+    public RuleContext visit(final ASTMethodDeclaration node, final RuleContext data) {
         if (!JavaAstUtils.isCloneMethod(node)) {
             return data;
         }
@@ -41,7 +42,7 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRulechain
         ASTTypeDeclaration type = node.getEnclosingType();
         if (type instanceof ASTClassDeclaration && !TypeTestUtil.isA(Cloneable.class, type)) {
             // Nothing can save us now
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -194,18 +194,18 @@ public class CloseResourceRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         checkForResources(node, data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         checkForResources(node, data);
         return super.visit(node, data);
     }
 
-    private void checkForResources(ASTExecutableDeclaration methodOrConstructor, Object data) {
+    private void checkForResources(ASTExecutableDeclaration methodOrConstructor, RuleContext data) {
         reportedVarNames.clear();
         Map<ASTVariableId, TypeNode> resVars = getResourceVariables(methodOrConstructor);
         for (Map.Entry<ASTVariableId, TypeNode> resVarEntry : resVars.entrySet()) {
@@ -215,7 +215,7 @@ public class CloseResourceRule extends AbstractJavaRule {
 
             if (isWrappingResourceSpecifiedInTry(resVar)) {
                 reportedVarNames.add(resVar.getName());
-                asCtx(data).addViolationWithMessage(resVar, WRAPPING_TRY_WITH_RES_VAR_MESSAGE,
+                data.addViolationWithMessage(resVar, WRAPPING_TRY_WITH_RES_VAR_MESSAGE,
                                                     resVar.getName());
             } else if (shouldVarOfTypeBeClosedInMethod(resVar, resVarType, methodOrConstructor)) {
                 reportedVarNames.add(resVar.getName());
@@ -224,7 +224,7 @@ public class CloseResourceRule extends AbstractJavaRule {
                 ASTExpressionStatement reassigningStatement = getFirstReassigningStatementBeforeBeingClosed(resVar, methodOrConstructor);
                 if (reassigningStatement != null) {
                     reportedVarNames.add(resVar.getName());
-                    asCtx(data).addViolationWithMessage(reassigningStatement, REASSIGN_BEFORE_CLOSED_MESSAGE,
+                    data.addViolationWithMessage(reassigningStatement, REASSIGN_BEFORE_CLOSED_MESSAGE,
                                                         resVar.getName());
                 }
             }
@@ -766,9 +766,9 @@ public class CloseResourceRule extends AbstractJavaRule {
                 .nonEmpty();
     }
 
-    private void addCloseResourceViolation(ASTVariableId id, TypeNode type, Object data) {
+    private void addCloseResourceViolation(ASTVariableId id, TypeNode type, RuleContext data) {
         String resTypeName = getResourceTypeName(id, type);
-        asCtx(data).addViolation(id, resTypeName);
+        data.addViolation(id, resTypeName);
     }
 
     private String getResourceTypeName(ASTVariableId varId, TypeNode type) {
@@ -794,7 +794,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (!getProperty(DETECT_CLOSE_NOT_IN_FINALLY)) {
             return super.visit(node, data);
         }
@@ -802,7 +802,7 @@ public class CloseResourceRule extends AbstractJavaRule {
         if (isCloseTargetMethodCall(node) && node.getQualifier() instanceof ASTVariableAccess) {
             ASTVariableAccess closedVar = (ASTVariableAccess) node.getQualifier();
             if (isNotInFinallyBlock(closedVar) && !reportedVarNames.contains(closedVar.getName())) {
-                asCtx(data).addViolationWithMessage(closedVar, CLOSE_IN_FINALLY_BLOCK_MESSAGE,
+                data.addViolationWithMessage(closedVar, CLOSE_IN_FINALLY_BLOCK_MESSAGE,
                                                     closedVar.getName());
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CollectionTypeMismatchRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CollectionTypeMismatchRule.java
@@ -60,8 +60,7 @@ public class CollectionTypeMismatchRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
-        RuleContext ctx = (RuleContext) data;
+    public RuleContext visit(ASTMethodCall node, RuleContext ctx) {
 
         if (COLLECTION_CONTAINS.matchesCall(node)
                 || COLLECTION_REMOVE.matchesCall(node)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypePrettyPrint;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainRule {
 
@@ -24,7 +25,7 @@ public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainR
     }
 
     @Override
-    public Object visit(ASTArgumentList argList, Object data) {
+    public RuleContext visit(ASTArgumentList argList, RuleContext data) {
         if (argList.isEmpty()) {
             return null;
         }
@@ -56,7 +57,7 @@ public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainR
             } else {
                 message = "Unclear if a varargs or non-varargs call is intended. Cast to {0} or {0}[] to clarify intent.";
             }
-            asCtx(data).addViolationWithMessage(varargsArg, message, TypePrettyPrint.prettyPrintWithSimpleNames(expectedComponent));
+            data.addViolationWithMessage(varargsArg, message, TypePrettyPrint.prettyPrintWithSimpleNames(expectedComponent));
         }
 
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -74,7 +74,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
     }
 
     @Override
-    public Object visit(ASTConstructorDeclaration node, Object data) {
+    public RuleContext visit(ASTConstructorDeclaration node, RuleContext data) {
         if (node.getEnclosingType().isFinal() || JavaAstUtils.hasAnyAnnotation(node.getEnclosingType(), MAKE_FIELD_FINAL_CLASS_ANNOT)) {
             return null; // then cannot be overridden
         }
@@ -86,7 +86,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
                 String message = unsafeMethod.equals(overload) ? MESSAGE : MESSAGE_TRANSITIVE;
                 String lastMethod = PrettyPrintingUtil.prettyPrintOverload(unsafetyReason.getLast());
                 String stack = unsafetyReason.stream().map(PrettyPrintingUtil::prettyPrintOverload).collect(Collectors.joining(", "));
-                asCtx(data).addViolationWithMessage(call, message, lastMethod, stack);
+                data.addViolationWithMessage(call, message, lastMethod, stack);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class DetachedTestCaseRule extends AbstractJavaRulechainRule {
 
@@ -18,7 +19,7 @@ public class DetachedTestCaseRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, final Object data) {
+    public RuleContext visit(ASTClassDeclaration node, final RuleContext data) {
         NodeStream<ASTMethodDeclaration> methods = node.getDeclarations(ASTMethodDeclaration.class);
         if (methods.any(TestFrameworksUtil::isTestMethod)) {
             // looks like a test case
@@ -27,7 +28,7 @@ public class DetachedTestCaseRule extends AbstractJavaRulechainRule {
                        && !m.getModifiers().hasAny(JModifier.STATIC, JModifier.PRIVATE, JModifier.PROTECTED, JModifier.ABSTRACT))
                    // the method itself has no annotation
                    .filter(it -> it.getDeclaredAnnotations().isEmpty())
-                   .forEach(m -> asCtx(data).addViolation(m));
+                   .forEach(m -> data.addViolation(m));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdempotentOperationsRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.AssignmentOp;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class IdempotentOperationsRule extends AbstractJavaRulechainRule {
 
@@ -16,10 +17,10 @@ public class IdempotentOperationsRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTAssignmentExpression node, Object data) {
+    public RuleContext visit(ASTAssignmentExpression node, RuleContext data) {
         if (node.getOperator() == AssignmentOp.ASSIGN
             && JavaAstUtils.isReferenceToSameVar(node.getLeftOperand(), node.getRightOperand())) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdenticalConditionalBranchesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/IdenticalConditionalBranchesRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects conditional expressions and statements where both branches are equal.
@@ -23,11 +24,11 @@ public class IdenticalConditionalBranchesRule extends AbstractJavaRulechainRule 
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         if (node.getElseBranch() != null
                 && areEquivalent(normalize(node.getThenBranch()),
                     normalize(node.getElseBranch()))) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }
@@ -49,10 +50,10 @@ public class IdenticalConditionalBranchesRule extends AbstractJavaRulechainRule 
     }
 
     @Override
-    public Object visit(ASTConditionalExpression node, Object data) {
+    public RuleContext visit(ASTConditionalExpression node, RuleContext data) {
         if (node.getElseBranch() != null
             && JavaAstUtils.tokenEquals(node.getThenBranch(), node.getElseBranch())) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughRule.java
@@ -31,14 +31,14 @@ public class ImplicitSwitchFallThroughRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTSwitchStatement node, Object data) {
-        checkSwitchLike(node, asCtx(data));
+    public RuleContext visit(ASTSwitchStatement node, RuleContext data) {
+        checkSwitchLike(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTSwitchExpression node, Object data) {
-        checkSwitchLike(node, asCtx(data));
+    public RuleContext visit(ASTSwitchExpression node, RuleContext data) {
+        checkSwitchLike(node, data);
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -33,6 +33,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.ReachingDefiniti
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 public class InvalidLogMessageFormatRule extends AbstractJavaRulechainRule {
@@ -60,7 +61,7 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, RuleContext data) {
         if (isLoggerCall(call, "org.slf4j.Logger", SLF4J)
             || isLoggerCall(call, "org.apache.logging.log4j.Logger", APACHE_SLF4J)) {
 
@@ -95,11 +96,11 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRulechainRule {
             }
 
             if (providedArguments < expectedArguments) {
-                asCtx(data).addViolationWithMessage(
+                data.addViolationWithMessage(
                     call,
                     "Missing arguments," + getExpectedMessage(providedArguments, expectedArguments));
             } else if (providedArguments > expectedArguments) {
-                asCtx(data).addViolationWithMessage(
+                data.addViolationWithMessage(
                     call,
                     "Too many arguments," + getExpectedMessage(providedArguments, expectedArguments));
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class JUnitSpellingRule extends AbstractJavaRulechainRule {
 
@@ -17,11 +18,11 @@ public class JUnitSpellingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (TestFrameworksUtil.isJUnit3Class(node)) {
             node.getDeclarations(ASTMethodDeclaration.class)
                 .filter(this::isViolation)
-                .forEach(it -> asCtx(data).addViolation(it));
+                .forEach(it -> data.addViolation(it));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class JUnitStaticSuiteRule extends AbstractJavaRulechainRule {
 
@@ -19,14 +20,14 @@ public class JUnitStaticSuiteRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (isJUnit3Class(node)) {
             ASTMethodDeclaration suiteMethod = node.getDeclarations(ASTMethodDeclaration.class)
                                                    .filter(it -> "suite".equals(it.getName()) && it.getArity() == 0)
                                                    .first();
             if (suiteMethod != null
                 && (suiteMethod.getVisibility() != Visibility.V_PUBLIC || !suiteMethod.isStatic())) {
-                asCtx(data).addViolation(suiteMethod);
+                data.addViolation(suiteMethod);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -68,24 +68,24 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         checkSerialPersistentFieldsField(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTEnumDeclaration node, Object data) {
+    public RuleContext visit(ASTEnumDeclaration node, RuleContext data) {
         checkSerialPersistentFieldsField(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTRecordDeclaration node, Object data) {
+    public RuleContext visit(ASTRecordDeclaration node, RuleContext data) {
         checkSerialPersistentFieldsField(node, data);
         return null;
     }
 
-    private void checkSerialPersistentFieldsField(ASTTypeDeclaration typeDeclaration, Object data) {
+    private void checkSerialPersistentFieldsField(ASTTypeDeclaration typeDeclaration, RuleContext data) {
         for (ASTFieldDeclaration field : typeDeclaration.descendants(ASTFieldDeclaration.class)) {
             for (ASTVariableId varId : field) {
                 if (SERIAL_PERSISTENT_FIELDS_NAME.equals(varId.getName())) {
@@ -93,7 +93,7 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
                             || field.getVisibility() != ModifierOwner.Visibility.V_PRIVATE
                             || !field.hasModifiers(JModifier.STATIC)
                             || !field.hasModifiers(JModifier.FINAL)) {
-                        asCtx(data).addViolationWithMessage(varId, "The field ''{0}'' should be private static final with type ''{1}''.",
+                        data.addViolationWithMessage(varId, "The field ''{0}'' should be private static final with type ''{1}''.",
                                 varId.getName(), SERIAL_PERSISTENT_FIELDS_TYPE);
                     }
                 }
@@ -102,7 +102,7 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         ASTTypeDeclaration typeDeclaration = node.ancestors(ASTTypeDeclaration.class).first();
 
         if (typeDeclaration == null
@@ -116,7 +116,7 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
         }
 
         if (isPersistentField(typeDeclaration, node) && isNotSerializable(node)) {
-            asCtx(data).addViolation(node, node.getName(), typeDeclaration.getBinaryName(), node.getTypeMirror());
+            data.addViolation(node, node.getName(), typeDeclaration.getBinaryName(), node.getTypeMirror());
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class NullAssignmentRule extends AbstractJavaRulechainRule {
 
@@ -24,18 +25,18 @@ public class NullAssignmentRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTNullLiteral node, Object data) {
+    public RuleContext visit(ASTNullLiteral node, RuleContext data) {
         if (node.getParent() instanceof ASTAssignmentExpression) {
             ASTAssignmentExpression assignment = (ASTAssignmentExpression) node.getParent();
             if (isAssignmentToFinal(assignment)) {
                 return data;
             }
             if (assignment.getRightOperand() == node) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         } else if (node.getParent() instanceof ASTConditionalExpression) {
             if (isBadTernary((ASTConditionalExpression) node.getParent(), node)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -26,7 +26,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractJavaRulechainRule
         return TypeTestUtil.isA(Comparable.class, node);
     }
 
-    private void visitTypeDecl(ASTTypeDeclaration node, Object data) {
+    private void visitTypeDecl(ASTTypeDeclaration node, RuleContext data) {
         if (skipType(node)) {
             return;
         }
@@ -46,7 +46,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractJavaRulechainRule
             }
         }
 
-        maybeReport(asCtx(data), node, hashCodeMethod, equalsMethod);
+        maybeReport(data, node, hashCodeMethod, equalsMethod);
     }
 
     protected void maybeReport(RuleContext ctx, ASTTypeDeclaration node, ASTMethodDeclaration hashCodeMethod, ASTMethodDeclaration equalsMethod) {
@@ -58,13 +58,13 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTAnonymousClassDeclaration node, Object data) {
+    public RuleContext visit(ASTAnonymousClassDeclaration node, RuleContext data) {
         visitTypeDecl(node, data);
         return null;
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (node.isInterface()) {
             return null;
         }
@@ -73,7 +73,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTRecordDeclaration node, Object data) {
+    public RuleContext visit(ASTRecordDeclaration node, RuleContext data) {
         visitTypeDecl(node, data);
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ProperCloneImplementationRule extends AbstractJavaRulechainRule {
 
@@ -22,11 +23,11 @@ public class ProperCloneImplementationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration method, Object data) {
+    public RuleContext visit(ASTMethodDeclaration method, RuleContext data) {
         if (JavaAstUtils.isCloneMethod(method) && !method.isAbstract()) {
             ASTTypeDeclaration enclosingType = method.getEnclosingType();
             if (isNotFinal(enclosingType) && hasAnyAllocationOfClass(method, enclosingType)) {
-                asCtx(data).addViolation(method);
+                data.addViolation(method);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingleMethodSingletonRule.java
@@ -8,6 +8,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Returns Checks if the singleton rule is used properly.
@@ -21,16 +22,16 @@ public class SingleMethodSingletonRule extends AbstractJavaRulechainRule {
     /**
      * Checks for getInstance method usage in the same class.
      * @param node of ASTCLass
-     * @param data of Object
-     * @return Object
+     * @param data of RuleContext
+     * @return RuleContext
      */
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         int count = node.descendants(ASTMethodDeclaration.class)
             .filter(m -> "getInstance".equals(m.getName()))
             .count();
         if (count > 1) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class SingletonClassReturningNewInstanceRule extends AbstractJavaRulechainRule {
 
@@ -23,14 +24,14 @@ public class SingletonClassReturningNewInstanceRule extends AbstractJavaRulechai
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (node.isVoid() || !"getInstance".equals(node.getName())) {
             return data;
         }
 
         DescendantNodeStream<ASTReturnStatement> rsl = node.descendants(ASTReturnStatement.class);
         if (returnsNewInstances(rsl) || returnsLocalVariables(rsl)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
 
@@ -14,7 +15,7 @@ public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTStringLiteral node, Object data) {
+    public RuleContext visit(ASTStringLiteral node, RuleContext data) {
         String image = node.getImage();
         // trim quotes
         String s = image.substring(1, image.length() - 1);
@@ -46,7 +47,7 @@ public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
                                     // escape followed by
                                     // an octal digit -- legal but very
                                     // confusing!
-                                    asCtx(data).addViolation(node, "\\" + first + second + " + " + third);
+                                    data.addViolation(node, "\\" + first + second + " + " + third);
                                 } else {
                                     // if there is a 4th decimal digit, it
                                     // could never be part of
@@ -55,7 +56,7 @@ public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
                                     if (escapeSequence.length() > 3) {
                                         char fourth = escapeSequence.charAt(3);
                                         if (isDecimal(fourth)) {
-                                            asCtx(data).addViolation(node, "\\" + first + second + third + " + " + fourth);
+                                            data.addViolation(node, "\\" + first + second + third + " + " + fourth);
                                         }
                                     }
                                 }
@@ -64,14 +65,14 @@ public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
                                 // this is a two-digit octal escape followed
                                 // by a decimal digit
                                 // legal but very confusing
-                                asCtx(data).addViolation(node, "\\" + first + second + " + " + third);
+                                data.addViolation(node, "\\" + first + second + " + " + third);
                             }
                         }
                     } else if (isDecimal(second)) {
                         // this is a one-digit octal escape followed by a
                         // decimal digit
                         // legal but very confusing
-                        asCtx(data).addViolation(node, "\\" + first + " + " + second);
+                        data.addViolation(node, "\\" + first + " + " + second);
                     }
                 }
             } else if (first == '\\') {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class TestClassWithoutTestCasesRule extends AbstractJavaRulechainRule {
 
@@ -31,7 +32,7 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration node, Object data) {
+    public RuleContext visit(ASTClassDeclaration node, RuleContext data) {
         if (isJUnit3Class(node) || isJUnit5NestedClass(node) || isTestClassByPattern(node)) {
             boolean hasTests =
                 node.getDeclarations(ASTMethodDeclaration.class)
@@ -40,7 +41,7 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRulechainRule {
                     .any(TestFrameworksUtil::isJUnit5NestedClass);
 
             if (!hasTests && !hasNestedTestClasses) {
-                asCtx(data).addViolation(node, node.getSimpleName());
+                data.addViolation(node, node.getSimpleName());
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -11,6 +11,7 @@ import java.util.List;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnnecessaryCaseChangeRule extends AbstractJavaRulechainRule {
 
@@ -22,11 +23,11 @@ public class UnnecessaryCaseChangeRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (EQUALITY_METHODS.contains(node.getMethodName()) && node.getArguments().size() == 1) {
             if (isCaseChangingMethodCall(node.getQualifier())
                     || isCaseChangingMethodCall(node.getArguments().get(0))) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * An operation on an Immutable object (String, BigDecimal or BigInteger) won't
@@ -28,7 +29,7 @@ public class UselessOperationOnImmutableRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         ASTExpression qualifier = node.getQualifier();
         boolean returnsVoid = node.getTypeMirror().isVoid();
         if (node.getParent() instanceof ASTExpressionStatement && qualifier != null && !returnsVoid) {
@@ -37,15 +38,15 @@ public class UselessOperationOnImmutableRule extends AbstractJavaRulechainRule {
             // result is ignored is a violation
             if (TypeTestUtil.isA(String.class, qualifier)) {
                 if (!"getChars".equals(node.getMethodName())) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             } else if (TypeTestUtil.isA(BigDecimal.class, qualifier)
                 || TypeTestUtil.isA(BigInteger.class, qualifier)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             } else if (TypeTestUtil.isA(Temporal.class, qualifier)
                 || TypeTestUtil.isA(Duration.class, qualifier)
                 || TypeTestUtil.isA(Period.class, qualifier)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessPureMethodCallRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessPureMethodCallRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Reports usages of pure methods where the result is ignored.
@@ -21,11 +22,11 @@ public class UselessPureMethodCallRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTExpressionStatement node, Object data) {
+    public RuleContext visit(ASTExpressionStatement node, RuleContext data) {
         if (node.getExpr() instanceof ASTMethodCall) {
             ASTMethodCall methodCall = (ASTMethodCall) node.getExpr();
             if (JavaRuleUtil.isKnownPure(methodCall)) {
-                asCtx(data).addViolation(node, methodCall.getMethodName());
+                data.addViolation(node, methodCall.getMethodName());
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -45,7 +46,7 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
     protected abstract int getMetric(T node);
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
         @SuppressWarnings("unchecked")
         T t = (T) node;
         // since we only visit this node, it's ok
@@ -54,7 +55,7 @@ public abstract class AbstractJavaCounterCheckRule<T extends JavaNode> extends A
             int metric = getMetric(t);
             int threshold = getProperty(reportLevel);
             if (metric >= threshold) {
-                asCtx(data).addViolation(node, metric, threshold);
+                data.addViolation(node, metric, threshold);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
@@ -63,7 +63,7 @@ public class TypeResTestRule extends AbstractJavaRule {
 
 
     @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
+    public RuleContext visit(ASTCompilationUnit node, RuleContext data) {
         for (JavaNode descendant : node.descendants().crossFindBoundaries()) {
             visitJavaNode(descendant, data);
         }
@@ -71,7 +71,7 @@ public class TypeResTestRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visitJavaNode(JavaNode node, Object data) {
+    public RuleContext visitJavaNode(JavaNode node, RuleContext data) {
 
         if (node instanceof TypeNode) {
             try {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/DoubleCheckedLockingRule.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JLocalVariableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * <pre>
@@ -61,7 +62,7 @@ public class DoubleCheckedLockingRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (node.isVoid() || node.getResultTypeNode() instanceof ASTPrimitiveType || node.getBody() == null) {
             return data;
         }
@@ -104,7 +105,7 @@ public class DoubleCheckedLockingRule extends AbstractJavaRule {
                         .filter(innerIf -> JavaRuleUtil.isNullCheck(innerIf.getCondition(), returnVariable))
                         .flatMap(innerIf -> innerIf.descendants(ASTAssignmentExpression.class));
                     if (assignments.all(assignment -> JavaAstUtils.isReferenceToVar(assignment.getLeftOperand(), returnVariable))) {
-                        assignments.firstOpt().ifPresent(ignored -> asCtx(data).addViolation(node));
+                        assignments.firstOpt().ifPresent(ignored -> data.addViolation(node));
                     }
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -59,7 +59,7 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         if (checkNonStaticFields || node.hasModifiers(JModifier.STATIC)) {
             for (ASTVariableId varId : node.getVarIds()) {
                 fields.add(varId.getName());
@@ -70,7 +70,7 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
 
 
     @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    public RuleContext visit(ASTMethodDeclaration node, RuleContext data) {
         if (checkNonStaticMethods && !node.hasModifiers(JModifier.STATIC)
                 || node.hasModifiers(JModifier.SYNCHRONIZED)) {
             return data;
@@ -104,7 +104,7 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
                 }
             }
             if (violation) {
-                asCtx(data).addViolation(ifStatement);
+                data.addViolation(ifStatement);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Using a Formatter (e.g. SimpleDateFormatter, DecimalFormatter) which is static can cause
@@ -59,7 +60,7 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRulechainRule
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration node, Object data) {
+    public RuleContext visit(ASTFieldDeclaration node, RuleContext data) {
         if (!node.hasModifiers(JModifier.STATIC)) {
             return data;
         }
@@ -107,7 +108,7 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRulechainRule
                 continue;
             }
 
-            asCtx(data).addViolation(ref);
+            data.addViolation(ref);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AddEmptyStringRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class AddEmptyStringRule extends AbstractJavaRulechainRule {
@@ -23,7 +24,7 @@ public class AddEmptyStringRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTStringLiteral node, Object data) {
+    public RuleContext visit(ASTStringLiteral node, RuleContext data) {
         if (!node.isEmpty()) {
             return null;
         }
@@ -40,10 +41,10 @@ public class AddEmptyStringRule extends AbstractJavaRulechainRule {
         return null;
     }
 
-    private void checkExpr(Object data, JavaNode parent, JavaNode emptyStringNode) {
+    private void checkExpr(RuleContext data, JavaNode parent, JavaNode emptyStringNode) {
         if (JavaAstUtils.isInfixExprWithOperator(parent, BinaryOp.ADD)
             && parent.ancestors(ASTAnnotation.class).isEmpty()) {
-            asCtx(data).addViolationWithPosition(parent, parent.getAstInfo(),
+            data.addViolationWithPosition(parent, parent.getAstInfo(),
                 emptyStringNode.getReportLocation(), getMessage());
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule finds the following:
@@ -31,7 +32,7 @@ public class AppendCharacterWithCharRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTStringLiteral node, Object data) {
+    public RuleContext visit(ASTStringLiteral node, RuleContext data) {
         if (node.getParent() instanceof ASTArgumentList
             && node.length() == 1
             && ((ASTArgumentList) node.getParent()).size() == 1) {
@@ -42,7 +43,7 @@ public class AppendCharacterWithCharRule extends AbstractJavaRulechainRule {
                     && (TypeTestUtil.isDeclaredInClass(StringBuilder.class, call.getMethodType())
                     || TypeTestUtil.isDeclaredInClass(StringBuffer.class, call.getMethodType()))
                 ) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidInstantiatingObjectsInLoopsRule extends AbstractJavaRulechainRule {
 
@@ -31,18 +32,18 @@ public class AvoidInstantiatingObjectsInLoopsRule extends AbstractJavaRulechainR
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         checkNode(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTArrayAllocation node, Object data) {
+    public RuleContext visit(ASTArrayAllocation node, RuleContext data) {
         checkNode(node, data);
         return data;
     }
 
-    private void checkNode(JavaNode node, Object data) {
+    private void checkNode(JavaNode node, RuleContext data) {
         if (notInsideLoop(node)) {
             return;
         }
@@ -52,7 +53,7 @@ public class AvoidInstantiatingObjectsInLoopsRule extends AbstractJavaRulechainR
                 && notBreakFollowing(node)
                 && notArrayAssignment(node)
                 && notCollectionAccess(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
@@ -32,7 +33,7 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         LanguageVersion languageVersion = node.getTextDocument().getLanguageVersion();
 
         @NonNull
@@ -56,24 +57,24 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
         if (TypeTestUtil.isA(BigInteger.class, node)) {
             // BigInteger.ZERO, ONE: since 1.2
             if ("0".equals(constValue) || "1".equals(constValue)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
             // BigInteger.TEN: since 1.5
             if (java5 && "10".equals(constValue)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
             // BigInteger.TWO: since 9
             if (java9 && "2".equals(constValue)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         } else if (TypeTestUtil.isA(BigDecimal.class, node)) {
             // BigDecimal.ZERO, ONE, TEN: since 1.5
             if (java5 && BIGDECIMAL_CONSTANTS.contains(String.valueOf(constValue))) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
             // BigDecimal.TWO: since 19
             if (java19 && "2".equals(String.valueOf(constValue))) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
 
@@ -31,7 +32,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTExpressionStatement node, Object data) {
+    public RuleContext visit(ASTExpressionStatement node, RuleContext data) {
         Node nextSibling = node.asStream().followingSiblings().first();
         if (nextSibling instanceof ASTExpressionStatement) {
             @Nullable JVariableSymbol variable = getVariableAppended(node);
@@ -41,7 +42,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
                         && nextVariable.equals(variable)
                         && !(node.getParent() instanceof ASTIfStatement)
                 ) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             }
         }
@@ -49,7 +50,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, RuleContext data) {
         Node nextSibling = node.asStream().followingSiblings().first();
         if (nextSibling instanceof ASTExpressionStatement) {
             @Nullable JVariableSymbol nextVariable = getVariableAppended((ASTExpressionStatement) nextSibling);
@@ -57,7 +58,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
                 ASTVariableId varDecl = nextVariable.tryGetNode();
                 if (varDecl != null && node.getVarIds().any(it -> it == varDecl)
                     && isStringBuilderAppend(varDecl.getInitializer())) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -37,6 +37,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -95,7 +96,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         if (!isStringBuilderOrBuffer(node)) {
             return data;
         }
@@ -152,7 +153,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
      *
      * @param node
      */
-    private void checkConstructor(Object data, ASTVariableId node) {
+    private void checkConstructor(RuleContext data, ASTVariableId node) {
         ASTExpression initializer = node.getInitializer();
         if (initializer == null) {
             return;
@@ -173,7 +174,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
         }
     }
 
-    private void analyzeInvocation(Object data, InvocationNode invocation) {
+    private void analyzeInvocation(RuleContext data, InvocationNode invocation) {
         if (!(invocation instanceof ASTExpression)) {
             return;
         }
@@ -192,7 +193,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
         }
     }
 
-    private void processAdditive(Object data, InvocationNode invocation) {
+    private void processAdditive(RuleContext data, InvocationNode invocation) {
         ASTExpression firstArg = invocation.getArguments().getFirstChild();
         if (firstArg.descendants(ASTNamedReferenceExpr.class).count() > 0) {
             // at least one variable/field access found
@@ -255,10 +256,10 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
      * Helper method checks to see if a violation occurred, and adds a
      * RuleViolation if it did
      */
-    private void checkForViolation(Object data) {
+    private void checkForViolation(RuleContext data) {
         if (counter.isViolation()) {
             assert counter.getReportNode() != null;
-            asCtx(data).addViolation(counter.getReportNode(), String.valueOf(counter.getCounter()));
+            data.addViolation(counter.getReportNode(), String.valueOf(counter.getCounter()));
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule finds code which inefficiently determines empty strings.
@@ -47,10 +48,10 @@ public class InefficientEmptyStringCheckRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, RuleContext data) {
         if (isTrimOrStripCall(call.getQualifier())
             && (isLengthZeroCheck(call) || isIsEmptyOrIsBlankCall(call))) {
-            asCtx(data).addViolation(call);
+            data.addViolation(call);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -29,17 +29,17 @@ public class InefficientStringBufferingRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (JavaRuleUtil.isStringBuilderCtorOrAppend(node)) {
-            checkArgument(node.getArguments(), (RuleContext) data);
+            checkArgument(node.getArguments(), data);
         }
         return null;
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         if (JavaRuleUtil.isStringBuilderCtorOrAppend(node)) {
-            checkArgument(node.getArguments(), (RuleContext) data);
+            checkArgument(node.getArguments(), data);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -32,6 +32,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule finds StringBuffers which may have been pre-sized incorrectly.
@@ -122,7 +123,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
     }
 
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         if (!TypeTestUtil.isA(StringBuilder.class, node) && !TypeTestUtil.isA(StringBuffer.class, node)) {
             return data;
         }
@@ -143,7 +144,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
 
                 if (newState.rootNode != null) {
                     if (state.isInsufficient()) {
-                        asCtx(data).addViolation(state.rootNode, state.getParamsForViolation());
+                        data.addViolation(state.rootNode, state.getParamsForViolation());
                     }
                     state = newState;
                 } else {
@@ -153,7 +154,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
         }
 
         if (state.isInsufficient()) {
-            asCtx(data).addViolation(state.rootNode, state.getParamsForViolation());
+            data.addViolation(state.rootNode, state.getParamsForViolation());
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
@@ -16,8 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
-
-
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -39,13 +38,13 @@ public class RedundantFieldInitializerRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTFieldDeclaration fieldDeclaration, Object data) {
+    public RuleContext visit(ASTFieldDeclaration fieldDeclaration, RuleContext data) {
         if (!fieldDeclaration.hasModifiers(JModifier.FINAL) && !JavaAstUtils.hasAnyAnnotation(fieldDeclaration.getEnclosingType(), MAKE_FIELD_FINAL_CLASS_ANNOT)) {
             for (ASTVariableId varId : fieldDeclaration.getVarIds()) {
                 ASTExpression init = varId.getInitializer();
                 if (init != null) {
                     if (!isWhitelisted(init) && JavaAstUtils.isDefaultValue(varId.getTypeMirror(), init)) {
-                        asCtx(data).addViolation(varId);
+                        data.addViolation(varId);
                     }
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class StringInstantiationRule extends AbstractJavaRule {
 
@@ -21,7 +22,7 @@ public class StringInstantiationRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         ASTArgumentList args = node.getArguments();
         if (args.size() <= 1
             && TypeTestUtil.isExactlyA(String.class, node.getTypeNode())) {
@@ -32,7 +33,7 @@ public class StringInstantiationRule extends AbstractJavaRule {
                 // byte/char array ctor is ok
                 return data;
             }
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseIndexOfCharRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  *
@@ -20,13 +21,13 @@ public class UseIndexOfCharRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if ("indexOf".equals(node.getMethodName()) || "lastIndexOf".equals(node.getMethodName())) {
             if (TypeTestUtil.isA(String.class, node.getQualifier())
                 && node.getArguments().size() >= 1) { // there are two overloads of each
                 ASTExpression arg = node.getArguments().get(0);
                 if (arg instanceof ASTStringLiteral && ((ASTStringLiteral) arg).getConstValue().length() == 1) {
-                    asCtx(data).addViolation(node);
+                    data.addViolation(node);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UseStringBufferForStringAppendsRule extends AbstractJavaRulechainRule {
 
@@ -27,10 +28,10 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRulechainRu
      * This method is used to check whether user appends string directly instead of using StringBuffer or StringBuilder
      * @param node This is the expression of part of java code to be checked.
      * @param data This is the data to return.
-     * @return Object This returns the data passed in. If violation happens, violation is added to data.
+     * @return RuleContext This returns the RuleContext passed in. If violation happens, violation is added to data.
      */
     @Override
-    public Object visit(ASTVariableId node, Object data) {
+    public RuleContext visit(ASTVariableId node, RuleContext data) {
         if (!TypeTestUtil.isA(String.class, node) || node.isForeachVariable()) {
             return data;
         }
@@ -71,7 +72,7 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRulechainRu
             if (usage.getAccessType() == AccessType.WRITE && !isSimpleAssignment) {
                 if (isWithinLoop(usage)) {
                     // always report appends within a loop
-                    asCtx(data).addViolation(usage);
+                    data.addViolation(usage);
                 } else {
                     possibleViolations.add(usage);
                 }
@@ -81,7 +82,7 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRulechainRu
         // only report, if it is used more than once
         // then all usage locations are reported
         if (usageCounter > 1) {
-            possibleViolations.forEach(v -> asCtx(data).addViolation(v));
+            possibleViolations.forEach(v -> data.addViolation(v));
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UselessStringValueOfRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UselessStringValueOfRule extends AbstractJavaRule {
 
@@ -23,13 +24,13 @@ public class UselessStringValueOfRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTMethodCall node, Object data) {
+    public RuleContext visit(ASTMethodCall node, RuleContext data) {
         if (JavaAstUtils.isStringConcatExpr(node.getParent())) {
             ASTExpression valueOfArg = getValueOfArg(node);
             if (valueOfArg == null) {
                 return data; //not a valueOf call
             } else if (TypeTestUtil.isExactlyA(String.class, valueOfArg)) {
-                asCtx(data).addViolation(node); // valueOf call on a string
+                data.addViolation(node); // valueOf call on a string
                 return data;
             }
 
@@ -39,7 +40,7 @@ public class UselessStringValueOfRule extends AbstractJavaRule {
                 // In `String.valueOf(a) + String.valueOf(b)`,
                 // only report the second call
                 && (getValueOfArg(sibling) == null || node.getIndexInParent() == 1)) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulechainRule {
 
@@ -28,7 +29,7 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
     }
 
     @Override
-    public Object visit(ASTConstructorCall node, Object data) {
+    public RuleContext visit(ASTConstructorCall node, RuleContext data) {
         if (TypeTestUtil.isA(type, node)) {
             ASTArgumentList arguments = node.getArguments();
             if (arguments.size() > 0) {
@@ -44,7 +45,7 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
      *
      * <p>Then checks the expression for being a string literal or array
      */
-    private void validateProperKeyArgument(Object data, ASTExpression firstArgumentExpression) {
+    private void validateProperKeyArgument(RuleContext data, ASTExpression firstArgumentExpression) {
         if (firstArgumentExpression == null) {
             return;
         }
@@ -70,28 +71,28 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
                 validateVarUsages(data, varDecl);
             } else if (varAccess.isCompileTimeConstant()
                     && varAccess.getConstValue() instanceof String) {
-                asCtx(data).addViolation(varAccess);
+                data.addViolation(varAccess);
             }
         } else if (firstArgumentExpression instanceof ASTArrayAllocation) {
             // hard coded array
             ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
             if (arrayInit != null) {
-                asCtx(data).addViolation(arrayInit);
+                data.addViolation(arrayInit);
             }
         } else if (firstArgumentExpression instanceof ASTArrayInitializer) {
             // hard coded array
-            asCtx(data).addViolation(firstArgumentExpression);
+            data.addViolation(firstArgumentExpression);
         } else {
             // string literal
             ASTStringLiteral literal = firstArgumentExpression.descendantsOrSelf()
                     .filterIs(ASTStringLiteral.class).first();
             if (literal != null) {
-                asCtx(data).addViolation(literal);
+                data.addViolation(literal);
             }
         }
     }
 
-    private void validateVarUsages(Object data, ASTVariableId varDecl) {
+    private void validateVarUsages(RuleContext data, ASTVariableId varDecl) {
         varDecl.getLocalUsages().stream()
             .filter(u -> u.getAccessType() == AccessType.WRITE)
             .filter(u -> u.getParent() instanceof ASTAssignmentExpression)

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ExcludeLinesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ExcludeLinesTest.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.rule.Rule;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 class ExcludeLinesTest extends BaseParserTest {
 
@@ -29,8 +30,8 @@ class ExcludeLinesTest extends BaseParserTest {
             }
 
             @Override
-            public Object visit(ASTVariableId node, Object data) {
-                asCtx(data).addViolation(node);
+            public RuleContext visit(ASTVariableId node, RuleContext data) {
+                data.addViolation(node);
                 return data;
             }
         };

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/FooRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class FooRule extends AbstractJavaRule {
 
@@ -19,17 +20,17 @@ public class FooRule extends AbstractJavaRule {
     }
 
     @Override
-    public Object visit(ASTClassDeclaration c, Object ctx) {
+    public RuleContext visit(ASTClassDeclaration c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getSimpleName())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }
 
     @Override
-    public Object visit(ASTVariableId c, Object ctx) {
+    public RuleContext visit(ASTVariableId c, RuleContext ctx) {
         if ("Foo".equalsIgnoreCase(c.getName())) {
-            asCtx(ctx).addViolation(c);
+            ctx.addViolation(c);
         }
         return super.visit(c, ctx);
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 class SuppressWarningsTest {
 
@@ -26,12 +27,12 @@ class SuppressWarningsTest {
         }
 
         @Override
-        public Object visit(ASTCompilationUnit cu, Object ctx) {
+        public RuleContext visit(ASTCompilationUnit cu, RuleContext ctx) {
             // Convoluted rule to make sure the violation is reported for the
             // ASTCompilationUnit node
             for (ASTClassDeclaration c : cu.descendants(ASTClassDeclaration.class)) {
                 if ("bar".equalsIgnoreCase(c.getSimpleName())) {
-                    asCtx(ctx).addViolation(cu);
+                    ctx.addViolation(cu);
                 }
             }
             return super.visit(cu, ctx);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/DummyJavaRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/DummyJavaRule.java
@@ -33,8 +33,8 @@ public class DummyJavaRule extends AbstractJavaRule {
         }
 
         @Override
-        public Object visit(ASTVariableId node, Object data) {
-            asCtx(data).addViolation(node, node.getName());
+        public RuleContext visit(ASTVariableId node, RuleContext data) {
+            data.addViolation(node, node.getName());
             return super.visit(node, data);
         }
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.rule.Rule;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
@@ -33,9 +34,9 @@ class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
         }
 
         @Override
-        public Object visit(ASTUnaryExpression node, Object data) {
+        public RuleContext visit(ASTUnaryExpression node, RuleContext data) {
             if (node.getOperator().isIncrement()) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
             return null;
         }
@@ -51,9 +52,9 @@ class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
         }
 
         @Override
-        public Object visit(ASTUnaryExpression node, Object data) {
+        public RuleContext visit(ASTUnaryExpression node, RuleContext data) {
             if (node.getOperator().isDecrement()) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
             return null;
         }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
@@ -11,7 +11,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public abstract class AbstractEcmascriptRule extends AbstractRule
-        implements EcmascriptVisitor<Object, Object> {
+        implements EcmascriptVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -19,7 +19,7 @@ public abstract class AbstractEcmascriptRule extends AbstractRule
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(c -> c.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.ecmascript.ast.ASTFunctionNode;
 import net.sourceforge.pmd.lang.ecmascript.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.ecmascript.rule.AbstractEcmascriptRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ConsistentReturnRule extends AbstractEcmascriptRule {
 
@@ -19,7 +20,7 @@ public class ConsistentReturnRule extends AbstractEcmascriptRule {
     }
 
     @Override
-    public Object visit(ASTFunctionNode functionNode, Object data) {
+    public RuleContext visit(ASTFunctionNode functionNode, RuleContext data) {
         Boolean hasResult = null;
         for (ASTReturnStatement returnStatement : functionNode.descendants(ASTReturnStatement.class)) {
             // Return for this function?
@@ -29,7 +30,7 @@ public class ConsistentReturnRule extends AbstractEcmascriptRule {
                 } else {
                     // Return has different result from previous return?
                     if (hasResult != returnStatement.hasResult()) {
-                        asCtx(data).addViolation(functionNode);
+                        data.addViolation(functionNode);
                         break;
                     }
                 }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ReportTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ReportTest.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptParserTestBase;
 import net.sourceforge.pmd.lang.ecmascript.rule.AbstractEcmascriptRule;
 import net.sourceforge.pmd.lang.rule.Rule;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 class ReportTest extends EcmascriptParserTestBase {
 
@@ -21,8 +22,8 @@ class ReportTest extends EcmascriptParserTestBase {
     void testExclusionsInReportWithNOPMDEcmascript() {
         Rule rule = new AbstractEcmascriptRule() {
             @Override
-            public Object visit(ASTFunctionNode node, Object data) {
-                asCtx(data).addViolationWithMessage(node, "Test");
+            public RuleContext visit(ASTFunctionNode node, RuleContext data) {
+                data.addViolationWithMessage(node, "Test");
                 return data;
             }
         };

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
@@ -19,6 +19,7 @@ import org.mozilla.javascript.ast.AstRoot;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ecmascript.rule.AbstractEcmascriptRule;
 import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 class EcmascriptParserTest extends EcmascriptParserTestBase {
 
@@ -62,8 +63,8 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
 
         class MyEcmascriptRule extends AbstractEcmascriptRule {
 
-            public Object visit(ASTScope node, Object data) {
-                asCtx(data).addViolationWithMessage(node, "Scope from " + node.getBeginLine() + " to " + node.getEndLine());
+            public RuleContext visit(ASTScope node, RuleContext data) {
+                data.addViolationWithMessage(node, "Scope from " + node.getBeginLine() + " to " + node.getEndLine());
                 return super.visit(node, data);
             }
         }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.lang.jsp.ast.JspVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractJspRule extends AbstractRule implements JspVisitor<Object, Object> {
+public abstract class AbstractJspRule extends AbstractRule implements JspVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -17,7 +17,7 @@ public abstract class AbstractJspRule extends AbstractRule implements JspVisitor
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(c -> c.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
@@ -22,7 +22,7 @@ public class DuplicateJspImportsRule extends AbstractJspRule {
     }
 
     @Override
-    public Object visit(ASTJspDirectiveAttribute node, Object data) {
+    public RuleContext visit(ASTJspDirectiveAttribute node, RuleContext data) {
 
         if (!"import".equals(node.getName())) {
             return super.visit(node, data);
@@ -33,7 +33,7 @@ public class DuplicateJspImportsRule extends AbstractJspRule {
         for (int ix = 0; ix < count; ix++) {
             String token = st.nextToken();
             if (imports.contains(token)) {
-                asCtx(data).addViolation(node, token);
+                data.addViolation(node, token);
             } else {
                 imports.add(token);
             }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import net.sourceforge.pmd.lang.jsp.ast.ASTAttribute;
 import net.sourceforge.pmd.lang.jsp.ast.ASTElement;
 import net.sourceforge.pmd.lang.jsp.rule.AbstractJspRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule checks that no "style" elements (like &lt;B&gt;, &lt;FONT&gt;, ...) are used,
@@ -43,18 +44,18 @@ public class NoInlineStyleInformationRule extends AbstractJspRule {
         setOf("STYLE", "FONT", "SIZE", "COLOR", "FACE", "ALIGN", "VALIGN", "BGCOLOR");
 
     @Override
-    public Object visit(ASTAttribute node, Object data) {
+    public RuleContext visit(ASTAttribute node, RuleContext data) {
         if (isStyleAttribute(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTElement node, Object data) {
+    public RuleContext visit(ASTElement node, RuleContext data) {
         if (isStyleElement(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return super.visit(node, data);

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.jsp.rule.security;
 import net.sourceforge.pmd.lang.jsp.ast.ASTElExpression;
 import net.sourceforge.pmd.lang.jsp.ast.ASTElement;
 import net.sourceforge.pmd.lang.jsp.rule.AbstractJspRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects unsanitized JSP Expressions (can lead to Cross Site
@@ -16,9 +17,9 @@ import net.sourceforge.pmd.lang.jsp.rule.AbstractJspRule;
  */
 public class NoUnsanitizedJSPExpressionRule extends AbstractJspRule {
     @Override
-    public Object visit(ASTElExpression node, Object data) {
+    public RuleContext visit(ASTElExpression node, RuleContext data) {
         if (elOutsideTaglib(node)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
 
         return super.visit(node, data);

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
 /**
  * Base class for rules for Modelica language.
  */
-public abstract class AbstractModelicaRule extends AbstractRule implements ModelicaVisitor<Object, Object> {
+public abstract class AbstractModelicaRule extends AbstractRule implements ModelicaVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -20,7 +20,7 @@ public abstract class AbstractModelicaRule extends AbstractRule implements Model
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(c -> c.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
@@ -8,10 +8,11 @@ import net.sourceforge.pmd.lang.modelica.ast.ASTName;
 import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
 import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
 import net.sourceforge.pmd.lang.modelica.rule.AbstractModelicaRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AmbiguousResolutionRule extends AbstractModelicaRule {
     @Override
-    public Object visit(ASTName node, Object data) {
+    public RuleContext visit(ASTName node, RuleContext data) {
         ResolutionResult<ResolvableEntity> candidates = node.getResolutionCandidates();
         if (candidates.isClashed()) {
             StringBuilder sb = new StringBuilder();
@@ -20,7 +21,7 @@ public class AmbiguousResolutionRule extends AbstractModelicaRule {
                 sb.append(candidate.getDescriptiveName());
                 sb.append(", ");
             }
-            asCtx(data).addViolation(node, sb.substring(0, sb.length() - 2));
+            data.addViolation(node, sb.substring(0, sb.length() - 2));
         }
         return super.visit(node, data);
     }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
@@ -12,9 +12,10 @@ import net.sourceforge.pmd.lang.modelica.resolver.ModelicaComponentDeclaration;
 import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
 import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
 import net.sourceforge.pmd.lang.modelica.rule.AbstractModelicaRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ConnectUsingNonConnectorRule extends AbstractModelicaRule {
-    private void reportIfViolated(ASTComponentReference ref, Object data) {
+    private void reportIfViolated(ASTComponentReference ref, RuleContext data) {
         ResolutionResult<ResolvableEntity> resolution = ref.getResolutionCandidates();
         if (!resolution.isUnresolved()) { // no false positive if not resolved at all
             ResolvableEntity firstDecl = resolution.getBestCandidates().get(0);
@@ -26,20 +27,20 @@ public class ConnectUsingNonConnectorRule extends AbstractModelicaRule {
                         ModelicaClassType classDecl = (ModelicaClassType) componentTypes.getBestCandidates().get(0);
                         ModelicaClassSpecialization restriction = classDecl.getSpecialization();
                         if (!classDecl.isConnectorLike()) {
-                            asCtx(data).addViolation(ref, restriction.toString());
+                            data.addViolation(ref, restriction.toString());
                         }
                     } else {
-                        asCtx(data).addViolation(ref, firstDecl.getDescriptiveName());
+                        data.addViolation(ref, firstDecl.getDescriptiveName());
                     }
                 }
             } else {
-                asCtx(data).addViolation(ref, firstDecl.getDescriptiveName());
+                data.addViolation(ref, firstDecl.getDescriptiveName());
             }
         }
     }
 
     @Override
-    public Object visit(ASTConnectClause node, Object data) {
+    public RuleContext visit(ASTConnectClause node, RuleContext data) {
         ASTComponentReference lhs = (ASTComponentReference) node.getChild(0);
         ASTComponentReference rhs = (ASTComponentReference) node.getChild(1);
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -17,7 +17,7 @@ import net.sourceforge.pmd.lang.plsql.ast.PlsqlVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractPLSQLRule extends AbstractRule implements PlsqlVisitor<Object, Object> {
+public abstract class AbstractPLSQLRule extends AbstractRule implements PlsqlVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -25,7 +25,7 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PlsqlVis
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(c -> c.acceptVisitor(this, param));
         return param;
     }
@@ -83,7 +83,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PlsqlVis
     /*
      * Treat all Executable Code
      */
+    /**
+     * @deprecated use PlsqlVisitor.visitPlsqlNode(PLSQLNode, RuleContext) instead.
+     */
+    @Deprecated
     public Object visit(ExecutableCode node, Object data) {
-        return visitPlsqlNode(node, data);
+        return visitPlsqlNode(node, (RuleContext) data);
     }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidTabCharacterRule extends AbstractPLSQLRule {
 
@@ -30,13 +31,13 @@ public class AvoidTabCharacterRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTInput node, Object data) {
+    public RuleContext visit(ASTInput node, RuleContext data) {
         boolean eachLine = getProperty(EACH_LINE);
 
         int lineNumber = 1;
         for (Chars line : node.getText().lines()) {
             if (line.indexOf('\t', 0) != -1) {
-                asCtx(data).addViolationWithPosition(node, lineNumber, lineNumber,
+                data.addViolationWithPosition(node, lineNumber, lineNumber,
                                         "Tab characters are not allowed. Use spaces for indentation");
 
                 if (!eachLine) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTVariableOrConstantDeclarator;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class CodeFormatRule extends AbstractPLSQLRule {
@@ -45,20 +46,20 @@ public class CodeFormatRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTInput node, Object data) {
+    public RuleContext visit(ASTInput node, RuleContext data) {
         indentation = getProperty(INDENTATION_PROPERTY);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTSelectList node, Object data) {
+    public RuleContext visit(ASTSelectList node, RuleContext data) {
         Node parent = node.getParent();
         checkEachChildOnNextLine(data, node, parent.getBeginLine(), parent.getBeginColumn() + 7);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTBulkCollectIntoClause node, Object data) {
+    public RuleContext visit(ASTBulkCollectIntoClause node, RuleContext data) {
         Node parent = node.getParent();
         checkIndentation(data, node, parent.getBeginColumn() + indentation, "BULK COLLECT INTO");
         checkEachChildOnNextLine(data, node, node.getBeginLine(), parent.getBeginColumn() + 7);
@@ -66,13 +67,13 @@ public class CodeFormatRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTFromClause node, Object data) {
+    public RuleContext visit(ASTFromClause node, RuleContext data) {
         checkIndentation(data, node, node.getParent().getBeginColumn() + indentation, "FROM");
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTJoinClause node, Object data) {
+    public RuleContext visit(ASTJoinClause node, RuleContext data) {
         // first child is the table reference
         Node tableReference = node.getChild(0);
 
@@ -82,7 +83,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
             lineNumber++;
             Node child = node.getChild(i);
             if (child.getBeginLine() != lineNumber) {
-                asCtx(data).addViolationWithMessage(child, child.getXPathNodeName() + " should be on line " + lineNumber);
+                data.addViolationWithMessage(child, child.getXPathNodeName() + " should be on line " + lineNumber);
             }
             List<ASTEqualityExpression> conditions = child.descendants(ASTEqualityExpression.class).toList();
 
@@ -90,7 +91,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
                 // one condition should be on the same line
                 ASTEqualityExpression singleCondition = conditions.get(0);
                 if (singleCondition.getBeginLine() != lineNumber) {
-                    asCtx(data).addViolationWithMessage(child,
+                    data.addViolationWithMessage(child,
                             "Join condition \"" + singleCondition.getImage() + "\" should be on line " + lineNumber);
                 }
             } else {
@@ -98,7 +99,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
                 for (ASTEqualityExpression singleCondition : conditions) {
                     lineNumber++;
                     if (singleCondition.getBeginLine() != lineNumber) {
-                        asCtx(data).addViolationWithMessage(child,
+                        data.addViolationWithMessage(child,
                                 "Join condition \"" + singleCondition.getImage() + "\" should be on line "
                                         + lineNumber);
                     }
@@ -109,7 +110,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTSubqueryOperation node, Object data) {
+    public RuleContext visit(ASTSubqueryOperation node, RuleContext data) {
         // get previous sibling
         int thisIndex = node.getIndexInParent();
         Node prevSibling = node.getParent().getChild(thisIndex - 1);
@@ -118,14 +119,14 @@ public class CodeFormatRule extends AbstractPLSQLRule {
 
         // it should also be on the next line
         if (node.getBeginLine() != prevSibling.getEndLine() + 1) {
-            asCtx(data).addViolationWithMessage(node,
+            data.addViolationWithMessage(node,
                     node.getImage() + " should be on line " + (prevSibling.getEndLine() + 1));
         }
 
         return super.visit(node, data);
     }
 
-    private int checkEachChildOnNextLine(Object data, Node parent, int firstLine, int indentation) {
+    private int checkEachChildOnNextLine(RuleContext data, Node parent, int firstLine, int indentation) {
         int currentLine = firstLine;
         for (int i = 0; i < parent.getNumChildren(); i++) {
             Node child = parent.getChild(i);
@@ -134,9 +135,9 @@ public class CodeFormatRule extends AbstractPLSQLRule {
                 image = child.getChild(0).getImage();
             }
             if (child.getBeginLine() != currentLine) {
-                asCtx(data).addViolationWithMessage(child, image + " should be on line " + currentLine);
+                data.addViolationWithMessage(child, image + " should be on line " + currentLine);
             } else if (i > 0 && child.getBeginColumn() != indentation) {
-                asCtx(data).addViolationWithMessage(child, image + " should begin at column " + indentation);
+                data.addViolationWithMessage(child, image + " should begin at column " + indentation);
             }
             // next entry needs to be on the next line
             currentLine++;
@@ -144,22 +145,22 @@ public class CodeFormatRule extends AbstractPLSQLRule {
         return currentLine;
     }
 
-    private void checkLineAndIndentation(Object data, Node node, int line, int indentation, String name) {
+    private void checkLineAndIndentation(RuleContext data, Node node, int line, int indentation, String name) {
         if (node.getBeginLine() != line) {
-            asCtx(data).addViolationWithMessage(node, name + " should be on line " + line);
+            data.addViolationWithMessage(node, name + " should be on line " + line);
         } else if (node.getBeginColumn() != indentation) {
-            asCtx(data).addViolationWithMessage(node, name + " should begin at column " + indentation);
+            data.addViolationWithMessage(node, name + " should begin at column " + indentation);
         }
     }
 
-    private void checkIndentation(Object data, Node node, int indentation, String name) {
+    private void checkIndentation(RuleContext data, Node node, int indentation, String name) {
         if (node.getBeginColumn() != indentation) {
-            asCtx(data).addViolationWithMessage(node, name + " should begin at column " + indentation);
+            data.addViolationWithMessage(node, name + " should begin at column " + indentation);
         }
     }
 
     @Override
-    public Object visit(ASTFormalParameters node, Object data) {
+    public RuleContext visit(ASTFormalParameters node, RuleContext data) {
         int parameterIndentation = node.getParent().getBeginColumn() + indentation;
         checkEachChildOnNextLine(data, node, node.getBeginLine() + 1, parameterIndentation);
 
@@ -178,7 +179,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTDeclarativeSection node, Object data) {
+    public RuleContext visit(ASTDeclarativeSection node, RuleContext data) {
         int variableIndentation = node.ancestors().get(1).getBeginColumn() + 2 * indentation;
         int line = node.getBeginLine();
 
@@ -208,19 +209,19 @@ public class CodeFormatRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTArgumentList node, Object data) {
+    public RuleContext visit(ASTArgumentList node, RuleContext data) {
         List<ASTArgument> arguments = node.children(ASTArgument.class).toList();
 
         // note: end column is exclusive
         if (node.getEndColumn() >= 120) {
-            asCtx(data).addViolationWithMessage(node, "Line is too long, please split parameters on separate lines");
+            data.addViolationWithMessage(node, "Line is too long, please split parameters on separate lines");
             return super.visit(node, data);
         }
 
         if (arguments.size() > 3) {
             // procedure calls with more than 3 parameters should use named parameters
             if (usesSimpleParameters(arguments)) {
-                asCtx(data).addViolationWithMessage(node,
+                data.addViolationWithMessage(node,
                         "Procedure call with more than three parameters should use named parameters.");
             }
 
@@ -256,7 +257,7 @@ public class CodeFormatRule extends AbstractPLSQLRule {
             // closing parenthesis should be on a new line
             Node primaryExpression = node.ancestors().get(2);
             if (primaryExpression.getEndLine() != node.getEndLine() + 1) {
-                asCtx(data).addViolationWithMessage(primaryExpression, "Closing parenthesis should be on a new line.");
+                data.addViolationWithMessage(primaryExpression, "Closing parenthesis should be on a new line.");
             }
         }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.properties.NumericConstraints;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LineLengthRule extends AbstractPLSQLRule {
 
@@ -37,14 +38,14 @@ public class LineLengthRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTInput node, Object data) {
+    public RuleContext visit(ASTInput node, RuleContext data) {
         boolean eachLine = getProperty(EACH_LINE);
         int maxLineLength = getProperty(MAX_LINE_LENGTH);
 
         int lineNumber = 1;
         for (Chars line : node.getText().lines()) {
             if (line.length() > maxLineLength) {
-                asCtx(data).addViolationWithPosition(node, lineNumber, lineNumber,
+                data.addViolationWithPosition(node, lineNumber, lineNumber,
                         "The line is too long. Only " + maxLineLength + " characters are allowed.");
 
                 if (!eachLine) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -98,7 +99,7 @@ abstract class AbstractCounterCheckRule<T extends PLSQLNode> extends AbstractPLS
     protected abstract int getMetric(T node);
 
     @Override
-    public Object visitPlsqlNode(PLSQLNode node, Object data) {
+    public RuleContext visitPlsqlNode(PLSQLNode node, RuleContext data) {
         @SuppressWarnings("unchecked")
         T t = (T) node;
         // since we only visit this node, it's ok
@@ -107,7 +108,7 @@ abstract class AbstractCounterCheckRule<T extends PLSQLNode> extends AbstractPLS
             int metric = getMetric(t);
             int limit = getProperty(reportLevel);
             if (metric >= limit) {
-                asCtx(data).addViolation(node, getViolationParameters(t, metric, limit));
+                data.addViolation(node, getViolationParameters(t, metric, limit));
             }
         }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -34,6 +34,7 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -92,7 +93,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTInput node, Object data) {
+    public RuleContext visit(ASTInput node, RuleContext data) {
         reportLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
         showClassesComplexity = getProperty(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
         showMethodsComplexity = getProperty(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
@@ -101,7 +102,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTElsifClause node, Object data) {
+    public RuleContext visit(ASTElsifClause node, RuleContext data) {
         int boolCompIf = NPathComplexityRule.sumExpressionComplexity(node.firstChild(ASTExpression.class));
         // If statement always has a complexity of at least 1
         boolCompIf++;
@@ -112,7 +113,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         int boolCompIf = NPathComplexityRule.sumExpressionComplexity(node.firstChild(ASTExpression.class));
         // If statement always has a complexity of at least 1
         boolCompIf++;
@@ -123,14 +124,14 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTExceptionHandler node, Object data) {
+    public RuleContext visit(ASTExceptionHandler node, RuleContext data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
         return data;
     }
 
     @Override
-    public Object visit(ASTForStatement node, Object data) {
+    public RuleContext visit(ASTForStatement node, RuleContext data) {
         int boolCompFor = NPathComplexityRule
                 .sumExpressionComplexity(node.descendants(ASTExpression.class).first());
         // For statement always has a complexity of at least 1
@@ -142,7 +143,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTLoopStatement node, Object data) {
+    public RuleContext visit(ASTLoopStatement node, RuleContext data) {
         int boolCompDo = NPathComplexityRule.sumExpressionComplexity(node.firstChild(ASTExpression.class));
         // Do statement always has a complexity of at least 1
         boolCompDo++;
@@ -153,7 +154,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTCaseStatement node, Object data) {
+    public RuleContext visit(ASTCaseStatement node, RuleContext data) {
         Entry entry = entryStack.peek();
 
         int boolCompSwitch = NPathComplexityRule.sumExpressionComplexity(node.firstChild(ASTExpression.class));
@@ -164,7 +165,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTCaseWhenClause node, Object data) {
+    public RuleContext visit(ASTCaseWhenClause node, RuleContext data) {
         Entry entry = entryStack.peek();
 
         entry.bumpDecisionPoints();
@@ -173,7 +174,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTWhileStatement node, Object data) {
+    public RuleContext visit(ASTWhileStatement node, RuleContext data) {
         int boolCompWhile = NPathComplexityRule.sumExpressionComplexity(node.firstChild(ASTExpression.class));
         // While statement always has a complexity of at least 1
         boolCompWhile++;
@@ -184,24 +185,24 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTConditionalOrExpression node, Object data) {
+    public RuleContext visit(ASTConditionalOrExpression node, RuleContext data) {
         return data;
     }
 
     @Override
-    public Object visit(ASTPackageSpecification node, Object data) {
+    public RuleContext visit(ASTPackageSpecification node, RuleContext data) {
         // Treat Package Specification like an Interface
         return data;
     }
 
     @Override
-    public Object visit(ASTTypeSpecification node, Object data) {
+    public RuleContext visit(ASTTypeSpecification node, RuleContext data) {
         // Treat Type Specification like an Interface
         return data;
     }
 
     @Override
-    public Object visit(ASTPackageBody node, Object data) {
+    public RuleContext visit(ASTPackageBody node, RuleContext data) {
 
         entryStack.push(new Entry());
         super.visit(node, data);
@@ -210,15 +211,15 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
                 classEntry.getComplexityAverage(), classEntry.highestDecisionPoints);
         if (showClassesComplexity) {
             if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node, "class", node.getImage(),
-                                         classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
+                data.addViolation(node, "class", node.getImage(),
+                                  classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTTriggerUnit node, Object data) {
+    public RuleContext visit(ASTTriggerUnit node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
@@ -227,8 +228,8 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
                 classEntry.highestDecisionPoints);
         if (showClassesComplexity) {
             if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node, "class", node.getImage(),
-                                         classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
+                data.addViolation(node, "class", node.getImage(),
+                                  classEntry.getComplexityAverage() + " (Highest = " + classEntry.highestDecisionPoints + ')');
             }
         }
         return data;
@@ -245,7 +246,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
     
     @Override
-    public Object visit(ASTProgramUnit node, Object data) {
+    public RuleContext visit(ASTProgramUnit node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry methodEntry = entryStack.pop();
@@ -275,16 +276,16 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
 
             ASTMethodDeclarator methodDeclarator = node.firstChild(ASTMethodDeclarator.class);
             if (methodEntry.decisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node,
-                                         "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
-                                         String.valueOf(methodEntry.decisionPoints));
+                data.addViolation(node,
+                                  "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
+                                  String.valueOf(methodEntry.decisionPoints));
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTTypeMethod node, Object data) {
+    public RuleContext visit(ASTTypeMethod node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry methodEntry = entryStack.pop();
@@ -305,16 +306,16 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
 
             ASTMethodDeclarator methodDeclarator = node.firstChild(ASTMethodDeclarator.class);
             if (methodEntry.decisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node,
-                                         "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
-                                         String.valueOf(methodEntry.decisionPoints));
+                data.addViolation(node,
+                                  "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
+                                  String.valueOf(methodEntry.decisionPoints));
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTTriggerTimingPointSection node, Object data) {
+    public RuleContext visit(ASTTriggerTimingPointSection node, RuleContext data) {
         entryStack.push(new Entry());
         super.visit(node, data);
         Entry methodEntry = entryStack.pop();
@@ -333,9 +334,9 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
 
             ASTMethodDeclarator methodDeclarator = node.firstChild(ASTMethodDeclarator.class);
             if (methodEntry.decisionPoints >= reportLevel) {
-                asCtx(data).addViolation(node,
-                                         "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
-                                         String.valueOf(methodEntry.decisionPoints));
+                data.addViolation(node,
+                                  "method", methodDeclarator == null ? "" : methodDeclarator.getImage(),
+                                  String.valueOf(methodEntry.decisionPoints));
             }
         }
         return data;

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssCountRule.java
@@ -65,7 +65,7 @@ public class NcssCountRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visitPlsqlNode(PLSQLNode node, Object data) {
+    public RuleContext visitPlsqlNode(PLSQLNode node, RuleContext data) {
         int methodReportLevel = getProperty(METHOD_REPORT_LEVEL_DESCRIPTOR);
         int objectReportLevel = getProperty(OBJECT_REPORT_LEVEL_DESCRIPTOR);
 
@@ -75,19 +75,19 @@ public class NcssCountRule extends AbstractPLSQLRule {
         }
         // Special handling for ProgramUnit to distinguish between Object and Method
         if (node instanceof ASTProgramUnit && !(node.getParent() instanceof ASTGlobal)) {
-            visitMethod((ExecutableCode) node, methodReportLevel, (RuleContext) data);
+            visitMethod((ExecutableCode) node, methodReportLevel, data);
             alreadyVisitedProgramUnits.add(node);
             return data;
         } else if (node instanceof ASTProgramUnit && node.getParent() instanceof ASTGlobal) {
-            visitObject((OracleObject) node, objectReportLevel, (RuleContext) data);
+            visitObject((OracleObject) node, objectReportLevel, data);
             alreadyVisitedProgramUnits.add(node);
             return data;
         }
 
         if (node instanceof ExecutableCode) {
-            visitMethod((ExecutableCode) node, methodReportLevel, (RuleContext) data);
+            visitMethod((ExecutableCode) node, methodReportLevel, data);
         } else if (node instanceof OracleObject) {
-            visitObject((OracleObject) node, objectReportLevel, (RuleContext) data);
+            visitObject((OracleObject) node, objectReportLevel, data);
         } else {
             throw AssertionUtil.shouldNotReachHere("node is not handled: " + node);
         }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.plsql.ast.PLSQLNode;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class TooManyFieldsRule extends AbstractPLSQLRule {
 
@@ -39,7 +40,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTInput node, Object data) {
+    public RuleContext visit(ASTInput node, RuleContext data) {
 
         stats = new HashMap<>(5);
         nodes = new HashMap<>(5);
@@ -48,7 +49,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTPackageSpecification node, Object data) {
+    public RuleContext visit(ASTPackageSpecification node, RuleContext data) {
 
         int maxFields = getProperty(MAX_FIELDS_DESCRIPTOR);
 
@@ -61,14 +62,14 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
             int val = stats.get(k);
             Node n = nodes.get(k);
             if (val > maxFields) {
-                asCtx(data).addViolation(n);
+                data.addViolation(n);
             }
         }
         return data;
     }
 
     @Override
-    public Object visit(ASTTypeSpecification node, Object data) {
+    public RuleContext visit(ASTTypeSpecification node, RuleContext data) {
 
         int maxFields = getProperty(MAX_FIELDS_DESCRIPTOR);
 
@@ -81,7 +82,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
             int val = stats.get(k);
             Node n = nodes.get(k);
             if (val > maxFields) {
-                asCtx(data).addViolation(n);
+                data.addViolation(n);
             }
         }
         return data;

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/AbstractVtlRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/AbstractVtlRule.java
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.velocity.ast.VtlVisitor;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractVtlRule extends AbstractRule implements VtlVisitor<Object, Object> {
+public abstract class AbstractVtlRule extends AbstractRule implements VtlVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -17,7 +17,7 @@ public abstract class AbstractVtlRule extends AbstractRule implements VtlVisitor
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(it -> it.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -11,11 +11,12 @@ import net.sourceforge.pmd.lang.velocity.ast.ASTDirective;
 import net.sourceforge.pmd.lang.velocity.ast.ASTReference;
 import net.sourceforge.pmd.lang.velocity.ast.ASTSetDirective;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidReassigningParametersRule extends AbstractVtlRule {
 
     @Override
-    public Object visit(final ASTDirective node, final Object data) {
+    public RuleContext visit(final ASTDirective node, final RuleContext data) {
         if ("macro".equals(node.getDirectiveName())) {
             final Set<String> paramNames = new HashSet<>();
             for (final ASTReference param : node.children(ASTReference.class)) {
@@ -24,7 +25,7 @@ public class AvoidReassigningParametersRule extends AbstractVtlRule {
             for (final ASTSetDirective assignment : node.descendants(ASTSetDirective.class)) {
                 final ASTReference ref = assignment.firstChild(ASTReference.class);
                 if (ref != null && paramNames.contains(ref.getFirstToken().getImage())) {
-                    asCtx(data).addViolation(node, ref.getFirstToken().getImage());
+                    data.addViolation(node, ref.getFirstToken().getImage());
                 }
             }
         }

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterRule.java
@@ -12,11 +12,12 @@ import net.sourceforge.pmd.lang.velocity.ast.ASTDirective;
 import net.sourceforge.pmd.lang.velocity.ast.ASTReference;
 import net.sourceforge.pmd.lang.velocity.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedMacroParameterRule extends AbstractVtlRule {
 
     @Override
-    public Object visit(final ASTDirective node, final Object data) {
+    public RuleContext visit(final ASTDirective node, final RuleContext data) {
         if ("macro".equals(node.getDirectiveName())) {
             final Set<String> paramNames = new HashSet<>();
             for (final ASTReference param : node.children(ASTReference.class)) {
@@ -33,7 +34,7 @@ public class UnusedMacroParameterRule extends AbstractVtlRule {
                 }
             }
             if (!paramNames.isEmpty()) {
-                asCtx(data).addViolation(node, paramNames.toString());
+                data.addViolation(node, paramNames.toString());
             }
         }
         return super.visit(node, data);

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.velocity.ast.VtlNode;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class AvoidDeeplyNestedIfStmtsRule extends AbstractVtlRule {
@@ -30,27 +31,27 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractVtlRule {
     }
 
     @Override
-    public Object visit(ASTTemplate node, Object data) {
+    public RuleContext visit(ASTTemplate node, RuleContext data) {
         depth = 0;
         depthLimit = getProperty(PROBLEM_DEPTH_DESCRIPTOR);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(ASTIfStatement node, Object data) {
+    public RuleContext visit(ASTIfStatement node, RuleContext data) {
         return handleIf(node, data);
     }
 
     @Override
-    public Object visit(ASTElseIfStatement node, Object data) {
+    public RuleContext visit(ASTElseIfStatement node, RuleContext data) {
         return handleIf(node, data);
     }
 
-    private Object handleIf(VtlNode node, Object data) {
+    private RuleContext handleIf(VtlNode node, RuleContext data) {
         depth++;
         super.visitVtlNode(node, data);
         if (depth == depthLimit) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         depth--;
         return data;

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsRule.java
@@ -14,17 +14,18 @@ import net.sourceforge.pmd.lang.velocity.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.velocity.ast.ASTText;
 import net.sourceforge.pmd.lang.velocity.ast.VtlNode;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class CollapsibleIfStatementsRule extends AbstractVtlRule {
 
     @Override
-    public Object visit(final ASTIfStatement node, final Object data) {
+    public RuleContext visit(final ASTIfStatement node, final RuleContext data) {
         handleIfElseIf(node, data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTElseIfStatement node, final Object data) {
+    public RuleContext visit(final ASTElseIfStatement node, final RuleContext data) {
         // verify that this elseif doesn't have any siblings
         if (node.getParent().children(ASTElseIfStatement.class).count() == 1) {
             handleIfElseIf(node, data);
@@ -32,7 +33,7 @@ public class CollapsibleIfStatementsRule extends AbstractVtlRule {
         return super.visit(node, data);
     }
 
-    private void handleIfElseIf(final VtlNode node, final Object data) {
+    private void handleIfElseIf(final VtlNode node, final RuleContext data) {
         if (node.firstChild(ASTElseStatement.class) == null
                 && node.firstChild(ASTElseIfStatement.class) == null) {
             final ASTBlock ifBlock = node.firstChild(ASTBlock.class);
@@ -66,7 +67,7 @@ public class CollapsibleIfStatementsRule extends AbstractVtlRule {
                 }
             }
             if (violationFound && ifCounter == 1) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
     }

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.lang.velocity.ast.ASTTemplate;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ExcessiveTemplateLengthRule extends AbstractVtlRule {
 
@@ -33,10 +34,10 @@ public class ExcessiveTemplateLengthRule extends AbstractVtlRule {
     }
 
     @Override
-    public Object visit(final ASTTemplate node, final Object data) {
+    public RuleContext visit(final ASTTemplate node, final RuleContext data) {
 
         if (node.getEndLine() - node.getBeginLine() >= getProperty(REPORT_LEVEL)) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return data;
     }

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptRule.java
@@ -9,18 +9,19 @@ import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.velocity.ast.ASTText;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class NoInlineJavaScriptRule extends AbstractVtlRule {
     private static final Pattern SCRIPT_PATTERN = Pattern.compile("<script\\s[^>]*>", Pattern.CASE_INSENSITIVE);
     private static final Pattern SRC_PATTERN = Pattern.compile("\\ssrc\\s*=", Pattern.CASE_INSENSITIVE);
 
     @Override
-    public Object visit(final ASTText node, final Object data) {
+    public RuleContext visit(final ASTText node, final RuleContext data) {
         final Matcher matcher = SCRIPT_PATTERN.matcher(node.literal());
         while (matcher.find()) {
             final String currentMatch = matcher.group();
             if (!SRC_PATTERN.matcher(currentMatch).find()) {
-                asCtx(data).addViolation(node);
+                data.addViolation(node);
             }
         }
         return super.visit(node, data);

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtRule.java
@@ -7,13 +7,14 @@ package net.sourceforge.pmd.lang.velocity.rule.errorprone;
 import net.sourceforge.pmd.lang.velocity.ast.ASTBlock;
 import net.sourceforge.pmd.lang.velocity.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class EmptyForeachStmtRule extends AbstractVtlRule {
 
     @Override
-    public Object visit(final ASTForeachStatement node, final Object data) {
+    public RuleContext visit(final ASTForeachStatement node, final RuleContext data) {
         if (node.firstChild(ASTBlock.class).isEmpty()) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
         return super.visit(node, data);
     }

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtRule.java
@@ -10,29 +10,30 @@ import net.sourceforge.pmd.lang.velocity.ast.ASTElseStatement;
 import net.sourceforge.pmd.lang.velocity.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.velocity.ast.VtlNode;
 import net.sourceforge.pmd.lang.velocity.rule.AbstractVtlRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class EmptyIfStmtRule extends AbstractVtlRule {
     @Override
-    public Object visit(final ASTIfStatement node, final Object data) {
+    public RuleContext visit(final ASTIfStatement node, final RuleContext data) {
         handleIf(node, data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTElseIfStatement node, final Object data) {
+    public RuleContext visit(final ASTElseIfStatement node, final RuleContext data) {
         handleIf(node, data);
         return super.visit(node, data);
     }
 
     @Override
-    public Object visit(final ASTElseStatement node, final Object data) {
+    public RuleContext visit(final ASTElseStatement node, final RuleContext data) {
         handleIf(node, data);
         return super.visit(node, data);
     }
 
-    private void handleIf(final VtlNode node, final Object data) {
+    private void handleIf(final VtlNode node, final RuleContext data) {
         if (node.firstChild(ASTBlock.class).isEmpty()) {
-            asCtx(data).addViolation(node);
+            data.addViolation(node);
         }
     }
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/AbstractVfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/AbstractVfRule.java
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.visualforce.ast.VfVisitor;
 import net.sourceforge.pmd.reporting.RuleContext;
 
-public abstract class AbstractVfRule extends AbstractRule implements VfVisitor<Object, Object> {
+public abstract class AbstractVfRule extends AbstractRule implements VfVisitor<RuleContext, RuleContext> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
@@ -17,7 +17,7 @@ public abstract class AbstractVfRule extends AbstractRule implements VfVisitor<O
     }
 
     @Override
-    public Object visitNode(Node node, Object param) {
+    public RuleContext visitNode(Node node, RuleContext param) {
         node.children().forEach(n -> n.acceptVisitor(this, param));
         return param;
     }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfCsrfRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.visualforce.ast.ASTElExpression;
 import net.sourceforge.pmd.lang.visualforce.ast.ASTElement;
 import net.sourceforge.pmd.lang.visualforce.ast.ASTIdentifier;
 import net.sourceforge.pmd.lang.visualforce.rule.AbstractVfRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @author sergey.gorbaty
@@ -22,7 +23,7 @@ public class VfCsrfRule extends AbstractVfRule {
     private static final String APEX_PAGE = "apex:page";
 
     @Override
-    public Object visit(ASTElement node, Object data) {
+    public RuleContext visit(ASTElement node, RuleContext data) {
         if (APEX_PAGE.equalsIgnoreCase(node.getName())) {
             List<ASTAttribute> attribs = node.children(ASTAttribute.class).toList();
             boolean controller = false;
@@ -51,7 +52,7 @@ public class VfCsrfRule extends AbstractVfRule {
             }
 
             if (controller && isEl && valToReport != null) {
-                asCtx(data).addViolation(valToReport);
+                data.addViolation(valToReport);
             }
 
         }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.visualforce.ast.ASTText;
 import net.sourceforge.pmd.lang.visualforce.ast.VfNode;
 import net.sourceforge.pmd.lang.visualforce.rule.AbstractVfRule;
 import net.sourceforge.pmd.lang.visualforce.rule.security.internal.ElEscapeDetector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class VfHtmlStyleTagXssRule extends AbstractVfRule {
@@ -46,7 +47,7 @@ public class VfHtmlStyleTagXssRule extends AbstractVfRule {
      * }</pre>
      */
     @Override
-    public Object visit(ASTElExpression node, Object data) {
+    public RuleContext visit(ASTElExpression node, RuleContext data) {
         final VfNode nodeParent = node.getParent();
         if (!(nodeParent instanceof ASTContent)) {
             // nothing to do here.
@@ -83,7 +84,7 @@ public class VfHtmlStyleTagXssRule extends AbstractVfRule {
             ASTElExpression node,
             ASTContent contentNode,
             ASTElement elementNode,
-            Object data) {
+            RuleContext data) {
         final String previousText = getPreviousText(contentNode, node);
         final boolean isWithinSafeResource = ElEscapeDetector.startsWithSafeResource(node);
 
@@ -105,24 +106,24 @@ public class VfHtmlStyleTagXssRule extends AbstractVfRule {
         return STYLE_TAG.equalsIgnoreCase(elementNode.getLocalName());
     }
 
-    private void verifyEncodingWithinUrl(ASTElExpression elExpressionNode, Object data) {
+    private void verifyEncodingWithinUrl(ASTElExpression elExpressionNode, RuleContext data) {
 
         // only allow URLENCODING or JSINHTMLENCODING
         if (ElEscapeDetector.doesElContainAnyUnescapedIdentifiers(
                 elExpressionNode,
                 URLENCODE_JSINHTMLENCODE)) {
-            asCtx(data).addViolationWithMessage(
+            data.addViolationWithMessage(
                     elExpressionNode,
                     "Dynamic EL content within URL in style tag should be URLENCODED or JSINHTMLENCODED as appropriate");
         }
 
     }
 
-    private void verifyEncodingWithoutUrl(ASTElExpression elExpressionNode, Object data) {
+    private void verifyEncodingWithoutUrl(ASTElExpression elExpressionNode, RuleContext data) {
         if (ElEscapeDetector.doesElContainAnyUnescapedIdentifiers(
                 elExpressionNode,
                 ANY_ENCODE)) {
-            asCtx(data).addViolationWithMessage(
+            data.addViolationWithMessage(
                     elExpressionNode,
                     "Dynamic EL content in style tag should be appropriately encoded");
         }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfUnescapeElRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.visualforce.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.visualforce.ast.ASTText;
 import net.sourceforge.pmd.lang.visualforce.rule.AbstractVfRule;
 import net.sourceforge.pmd.lang.visualforce.rule.security.internal.ElEscapeDetector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -50,13 +51,13 @@ public class VfUnescapeElRule extends AbstractVfRule {
     private static final Set<ElEscapeDetector.Escaping> ANY_ENCODE = EnumSet.of(ElEscapeDetector.Escaping.ANY);
 
     @Override
-    public Object visit(ASTHtmlScript node, Object data) {
+    public RuleContext visit(ASTHtmlScript node, RuleContext data) {
         checkIfCorrectlyEscaped(node, data);
 
         return super.visit(node, data);
     }
 
-    private void checkIfCorrectlyEscaped(ASTHtmlScript node, Object data) {
+    private void checkIfCorrectlyEscaped(ASTHtmlScript node, RuleContext data) {
         // churn thru every child just once instead of twice
         for (int i = 0; i < node.getNumChildren(); i++) {
             Node n = node.getChild(i);
@@ -67,9 +68,9 @@ public class VfUnescapeElRule extends AbstractVfRule {
         }
     }
 
-    private void processElInScriptContext(ASTElExpression elExpression, Object data) {
+    private void processElInScriptContext(ASTElExpression elExpression, RuleContext data) {
         if (!properlyEscaped(elExpression)) {
-            asCtx(data).addViolation(elExpression);
+            data.addViolation(elExpression);
         }
     }
 
@@ -84,7 +85,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
     }
 
     @Override
-    public Object visit(ASTElement node, Object data) {
+    public RuleContext visit(ASTElement node, RuleContext data) {
         if (doesTagSupportEscaping(node)) {
             checkApexTagsThatSupportEscaping(node, data);
         } else {
@@ -95,7 +96,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         return super.visit(node, data);
     }
 
-    private void checkLimitedFlags(ASTElement node, Object data) {
+    private void checkLimitedFlags(ASTElement node, RuleContext data) {
         switch (node.getName().toLowerCase(Locale.ROOT)) {
         case IFRAME_CONST:
         case APEXIFRAME_CONST:
@@ -150,13 +151,13 @@ public class VfUnescapeElRule extends AbstractVfRule {
 
         if (isEL) {
             for (ASTElExpression expr : toReport) {
-                asCtx(data).addViolation(expr);
+                data.addViolation(expr);
             }
         }
 
     }
 
-    private void checkAllOnEventTags(ASTElement node, Object data) {
+    private void checkAllOnEventTags(ASTElement node, RuleContext data) {
         boolean isEL = false;
         final Set<ASTElExpression> toReport = new HashSet<>();
 
@@ -181,7 +182,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
 
         if (isEL) {
             for (ASTElExpression expr : toReport) {
-                asCtx(data).addViolation(expr);
+                data.addViolation(expr);
             }
         }
 
@@ -205,7 +206,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         return false;
     }
 
-    private void checkApexTagsThatSupportEscaping(ASTElement node, Object data) {
+    private void checkApexTagsThatSupportEscaping(ASTElement node, RuleContext data) {
         final Set<ASTElExpression> toReport = new HashSet<>();
         boolean isUnescaped = false;
         boolean isEL = false;
@@ -255,13 +256,13 @@ public class VfUnescapeElRule extends AbstractVfRule {
 
         if (hasPlaceholders && isUnescaped) {
             for (ASTElExpression expr : hasELInInnerElements(node)) {
-                asCtx(data).addViolation(expr);
+                data.addViolation(expr);
             }
         }
 
         if (isEL && isUnescaped) {
             for (ASTElExpression expr : toReport) {
-                asCtx(data).addViolation(expr);
+                data.addViolation(expr);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -699,7 +699,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.25.6</version>
+                    <version>0.25.7</version>
                     <configuration>
                         <parameter>
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>


### PR DESCRIPTION
## Describe the PR

* For each language
  * Change `AbstractFooRule` to implement `FooVisitor<RuleContext, RuleContext>` instead of just `FooVisitor`.
  * Fix rules by replacing `Object data` with `RuleContext data`
  * Remove calls to `AbstractRule.asCtx()`
  * Remove casts to `(RuleContext)`
  * Some rules in pmd-java had some accidentally public methods deprecated
* Some languages didn't need any changes, as they used `AbstractVisitorRule`, which was already fixed.
* Deprecate `AbstractRule.asCtx()`
* Added some language to adding_a_new_javacc_based_language. adding_a_new_antlr_based_language.md recommends using `AbstractVisitorRule` (see above)

## Related issues

- Fix #4814 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

