### PR TITLE
[java] Fix #6602: Fix false negative in LocalVariableCouldBeFinalRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -6,12 +6,14 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
+import net.sourceforge.pmd.lang.java.ast.ASTForInit;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
 
@@ -24,24 +26,39 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+    public RuleContext visit(ASTLocalVariableDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.isFinal()) { // also for implicit finals, like resources, or lombok.val
-            return data;
+            return ctx;
         }
         if (getProperty(IGNORE_FOR_EACH) && node.getParent() instanceof ASTForeachStatement) {
-            return data;
+            return ctx;
         }
+        if (node.getParent() instanceof ASTForInit) {
+            return specialCaseForInit(node, ctx);
+        }
+        for (ASTVariableId vid : node.getVarIds()) {
+            if (!JavaAstUtils.isNeverUsed(vid) && JavaAstUtils.isEffectivelyFinal(vid)) {
+                ctx.addViolation(vid, vid.getName());
+            }
+        }
+        return ctx;
+    }
+
+    private RuleContext specialCaseForInit(ASTLocalVariableDeclaration node, RuleContext ctx) {
+        // See https://github.com/pmd/pmd/issues/1619 for why this is necessary
         if (node.getVarIds().all(JavaAstUtils::isEffectivelyFinal)) {
             // All variables declared in this ASTLocalVariableDeclaration need to be
             // effectively final, otherwise we cannot just add a final modifier.
             for (ASTVariableId vid : node.getVarIds()) {
                 if (!JavaAstUtils.isNeverUsed(vid)) {
                     // filter out unused variables
-                    asCtx(data).addViolation(vid, vid.getName());
+                    ctx.addViolation(vid, vid.getName());
                 }
             }
         }
-        return data;
+        return ctx;
     }
 
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
@@ -447,16 +447,20 @@ public class Test {
     </test-code>
 
     <test-code>
-        <description>[java] false negative in LocalVariableCouldBeFinal when multiple variables are declared in the same line #6602</description>
+        <description>[java] false negative in LocalVariableCouldBeFinal when multiple variables are declared in the same line #6602, verify message location</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
+        <expected-linenumbers>4-4</expected-linenumbers>
         <expected-messages>
             <message>Local variable 'j' could be declared final</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
     void foo(boolean cond1) {
-        int i=0, j=1;
+        int i=0,
+            j
+            =
+            1
+            ;
 
         if (cond1) {
             i = 3;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
@@ -450,6 +450,9 @@ public class Test {
         <description>[java] false negative in LocalVariableCouldBeFinal when multiple variables are declared in the same line #6602</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable 'j' could be declared final</message>
+        </expected-messages>
         <code><![CDATA[
 class Foo {
     void foo(boolean cond1) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
@@ -312,6 +312,7 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>#1619 FP with loop variable</description>
         <expected-problems>0</expected-problems>
@@ -323,6 +324,7 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>#3122 should consider blank variables</description>
         <expected-problems>2</expected-problems>
@@ -362,6 +364,7 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>#3122 should consider blank variables</description>
         <expected-problems>1</expected-problems>
@@ -390,6 +393,7 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description> [java] LocalVariableCouldBeFinal false positive with try/catch #5046 </description>
         <expected-problems>0</expected-problems>
@@ -410,6 +414,7 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>[java] LocalVariableCouldBeFinal false-positive with lombok.val #5079</description>
         <expected-problems>0</expected-problems>
@@ -439,5 +444,23 @@ public class Test {
                 }
             }
             ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] false negative in LocalVariableCouldBeFinal when multiple variables are declared in the same line #6602</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+class Foo {
+    void foo(boolean cond1) {
+        int i=0, j=1;
+
+        if (cond1) {
+            i = 3;
+        }
+
+        System.out.println(i + " " + j);
+    }
+}            ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Special handling for multiple declarations in one line was applied unconditionally. Should have been only applied if those multiple declaration were inside an ASTForInit.

## Related issues

- Fix #6602

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

