### PR TITLE
chore(deps-dev): Bump addressable from 2.8.9 to 2.9.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.1.1)


### PR DESCRIPTION
* Fixes https://github.com/pmd/pmd/security/dependabot/100
