### PR TITLE
[java] Fix #4288: Document that CallSuperFirst and CallSuperLast are android only

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -806,7 +806,11 @@ public String bar(String string) {
           message="super should be called at the start of the method"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#callsuperfirst">
-        <description>Super should be called at the start of the method</description>
+        <description>
+Super should be called at the start of the method
+
+This rule is intended for Android development. Don't use for general purpose java development!
+        </description>
         <priority>3</priority>
         <properties>
             <property name="xpath">
@@ -851,6 +855,8 @@ public class DummyActivity extends Activity {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#callsuperlast">
         <description>
 Super should be called at the end of the method
+
+This rule is intended for Android development. Don't use for general purpose java development!
         </description>
         <priority>3</priority>
         <properties>


### PR DESCRIPTION
## Describe the PR

Document that CallSuperFirst and CallSuperLast are android only.

## Related issues

- Fix #4288 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [n/a] Passing all unit tests
- [n/a] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

