### PR TITLE
[java] Fix #2801: Add a property to OnlyOneReturnRule to allow guard ifs

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -51,7 +51,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
-import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTLabeledStatement;
@@ -909,38 +908,6 @@ public final class JavaAstUtils {
             return true;
         }
         return switchLike.isExhaustive();
-    }
-
-    /**
-     * Determine if the node argument has the typical form of a "guard if", that is
-     * an if statement with no else block, and the only thing the then block does is either
-     * return or throw an expression.
-     *
-     * Does NOT check if the node is at the beginning of a function!
-     */
-    public static boolean isGuardIf(JavaNode node) {
-        if (!(node instanceof ASTIfStatement)) {
-            return false;
-        }
-        ASTIfStatement ifStatement = (ASTIfStatement) node;
-
-        if (ifStatement.getElseBranch() != null) {
-            return false;
-        }
-
-        ASTStatement thenBranch = ifStatement.getThenBranch();
-        ASTStatement onlyStatementInThenBranch;
-        if (thenBranch instanceof ASTBlock) {
-            onlyStatementInThenBranch = ASTList.singleOrNull((ASTBlock) thenBranch);
-            if (onlyStatementInThenBranch == null) {
-                return false;
-            }
-        } else {
-            onlyStatementInThenBranch = thenBranch;
-        }
-
-        return onlyStatementInThenBranch instanceof ASTReturnStatement
-                || onlyStatementInThenBranch instanceof ASTThrowStatement;
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -51,6 +51,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTLabeledStatement;
@@ -308,6 +309,17 @@ public final class JavaAstUtils {
                             )
                             .last();
         return (ASTExpression) Objects.requireNonNull(last);
+    }
+
+    /**
+     * Given a statement inside a method, returns the ancestor statement that is directly below the method body.
+     */
+    public static @NonNull ASTStatement getMethodLevelStatement(ASTStatement expr) {
+        JavaNode last = expr
+                .ancestorsOrSelf()
+                .takeWhile(node -> !(node.getParent() instanceof ASTMethodDeclaration))
+                .last();
+        return (ASTStatement) Objects.requireNonNull(last);
     }
 
     /**
@@ -898,4 +910,37 @@ public final class JavaAstUtils {
         }
         return switchLike.isExhaustive();
     }
+
+    /**
+     * Determine if the node argument has the typical form of a "guard if", that is
+     * an if statement with no else block, and the only thing the then block does is either
+     * return or throw an expression.
+     *
+     * Does NOT check if the node is at the beginning of a function!
+     */
+    public static boolean isGuardIf(JavaNode node) {
+        if (!(node instanceof ASTIfStatement)) {
+            return false;
+        }
+        ASTIfStatement ifStatement = (ASTIfStatement) node;
+
+        if (ifStatement.getElseBranch() != null) {
+            return false;
+        }
+
+        ASTStatement thenBranch = ifStatement.getThenBranch();
+        ASTStatement onlyStatementInThenBranch;
+        if (thenBranch instanceof ASTBlock) {
+            onlyStatementInThenBranch = ASTList.singleOrNull((ASTBlock) thenBranch);
+            if (onlyStatementInThenBranch == null) {
+                return false;
+            }
+        } else {
+            onlyStatementInThenBranch = thenBranch;
+        }
+
+        return onlyStatementInThenBranch instanceof ASTReturnStatement
+                || onlyStatementInThenBranch instanceof ASTThrowStatement;
+    }
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -4,11 +4,15 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.getMethodLevelStatement;
+
 import java.util.List;
 
-import net.sourceforge.pmd.lang.ast.NodeStream;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -20,10 +24,16 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
                     .defaultValues("compareTo", "equals")
                     .desc("Method names that are ignored from checking for only one return.")
                     .build();
+    private static final PropertyDescriptor<Boolean> ALLOW_GUARD_IFS
+            = PropertyFactory.booleanProperty("allowGuardIfs")
+                    .defaultValue(false)
+                    .desc("Are guard ifs allowed? Guard ifs are statements \"like if (cond()) return\" or \"if (cond()) throw exception\" at the beginning of a method.")
+                    .build();
 
     public OnlyOneReturnRule() {
         super(ASTMethodDeclaration.class);
         definePropertyDescriptor(IGNORED_METHOD_NAMES);
+        definePropertyDescriptor(ALLOW_GUARD_IFS);
     }
 
     @Override
@@ -32,10 +42,15 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
             return null;
         }
 
-        NodeStream<ASTReturnStatement> returnsExceptLast =
-            node.getBody().descendants(ASTReturnStatement.class).dropLast(1);
+        List<ASTReturnStatement> returnsToViolate =
+            node.getBody().descendants(ASTReturnStatement.class).dropLast(1).toList();
 
-        for (ASTReturnStatement returnStmt : returnsExceptLast) {
+        if (getProperty(ALLOW_GUARD_IFS)) {
+            List<ASTIfStatement> guardIfs = findGuardIfs(node.getBody());
+            removeGuardIfs(returnsToViolate, guardIfs);
+        }
+
+        for (ASTReturnStatement returnStmt : returnsToViolate) {
             asCtx(data).addViolation(returnStmt);
         }
         return null;
@@ -43,5 +58,23 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
 
     private boolean isIgnoredMethod(ASTMethodDeclaration node) {
         return getProperty(IGNORED_METHOD_NAMES).contains(node.getName());
+    }
+
+    private List<ASTIfStatement> findGuardIfs(ASTBlock body) {
+        return body.children()
+                .takeWhile(node -> JavaAstUtils.isGuardIf(node))
+                .map(node -> (ASTIfStatement) node)
+                .toList();
+    }
+
+    /**
+     * removes return statements, if they are part of a guard if.
+     */
+    private void removeGuardIfs(List<ASTReturnStatement> returnsToViolate, List<ASTIfStatement> guardIfs) {
+        while (!returnsToViolate.isEmpty()
+                && guardIfs.contains(getMethodLevelStatement(returnsToViolate.get(0)))
+        ) {
+            returnsToViolate.remove(0);
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.getMethodLevelStatement;
+import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isGuardIf;
 
 import java.util.List;
 
@@ -12,7 +13,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
-import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -62,7 +62,7 @@ public class OnlyOneReturnRule extends AbstractJavaRulechainRule {
 
     private List<ASTIfStatement> findGuardIfs(ASTBlock body) {
         return body.children()
-                .takeWhile(node -> JavaAstUtils.isGuardIf(node))
+                .takeWhile(node -> isGuardIf(node))
                 .map(node -> (ASTIfStatement) node)
                 .toList();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -18,16 +18,21 @@ import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
+import net.sourceforge.pmd.lang.java.ast.ASTList;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
@@ -475,5 +480,36 @@ public final class JavaRuleUtil {
         return false;
     }
 
+    /**
+     * Determine if the node argument has the typical form of a "guard if", that is
+     * an if statement with no else block, and the only thing the then block does is either
+     * return or throw an expression.
+     *
+     * Does NOT check if the node is at the beginning of a function!
+     */
+    public static boolean isGuardIf(JavaNode node) {
+        if (!(node instanceof ASTIfStatement)) {
+            return false;
+        }
+        ASTIfStatement ifStatement = (ASTIfStatement) node;
+
+        if (ifStatement.getElseBranch() != null) {
+            return false;
+        }
+
+        ASTStatement thenBranch = ifStatement.getThenBranch();
+        ASTStatement onlyStatementInThenBranch;
+        if (thenBranch instanceof ASTBlock) {
+            onlyStatementInThenBranch = ASTList.singleOrNull((ASTBlock) thenBranch);
+            if (onlyStatementInThenBranch == null) {
+                return false;
+            }
+        } else {
+            onlyStatementInThenBranch = thenBranch;
+        }
+
+        return onlyStatementInThenBranch instanceof ASTReturnStatement
+                || onlyStatementInThenBranch instanceof ASTThrowStatement;
+    }
 
 }

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1215,7 +1215,8 @@ public class ClassInDefaultPackage {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#onlyonereturn">
         <description>
 A method should have only one exit point, and that should be the last statement in the method.
-If allowGuardIfs is set to true, an unlimited amount of guard ifs at the beginning of the method are allows.
+
+If the property `allowGuardIfs` is set to true, an unlimited amount of guard ifs at the beginning of the method are allowed.
 A guard if is an if of the form `if (cond) { return somevalue; }` or `if (cond) { throw ex }`. In the example below,
 the first exit is part of a guard if, so it isn't counted.
         </description>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1215,6 +1215,9 @@ public class ClassInDefaultPackage {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#onlyonereturn">
         <description>
 A method should have only one exit point, and that should be the last statement in the method.
+If allowGuardIfs is set to true, an unlimited amount of guard ifs at the beginning of the method are allows.
+A guard if is an if of the form `if (cond) { return somevalue; }` or `if (cond) { throw ex }`. In the example below,
+the first exit is part of a guard if, so it isn't counted.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
@@ -191,4 +191,146 @@ public class Person implements Comparable<Person> {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>one guard if</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public int foo(int x) {
+        if (x == 0) {
+            return 3;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>two guard ifs</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public int foo(int x) {
+        if (x == 0) {
+            return 3;
+        }
+        if (x == 1) {
+            return 4;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>two guard ifs, first one throws</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public int foo(int x) {
+        if (x == 0) {
+            throw IllegalArgumentException();
+        }
+        if (x == 1) {
+            return 4;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>guard if without braces</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public int foo(int x) {
+        if (x == 0)
+            return 3;
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>if there's a statement before the if, it's not a guard if</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int x) {
+        x++;
+        if (x == 0) {
+            return 3;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>if there's an else statement, it's not a guard if</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int x) {
+        if (x == 0) {
+            return 3;
+        } else {}
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>if there's more stuff in the if block, it's not a guard if</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int x) {
+        if (x == 0) {
+            x++;
+            return 3;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>if there's no return, it's not a guard if</description>
+        <rule-property name="allowGuardIfs">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void foo(int x) {
+        if (x == 0) {
+            x++;
+        }
+        if (x == 1) {
+            return 3;
+        }
+        return 2;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Add a new property to [OnlyOneReturnRule](https://docs.pmd-code.org/latest/pmd_rules_java_codestyle.html#onlyonereturn) called `allowGuardIfs`. If that property is set to true, returns as part of guard ifs are ignored. A guard if is defined as an if statement, that is
- at the beginning of a method
- the then part only returns or throws
- has no else block

## Related issues

- Fix #2801 (not quite, the issue is only about null checks. I figured let's go one step further)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

