### PR TITLE
[java] Fix #3212: Enhance UseStandardCharsets

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -4,14 +4,20 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.lang.java.types.JMethodSig;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
@@ -25,19 +31,79 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
 
     private static final InvocationMatcher CHARSET_FOR_NAME = InvocationMatcher.parse("java.nio.charset.Charset#forName(java.lang.String)");
     private static final Set<String> STANDARD_CHARSET_EXISTS = new HashSet<>(Arrays.asList("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16"));
+    private static final String CHARSET = "java.nio.charset.Charset";
 
     public UseStandardCharsetsRule() {
         super(ASTConstructorCall.class, ASTMethodCall.class);
     }
 
     @Override
-    public Object visit(ASTMethodCall call, Object data) {
+    public RuleContext visit(ASTMethodCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (CHARSET_FOR_NAME.matchesCall(call)
                 && STANDARD_CHARSET_EXISTS.contains(call.getArguments().get(0).getConstValue())
         ) {
-            ((RuleContext) data).addViolation(call);
+            ctx.addViolation(call);
         }
 
-        return data;
+        for (int i = 0; i < call.getArguments().size(); i++) {
+            checkIthArgument(ctx, call, i);
+        }
+
+        return ctx;
+    }
+
+    @Override
+    public RuleContext visit(ASTConstructorCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        for (int i = 0; i < call.getArguments().size(); i++) {
+            checkIthArgument(ctx, call, i);
+        }
+
+        return ctx;
+    }
+
+    private void checkIthArgument(RuleContext ctx, InvocationNode call, int index) {
+        ASTExpression ex = call.getArguments().get(index);
+        if (STANDARD_CHARSET_EXISTS.contains(ex.getConstValue())) {
+            JMethodSig callSignature = call.getMethodType();
+            Stream<JMethodSig> otherSignatures = (call instanceof ASTMethodCall)
+                    ? ((ASTMethodCall) call).getQualifier().getTypeMirror().streamMethods(sig -> true)
+                    : ((ASTConstructorCall) call).getTypeNode().getTypeMirror().getConstructors().stream();
+            long count = otherSignatures
+                    .filter(sig -> Modifier.isPublic(sig.getModifiers()))
+                    .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
+                    .filter(sig -> CHARSET.equals(sig.getFormalParameters().get(index).toString()))
+                    .count();
+            if (count > 0) {
+                ctx.addViolation(call);
+            }
+        }
+    }
+
+    /**
+     * returns true iff the two method signatures are identical - except for the indexth argument
+     */
+    private boolean isSameSignatureExcept(JMethodSig a, JMethodSig b, int index) {
+        if (!a.getName().equals(b.getName())) {
+            return false;
+        }
+        if (a.getArity() != b.getArity()) {
+            return false;
+        }
+        for (int i = 0; i < a.getArity(); i++) {
+            if (i == index) {
+                continue;
+            }
+
+            JTypeMirror aParameter = a.getFormalParameters().get(i);
+            JTypeMirror bParameter = b.getFormalParameters().get(i);
+            if (!aParameter.equals(bParameter)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -22,10 +22,10 @@ import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
- * Using the constants is less error prone, and can provide a small performance advantage compared to
+ * Using the constants is less error-prone, and can provide a small performance advantage compared to
  * `Charset.forName(...)` or `String.getBytes(String)` since no scan across the internal `Charset` caches is needed.
  *
- * @since 6.34.0 (as XPath) / 7.24.0 (as Java)
+ * @since 6.34.0 (as XPath) / 7.25.0 (as Java)
  */
 public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -69,9 +69,7 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
         ASTExpression ex = call.getArguments().get(index);
         if (STANDARD_CHARSET_EXISTS.contains(ex.getConstValue())) {
             JMethodSig callSignature = call.getMethodType();
-            Stream<JMethodSig> otherSignatures = (call instanceof ASTMethodCall)
-                    ? ((ASTMethodCall) call).getQualifier().getTypeMirror().streamMethods(sig -> true)
-                    : ((ASTConstructorCall) call).getTypeNode().getTypeMirror().getConstructors().stream();
+            Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
             long count = otherSignatures
                     .filter(sig -> Modifier.isPublic(sig.getModifiers()))
                     .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
@@ -81,6 +79,14 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
                 ctx.addViolation(call);
             }
         }
+    }
+
+    private Stream<JMethodSig> streamMethodSignatures(InvocationNode call) {
+        if (call instanceof ASTConstructorCall) {
+            return ((ASTConstructorCall) call).getTypeNode().getTypeMirror().getConstructors().stream();
+        }
+        ASTMethodCall methodCall = (ASTMethodCall) call;
+        return methodCall.getMethodType().getDeclaringType().streamMethods(sig -> true);
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -23,7 +23,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
 /**
  * Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
  * Using the constants is less error prone, and can provide a small performance advantage compared to
- * `Charset.forName(...)` since no scan across the internal `Charset` caches is needed.
+ * `Charset.forName(...)` or `String.getBytes(String)` since no scan across the internal `Charset` caches is needed.
  *
  * @since 6.34.0 (as XPath) / 7.24.0 (as Java)
  */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -1,0 +1,43 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
+ * Using the constants is less error prone, and can provide a small performance advantage compared to
+ * `Charset.forName(...)` since no scan across the internal `Charset` caches is needed.
+ *
+ * @since 6.34.0 (as XPath) / 7.24.0 (as Java)
+ */
+public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
+
+    private static final InvocationMatcher CHARSET_FOR_NAME = InvocationMatcher.parse("java.nio.charset.Charset#forName(java.lang.String)");
+    private static final Set<String> STANDARD_CHARSET_EXISTS = new HashSet<>(Arrays.asList("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16"));
+
+    public UseStandardCharsetsRule() {
+        super(ASTConstructorCall.class, ASTMethodCall.class);
+    }
+
+    @Override
+    public Object visit(ASTMethodCall call, Object data) {
+        if (CHARSET_FOR_NAME.matchesCall(call)
+                && STANDARD_CHARSET_EXISTS.contains(call.getArguments().get(0).getConstValue())
+        ) {
+            ((RuleContext) data).addViolation(call);
+        }
+
+        return data;
+    }
+}

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -2170,7 +2170,7 @@ public class Foo {
           since="6.34.0"
           minimumLanguageVersion="1.7"
           message="Please use StandardCharsets constants"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.UseStandardCharsetsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#usestandardcharsets">
         <description>
 Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
@@ -2178,19 +2178,6 @@ Using the constants is less error prone, and can provide a small performance adv
 since no scan across the internal `Charset` caches is needed.
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//MethodCall[@MethodName = 'forName'][pmd-java:typeIs('java.nio.charset.Charset')]
-    [
-        ArgumentList/StringLiteral
-            [@Image = ('"US-ASCII"', '"ISO-8859-1"', '"UTF-8"', '"UTF-16BE"', '"UTF-16LE"', '"UTF-16"')]
-    ]
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 public class UseStandardCharsets {

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -2181,17 +2181,20 @@ or `String.getBytes(String)` since no scan across the internal `Charset` caches 
         <example>
 <![CDATA[
 public class UseStandardCharsets {
-    public void run() {
-
+    public void bad() {
         // looking up the charset dynamically
         try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-8"))) {
             osw.write("test");
         }
+        "foo".getBytes("UTF-8");
+    }
 
+    public void good() {
         // best to use StandardCharsets
         try (OutputStreamWriter osw = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
             osw.write("test");
         }
+        "foo".getBytes(StandardCharsets.UTF_8);
     }
 }
 ]]>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -2175,7 +2175,7 @@ public class Foo {
         <description>
 Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
 Using the constants is less error prone, and can provide a small performance advantage compared to `Charset.forName(...)`
-since no scan across the internal `Charset` caches is needed.
+or `String.getBytes(String)` since no scan across the internal `Charset` caches is needed.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -240,4 +240,40 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>call inside the same class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String x) {
+        foo(x, "UTF-8");
+    }
+
+    public void foo(String x, String enc) {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>call inside the same class, alternative exists</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public void foo(String x) {
+        foo(x, "UTF-8");
+    }
+
+    public void foo(String x, String enc) {
+    }
+
+    public void foo(String x, Charset enc) {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -154,5 +154,90 @@ public class Foo {
 }
         ]]></code>
     </test-code>
-    
+
+    <test-code>
+        <description>fail, String.getBytes(String) - UTF-8</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("UTF-8");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, String.getBytes(Charset) - UTF-8 from StandardCharsets</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.nio.charset.StandardCharsets;
+
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes(StandardCharsets.UTF_8);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, String.getBytes(String) - ISO-8859-2, no constant for it</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("ISO-8859-2");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, new Scanner(Path, String) - UTF-8</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Scanner;
+import java.nio.file.Path;
+
+public class Foo {
+    public static void charset(Path path) {
+        new Scanner(path, "UTF-8");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, new Scanner(Path, Charset) - UTF-8 from StandardCharsets</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Scanner;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+
+public class Foo {
+    public static void charset(Path path) {
+        new Scanner(path, StandardCharsets.UTF_8);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, new Scanner(Path, String) - ISO-8859-2, no constant for it</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Scanner;
+import java.nio.file.Path;
+
+public class Foo {
+    public static void charset(Path path) {
+        new Scanner(path, "ISO-8859-2");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR changes UseStandardCharsets to not only violate use of `Charset.forName`, but also looks for method calls where a charset is named by String while a similar method that takes a Charset exists.

I thought about using a long list of InvocationMatchers (like in RelianceOnDefaultCharsetRule), but decided to try a different approach: The code looks for a method of the same name, where the String argument is replaced with a Charset argument. This way this should automatically work for non-JCL (like apache commons-io mentioned in the ticket) as well.

## Related issues

- Fix #3212

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

