### PR TITLE
[java] Fix #3288: New rule JUnit5TestNoPrivateModifierRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
@@ -1,0 +1,43 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PRIVATE;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Class;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Method;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+public class JUnit5TestNoPrivateModifierRule extends AbstractJavaRulechainRule {
+
+    public JUnit5TestNoPrivateModifierRule() {
+        super(ASTClassDeclaration.class, ASTMethodDeclaration.class);
+    }
+
+    @Override
+    public RuleContext visit(ASTClassDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isJUnit5Class(node) && node.hasVisibility(V_PRIVATE)) {
+            ctx.addViolation(node);
+        }
+
+        return ctx;
+    }
+
+    @Override
+    public RuleContext visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isJUnit5Method(node) && node.hasVisibility(V_PRIVATE)) {
+            ctx.addViolation(node);
+        }
+
+        return ctx;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
@@ -13,6 +13,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
+/**
+ * @since 7.25.0
+ */
 public class JUnit5TestNoPrivateModifierRule extends AbstractJavaRulechainRule {
 
     public JUnit5TestNoPrivateModifierRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
@@ -23,7 +23,7 @@ public class JUnit5TestNoPrivateModifierRule extends AbstractJavaRulechainRule {
     public RuleContext visit(ASTClassDeclaration node, Object data) {
         RuleContext ctx = (RuleContext) data;
 
-        if (isJUnit5Class(node) && node.hasVisibility(V_PRIVATE)) {
+        if (isJUnit5Class(node.getTypeMirror()) && node.hasVisibility(V_PRIVATE)) {
             ctx.addViolation(node);
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierRule.java
@@ -26,7 +26,7 @@ public class JUnit5TestNoPrivateModifierRule extends AbstractJavaRulechainRule {
     public RuleContext visit(ASTClassDeclaration node, Object data) {
         RuleContext ctx = (RuleContext) data;
 
-        if (isJUnit5Class(node.getTypeMirror()) && node.hasVisibility(V_PRIVATE)) {
+        if (isJUnit5Class(node) && node.hasVisibility(V_PRIVATE)) {
             ctx.addViolation(node);
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -110,18 +110,13 @@ public final class TestFrameworksUtil {
     }
 
     public static boolean isJUnit5Method(ASTMethodDeclaration method) {
-        return method.getDeclaredAnnotations().any(
-            it -> {
-                String canonicalName = it.getTypeMirror().getSymbol().getCanonicalName();
-                return JUNIT5_ALL_TEST_ANNOTS.contains(canonicalName);
-            }
-        );
+        return isJUnit5Method(method.getSymbol());
     }
 
-    public static boolean isJUnit5Method(JMethodSymbol methodSymbol) {
-        return methodSymbol.getDeclaredAnnotations().stream().anyMatch(it -> {
-            return JUNIT5_ALL_TEST_ANNOTS.contains(it.getBinaryName());
-        });
+    private static boolean isJUnit5Method(JMethodSymbol methodSymbol) {
+        return methodSymbol.getDeclaredAnnotations().stream().anyMatch(
+                it -> JUNIT5_ALL_TEST_ANNOTS.contains(it.getBinaryName())
+        );
     }
 
     public static boolean isJUnit3Method(ASTMethodDeclaration method) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -9,6 +9,7 @@ import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
@@ -155,7 +156,9 @@ public final class TestFrameworksUtil {
                    .any(TestFrameworksUtil::isTestMethod));
     }
 
-    public static boolean isJUnit5Class(JClassType typeMirror) {
+    public static boolean isJUnit5Class(ASTClassDeclaration node) {
+        JClassType typeMirror = node.getTypeMirror();
+
         return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
                 && typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
                         .findAny().isPresent();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -154,12 +154,8 @@ public final class TestFrameworksUtil {
 
     public static boolean isJUnit5Class(ASTTypeDeclaration classDeclaration) {
         return classDeclaration.isRegularClass() && !classDeclaration.isAbstract() && !classDeclaration.isNested()
-                && classDeclaration.getTypeMirror().streamMethods(x -> true)
-                        .map(x -> x.getSymbol().tryGetNode())
-                        .filter(x -> x != null)
-                        .filter(x -> x instanceof ASTMethodDeclaration)
-                        .map(x -> (ASTMethodDeclaration) x)
-                        .anyMatch(TestFrameworksUtil::isJUnit5Method);
+                && classDeclaration.getDeclarations(ASTMethodDeclaration.class)
+                        .any(TestFrameworksUtil::isJUnit5Method);
     }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -15,7 +15,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
+import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
@@ -116,6 +118,12 @@ public final class TestFrameworksUtil {
         );
     }
 
+    public static boolean isJUnit5Method(JMethodSymbol methodSymbol) {
+        return methodSymbol.getDeclaredAnnotations().stream().anyMatch(it -> {
+            return JUNIT5_ALL_TEST_ANNOTS.contains(it.getBinaryName());
+        });
+    }
+
     public static boolean isJUnit3Method(ASTMethodDeclaration method) {
         return isJUnit3Class(method.getEnclosingType())
             && isJunit3MethodSignature(method);
@@ -152,10 +160,10 @@ public final class TestFrameworksUtil {
                    .any(TestFrameworksUtil::isTestMethod));
     }
 
-    public static boolean isJUnit5Class(ASTTypeDeclaration classDeclaration) {
-        return classDeclaration.isRegularClass() && !classDeclaration.isAbstract() && !classDeclaration.isNested()
-                && classDeclaration.getDeclarations(ASTMethodDeclaration.class)
-                        .any(TestFrameworksUtil::isJUnit5Method);
+    public static boolean isJUnit5Class(JClassType typeMirror) {
+        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
+                && typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
+                        .findAny().isPresent();
     }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -152,6 +152,11 @@ public final class TestFrameworksUtil {
                    .any(TestFrameworksUtil::isTestMethod));
     }
 
+    public static boolean isJUnit5Class(ASTTypeDeclaration classDeclaration) {
+        return classDeclaration.isRegularClass() && !classDeclaration.isAbstract() && !classDeclaration.isNested()
+                && classDeclaration.getDeclarations(ASTMethodDeclaration.class)
+                        .any(TestFrameworksUtil::isJUnit5Method);
+    }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {
         return innerClassDecl.isAnnotationPresent(JUNIT5_NESTED);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -154,8 +154,12 @@ public final class TestFrameworksUtil {
 
     public static boolean isJUnit5Class(ASTTypeDeclaration classDeclaration) {
         return classDeclaration.isRegularClass() && !classDeclaration.isAbstract() && !classDeclaration.isNested()
-                && classDeclaration.getDeclarations(ASTMethodDeclaration.class)
-                        .any(TestFrameworksUtil::isJUnit5Method);
+                && classDeclaration.getTypeMirror().streamMethods(x -> true)
+                        .map(x -> x.getSymbol().tryGetNode())
+                        .filter(x -> x != null)
+                        .filter(x -> x instanceof ASTMethodDeclaration)
+                        .map(x -> (ASTMethodDeclaration) x)
+                        .anyMatch(TestFrameworksUtil::isJUnit5Method);
     }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2062,7 +2062,7 @@ public class JumbledIncrementerRule1 {
 
     <rule name="JUnit5TestNoPrivateModifier"
           language="java"
-          since="7.24.0"
+          since="7.25.0"
           message="JUnit tests cannot be private"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.JUnit5TestNoPrivateModifierRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#junit5testnoprivatemodifier">

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2060,6 +2060,70 @@ public class JumbledIncrementerRule1 {
         </example>
     </rule>
 
+    <rule name="JUnit5TestNoPrivateModifier"
+          language="java"
+          since="7.24.0"
+          message="JUnit tests cannot be private"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#junit5testnoprivatemodifier">
+        <description>
+            JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//ClassDeclaration[
+    (: a Junit 5 test class, ie, it has methods with the annotation :)
+    @Interface = false() and
+    ClassBody/MethodDeclaration
+    [ModifierList/Annotation[
+               pmd-java:typeIs('org.junit.jupiter.api.Test')
+            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+    ]]
+]/(
+       self::*[@Abstract = false() and @Visibility = ("private")]
+|      ClassBody/MethodDeclaration
+       [@Visibility = ("private")]
+       [ModifierList/Annotation[
+               pmd-java:typeIs('org.junit.jupiter.api.Test')
+            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+       ]]
+)
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+import org.junit.jupiter.api.Test;
+
+//bad
+class MyTests {
+    @Test
+    private void testFoo() { }
+}
+
+//bad
+private class MyTests {
+    @Test
+    void testFoo() { }
+}
+
+//good
+class MyTests {
+    @Test
+    void testFoo() { }
+}
+        </example>
+    </rule>
+
     <rule name="JUnitSpelling"
           language="java"
           since="1.0"

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2064,43 +2064,12 @@ public class JumbledIncrementerRule1 {
           language="java"
           since="7.24.0"
           message="JUnit tests cannot be private"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.JUnit5TestNoPrivateModifierRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#junit5testnoprivatemodifier">
         <description>
             JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-                    <![CDATA[
-//ClassDeclaration[
-    (: a Junit 5 test class, ie, it has methods with the annotation :)
-    @Interface = false() and
-    ClassBody/MethodDeclaration
-    [ModifierList/Annotation[
-               pmd-java:typeIs('org.junit.jupiter.api.Test')
-            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-    ]]
-]/(
-       self::*[@Abstract = false() and @Visibility = ("private")]
-|      ClassBody/MethodDeclaration
-       [@Visibility = ("private")]
-       [ModifierList/Annotation[
-               pmd-java:typeIs('org.junit.jupiter.api.Test')
-            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-       ]]
-)
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 import org.junit.jupiter.api.Test;
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2066,9 +2066,12 @@ public class JumbledIncrementerRule1 {
           message="JUnit tests cannot be private"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.JUnit5TestNoPrivateModifierRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#junit5testnoprivatemodifier">
-        <description>
-            JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework
-        </description>
+        <description><![CDATA[
+JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework:
+
+> Test classes, test methods, and lifecycle methods are not required to be `public`, but they must not be `private`.
+> — [JUnit Documentation](https://docs.junit.org/6.0.3/writing-tests/test-classes-and-methods.html)
+        ]]></description>
         <priority>3</priority>
         <example>
 import org.junit.jupiter.api.Test;

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2070,6 +2070,7 @@ public class JumbledIncrementerRule1 {
 JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework:
 
 > Test classes, test methods, and lifecycle methods are not required to be `public`, but they must not be `private`.
+>
 > — [JUnit Documentation](https://docs.junit.org/6.0.3/writing-tests/test-classes-and-methods.html)
         ]]></description>
         <priority>3</priority>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2070,8 +2070,8 @@ public class JumbledIncrementerRule1 {
 JUnit 5/6 tests cannot be private. Otherwise, they won't be found by the framework:
 
 > Test classes, test methods, and lifecycle methods are not required to be `public`, but they must not be `private`.
->
-> — [JUnit Documentation](https://docs.junit.org/6.0.3/writing-tests/test-classes-and-methods.html)
+
+— [JUnit Documentation](https://docs.junit.org/6.0.3/writing-tests/test-classes-and-methods.html)
         ]]></description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnit5TestNoPrivateModifierTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class JUnit5TestNoPrivateModifierTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/juni5testnoprivatemodifier/ParentWithTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/juni5testnoprivatemodifier/ParentWithTest.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.juni5testnoprivatemodifier;
+
+import org.junit.jupiter.api.Test;
+
+public abstract class ParentWithTest {
+    @Test
+    void testRegular() {
+        // nothing
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/junit5testnoprivatemodifier/ParentWithTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/junit5testnoprivatemodifier/ParentWithTest.java
@@ -2,7 +2,7 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.lang.java.rule.errorprone.juni5testnoprivatemodifier;
+package net.sourceforge.pmd.lang.java.rule.errorprone.junit5testnoprivatemodifier;
 
 import org.junit.jupiter.api.Test;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -91,7 +91,7 @@ private class Child extends Parent {}
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
-import net.sourceforge.pmd.lang.java.rule.errorprone.juni5testnoprivatemodifier.ParentWithTest;
+import net.sourceforge.pmd.lang.java.rule.errorprone.junit5testnoprivatemodifier.ParentWithTest;
 
 private class Child extends ParentWithTest {}
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -69,4 +69,30 @@ class MyTests {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>test class must not be private, even if the test methods are in a parent class</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+abstract class Parent {
+    @Test
+    void testRegular() { }
+}
+
+private class Child extends Parent {}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>non-test class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+private class NoTest {
+    void notATest() { }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -2,7 +2,7 @@
 <test-data
         xmlns="http://pmd.sourceforge.net/rule-tests"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_1_0.xsd">
 
     <test-code>
         <description>test must not be private</description>
@@ -70,7 +70,7 @@ class MyTests {
         ]]></code>
     </test-code>
 
-    <test-code>
+    <test-code disabled="true">
         <description>test class must not be private, even if the test methods are in a parent class</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>8</expected-linenumbers>
@@ -83,6 +83,17 @@ abstract class Parent {
 }
 
 private class Child extends Parent {}
+        ]]></code>
+    </test-code>
+
+    <test-code disabled="true">
+        <description>test class must not be private, even if the test methods are in a parent class (parent is in different .class file)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.juni5testnoprivatemodifier.ParentWithTest;
+
+private class Child extends ParentWithTest {}
         ]]></code>
     </test-code>
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>test must not be private</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+    @Test
+    private void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>test class must not be private</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+private class MyTests {
+    @Test
+    void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>other kinds of tests</description>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>4,6,8,10,12</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+
+private class MyTests {
+    @RepeatedTest
+    private void testRepeated() { }
+    @TestFactory
+    private void testFactory() { }
+    @TestTemplate
+    private void testTemplate() { }
+    @ParameterizedTest
+    private void testParameterized() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>default/protected/public are fine</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+    @Test
+    void testDefault() { }
+    @Test
+    protected void testProtected() { }
+    @Test
+    public void testPublic() { }
+}
+        ]]></code>
+    </test-code>
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -70,7 +70,7 @@ class MyTests {
         ]]></code>
     </test-code>
 
-    <test-code disabled="true">
+    <test-code>
         <description>test class must not be private, even if the test methods are in a parent class</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>8</expected-linenumbers>
@@ -86,10 +86,10 @@ private class Child extends Parent {}
         ]]></code>
     </test-code>
 
-    <test-code disabled="true">
+    <test-code>
         <description>test class must not be private, even if the test methods are in a parent class (parent is in different .class file)</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>8</expected-linenumbers>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 import net.sourceforge.pmd.lang.java.rule.errorprone.juni5testnoprivatemodifier.ParentWithTest;
 


### PR DESCRIPTION
## Describe the PR

Flip side of JUnit5TestShouldBePackagePrivate - the existing rule checks that our junit5 tests aren't too visible, this new rule checks that they are visible enough. I didn't implement the (optional) JUnit4 part of the rule. Didn't feel like spending time on it, JUnit5 has been out for over 8 years.

## Related issues

- Fix #3288

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

