### PR TITLE
[java][apex] Remove dependency on guava. It seems to be unused?

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -78,11 +78,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <scope>compile</scope>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -257,11 +257,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -959,11 +959,6 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>2.6</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
-            </dependency>
 
             <!-- scala-reflect and scala-library needed by pmd-apex via apex-link -->
             <dependency>


### PR DESCRIPTION
## Describe the PR

Is there a reason we're depending on google guava? `./mvnw clean verify` runs clean without it.

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

