### PR TITLE
[java] Fix #6308: Add syntax highlighting to MarkdownRenderer

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -72,6 +72,8 @@ This is a {{ site.pmd.release_type }} release.
   * {% rule java/design/UseUtilityClass %}
 
 ### 🐛️ Fixed Issues
+* core
+  * [#6308](https://github.com/pmd/pmd/issues/6308): \[core] CPD Markdown format: Add syntax highlighting
 * java
   * [#5721](https://github.com/pmd/pmd/issues/5721): \[java] StackOverflowError in 7.17.0 with nested wildcard generics
 * java-bestpractices
@@ -99,6 +101,7 @@ This is a {{ site.pmd.release_type }} release.
 * [#6587](https://github.com/pmd/pmd/pull/6587): \[java] Fix #2801: Add a property to OnlyOneReturnRule to allow guard ifs - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6597](https://github.com/pmd/pmd/pull/6597): \[java] Fix #3212: Enhance UseStandardCharsets - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6601](https://github.com/pmd/pmd/pull/6601): \[java] Fix #4288: Document that CallSuperFirst and CallSuperLast are android only - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#6605](https://github.com/pmd/pmd/pull/6605): \[java] Fix #6308: Add syntax highlighting to MarkdownRenderer - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 
 ### 📦️ Dependency updates
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
@@ -87,8 +87,7 @@ public class CPDReport {
 
     /**
      * Return the {@link LanguageVersion} of the fileId
-     * @param fileId
-     * @return
+     * @since 7.25.0
      */
     public LanguageVersion getLanguageVersion(FileId fileId) {
         return sourceManager.getFileLanguageVersion(fileId);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReport.java
@@ -11,6 +11,7 @@ import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.reporting.Report;
@@ -82,5 +83,14 @@ public class CPDReport {
      */
     public String getDisplayName(FileId fileId) {
         return sourceManager.getFileDisplayName(fileId);
+    }
+
+    /**
+     * Return the {@link LanguageVersion} of the fileId
+     * @param fileId
+     * @return
+     */
+    public LanguageVersion getLanguageVersion(FileId fileId) {
+        return sourceManager.getFileLanguageVersion(fileId);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MarkdownRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MarkdownRenderer.java
@@ -7,13 +7,13 @@ package net.sourceforge.pmd.cpd;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.document.Chars;
+import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.FileLocation;
 
 /**
@@ -51,15 +51,22 @@ public class MarkdownRenderer implements CPDReportRenderer {
         }
 
         Mark firstMark = match.getFirstMark();
-        String filename = firstMark.getFileId().getFileName().toLowerCase(Locale.ROOT);
-        String highlightLanguage = null;
-        if (filename.endsWith(".java") || filename.endsWith(".jav")) {
-            highlightLanguage = "java";
-        }
+        String highlightLanguage = getMarkdownLanguageTag(report, firstMark.getFileId());
 
         Chars source = report.getSourceCodeSlice(firstMark);
         final MarkdownCodeBlock markdownCodeBlock = new MarkdownCodeBlock(source, highlightLanguage);
         writer.append(markdownCodeBlock.toString());
+    }
+
+    String getMarkdownLanguageTag(CPDReport report, FileId fileId) {
+        String languageId = report.getLanguageVersion(fileId).getLanguage().getId();
+
+        switch (languageId) {
+        case "ecmascript": return "js";
+        case "typescript": return "ts";
+        default: return languageId;
+        }
+
     }
 
     static class MarkdownCodeBlock {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import net.sourceforge.pmd.internal.util.IOUtil;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.FileLocation;
@@ -92,5 +93,9 @@ class SourceManager implements AutoCloseable {
 
     String getFileDisplayName(FileId fileId) {
         return fileNameRenderer.getDisplayName(fileId);
+    }
+
+    LanguageVersion getFileLanguageVersion(FileId fileId) {
+        return fileByPathId.get(fileId).getLanguageVersion();
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDReportTest.java
@@ -21,12 +21,12 @@ class CPDReportTest {
         FileId file1 = FileId.fromPathLikeString("file1.java");
         FileId file2 = FileId.fromPathLikeString("file2.java");
         FileId file3 = FileId.fromPathLikeString("file3.java");
+        reportBuilder.setFileContent(file1, 10);
+        reportBuilder.setFileContent(file2, 15);
+        reportBuilder.setFileContent(file3, 20);
         reportBuilder.addMatch(createMatch(reportBuilder, file1, file2, 1));
         reportBuilder.addMatch(createMatch(reportBuilder, file1, file3, 2));
         reportBuilder.addMatch(createMatch(reportBuilder, file2, file3, 3));
-        reportBuilder.recordNumTokens(file1, 10);
-        reportBuilder.recordNumTokens(file2, 15);
-        reportBuilder.recordNumTokens(file3, 20);
         CPDReport original = reportBuilder.build();
 
         assertEquals(3, original.getMatches().size());
@@ -49,8 +49,8 @@ class CPDReportTest {
     }
 
     private Match createMatch(CpdReportBuilder builder, FileId file1, FileId file2, int line) {
-        return new Match(5,
-                         builder.tokens.addToken("firstToken", file1, line, 1, line, 1),
-                         builder.tokens.addToken("secondToken", file2, line, 2, line, 2));
+        Mark mark1 = builder.createMark("firstToken", file1, line, 1, 1, 1);
+        Mark mark2 = builder.createMark("secondToken", file2, line, 1, 2, 2);
+        return new Match(5, mark1, mark2);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.DummyLanguageModule;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.reporting.Report;
@@ -53,6 +54,7 @@ final class CpdTestUtils {
         final Tokens tokens = new Tokens();
         private final List<Match> matches = new ArrayList<>();
         private Map<FileId, Integer> numTokensPerFile = new HashMap<>();
+        private final Map<FileId, LanguageVersion> languageVersionPerFile = new HashMap<>();
 
         CpdReportBuilder setFileContent(FileId fileName, String content) {
             fileContents.put(fileName, content);
@@ -69,9 +71,20 @@ final class CpdTestUtils {
             return this;
         }
 
+        public CpdReportBuilder setLanguageVersionOfFile(FileId fileName, LanguageVersion languageVersion) {
+            languageVersionPerFile.put(fileName, languageVersion);
+            return this;
+        }
+
         CPDReport build() {
             Set<TextFile> textFiles = new HashSet<>();
-            fileContents.forEach((fname, contents) -> textFiles.add(TextFile.forCharSeq(contents, fname, DummyLanguageModule.getInstance().getDefaultVersion())));
+            fileContents.forEach((fname, contents) -> {
+                textFiles.add(TextFile.forCharSeq(
+                        contents,
+                        fname,
+                        languageVersionPerFile.getOrDefault(fname, DummyLanguageModule.getInstance().getDefaultVersion())
+                ));
+            });
             return new CPDReport(
                 new SourceManager(new ArrayList<>(textFiles)),
                 matches,

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.cpd;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,27 +26,6 @@ final class CpdTestUtils {
         // utility class
     }
 
-    static CPDReport makeReport(List<Match> matches) {
-        return makeReport(matches, Collections.emptyMap(), Collections.emptyList());
-    }
-
-    static CPDReport makeReport(List<Match> matches, Map<FileId, Integer> numTokensPerFile, List<Report.ProcessingError> processingErrors) {
-        Set<TextFile> textFiles = new HashSet<>();
-        for (Match match : matches) {
-            match.iterator().forEachRemaining(
-                mark -> textFiles.add(
-                    TextFile.forCharSeq(DUMMY_FILE_CONTENT,
-                                        mark.getLocation().getFileId(),
-                                        DummyLanguageModule.getInstance().getDefaultVersion())));
-        }
-        return new CPDReport(
-            new SourceManager(new ArrayList<>(textFiles)),
-            matches,
-            numTokensPerFile,
-            processingErrors
-        );
-    }
-
     static class CpdReportBuilder {
 
         private final Map<FileId, String> fileContents = new HashMap<>();
@@ -55,6 +33,7 @@ final class CpdTestUtils {
         private final List<Match> matches = new ArrayList<>();
         private Map<FileId, Integer> numTokensPerFile = new HashMap<>();
         private final Map<FileId, LanguageVersion> languageVersionPerFile = new HashMap<>();
+        private final List<Report.ProcessingError> processingErrors = new ArrayList<>();
 
         CpdReportBuilder setFileContent(FileId fileName, String content) {
             fileContents.put(fileName, content);
@@ -76,6 +55,11 @@ final class CpdTestUtils {
             return this;
         }
 
+        public CpdReportBuilder addProcessingError(Report.ProcessingError processingError) {
+            processingErrors.add(processingError);
+            return this;
+        }
+
         CPDReport build() {
             Set<TextFile> textFiles = new HashSet<>();
             fileContents.forEach((fname, contents) -> {
@@ -89,7 +73,7 @@ final class CpdTestUtils {
                 new SourceManager(new ArrayList<>(textFiles)),
                 matches,
                 numTokensPerFile,
-                Collections.emptyList()
+                processingErrors
             );
 
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
@@ -4,12 +4,12 @@
 
 package net.sourceforge.pmd.cpd;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -27,70 +27,76 @@ final class CpdTestUtils {
     }
 
     static class CpdReportBuilder {
+        static final String DUMMY_FILE_CONTENT = generateDummyContent(60);
 
-        private final Map<FileId, String> fileContents = new HashMap<>();
-        final Tokens tokens = new Tokens();
+        private final Map<FileId, TextFile> files = new HashMap<>();
+        private final Map<FileId, Integer> numTokensPerFile = new HashMap<>();
+
+        private final Tokens tokens = new Tokens();
         private final List<Match> matches = new ArrayList<>();
-        private Map<FileId, Integer> numTokensPerFile = new HashMap<>();
-        private final Map<FileId, LanguageVersion> languageVersionPerFile = new HashMap<>();
         private final List<Report.ProcessingError> processingErrors = new ArrayList<>();
 
+        CpdReportBuilder setFileContent(FileId fileName) {
+            setFileContent(fileName, DUMMY_FILE_CONTENT);
+            return this;
+        }
+
+        CpdReportBuilder setFileContent(FileId fileName, LanguageVersion version) {
+            setFileContent(fileName, DUMMY_FILE_CONTENT, version);
+            return this;
+        }
+
+        CpdReportBuilder setFileContent(FileId fileName, int numTokens) {
+            setFileContent(fileName, DUMMY_FILE_CONTENT, DummyLanguageModule.getInstance().getDefaultVersion(), numTokens);
+            return this;
+        }
+
         CpdReportBuilder setFileContent(FileId fileName, String content) {
-            fileContents.put(fileName, content);
+            setFileContent(fileName, content, DummyLanguageModule.getInstance().getDefaultVersion());
             return this;
         }
 
-        public CpdReportBuilder setNumTokensPerFile(Map<FileId, Integer> numTokensPerFile) {
-            this.numTokensPerFile = numTokensPerFile;
+        CpdReportBuilder setFileContent(FileId fileName, String content, LanguageVersion version) {
+            setFileContent(fileName, content, version, 10);
             return this;
         }
 
-        public CpdReportBuilder recordNumTokens(FileId fileName, int numTokens) {
-            this.numTokensPerFile.put(fileName, numTokens);
+        CpdReportBuilder setFileContent(FileId fileName, String content, LanguageVersion version, int numTokens) {
+            files.put(fileName, TextFile.forCharSeq(
+                    content,
+                    fileName,
+                    version
+            ));
+            numTokensPerFile.put(fileName, numTokens);
             return this;
         }
 
-        public CpdReportBuilder setLanguageVersionOfFile(FileId fileName, LanguageVersion languageVersion) {
-            languageVersionPerFile.put(fileName, languageVersion);
-            return this;
-        }
-
-        public CpdReportBuilder addProcessingError(Report.ProcessingError processingError) {
+        CpdReportBuilder addProcessingError(Report.ProcessingError processingError) {
             processingErrors.add(processingError);
             return this;
         }
 
-        CPDReport build() {
-            Set<TextFile> textFiles = new HashSet<>();
-            fileContents.forEach((fname, contents) -> {
-                textFiles.add(TextFile.forCharSeq(
-                        contents,
-                        fname,
-                        languageVersionPerFile.getOrDefault(fname, DummyLanguageModule.getInstance().getDefaultVersion())
-                ));
-            });
-            return new CPDReport(
-                new SourceManager(new ArrayList<>(textFiles)),
-                matches,
-                numTokensPerFile,
-                processingErrors
-            );
-
-        }
-
         Mark createMark(String image, FileId fileName, int beginLine, int lineCount) {
-            fileContents.putIfAbsent(fileName, DUMMY_FILE_CONTENT);
+            if (!files.containsKey(fileName)) {
+                setFileContent(fileName);
+            }
             return new Mark(tokens.addToken(image, fileName, beginLine, 1, beginLine + lineCount - 1, 1));
         }
 
         CpdReportBuilder addMatch(Match match) {
-            fileContents.putIfAbsent(match.getFirstMark().getLocation().getFileId(), DUMMY_FILE_CONTENT);
+            for (Mark mark : match) {
+                if (!files.containsKey(mark.getLocation().getFileId())) {
+                    setFileContent(mark.getLocation().getFileId());
+                }
+            }
             matches.add(match);
             return this;
         }
 
         Mark createMark(String image, FileId fileId, int beginLine, int lineCount, int beginColumn, int endColumn) {
-            fileContents.putIfAbsent(fileId, DUMMY_FILE_CONTENT);
+            if (!files.containsKey(fileId)) {
+                setFileContent(fileId);
+            }
             final TokenEntry beginToken = tokens.addToken(image, fileId, beginLine, beginColumn, beginLine,
                                                           beginColumn + image.length());
             final TokenEntry endToken = tokens.addToken(image, fileId,
@@ -102,9 +108,17 @@ final class CpdTestUtils {
             return result;
         }
 
-    }
+        CPDReport build() {
+            assertEquals(files.size(), numTokensPerFile.size(), "files size/numTokensPerFile mismatch");
 
-    public static final String DUMMY_FILE_CONTENT = generateDummyContent(60);
+            return new CPDReport(
+                    new SourceManager(new ArrayList<>(files.values())),
+                    matches,
+                    numTokensPerFile,
+                    processingErrors
+            );
+        }
+    }
 
     static String generateDummyContent(int lengthInLines) {
         StringBuilder sb = new StringBuilder();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownRendererTest.java
@@ -32,7 +32,7 @@ class MarkdownRendererTest {
         FileId foo = CpdTestUtils.FOO_FILE_ID;
         FileId bar = CpdTestUtils.BAR_FILE_ID;
 
-        builder.setLanguageVersionOfFile(foo, java25).setLanguageVersionOfFile(bar, java25);
+        builder.setFileContent(foo, java25).setFileContent(bar, java25);
 
         int lineCount1 = 6;
         Mark mark1 = builder.createMark("public", foo, 48, lineCount1);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownRendererTest.java
@@ -5,23 +5,34 @@
 package net.sourceforge.pmd.cpd;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.document.FileId;
 
 class MarkdownRendererTest {
 
     @Test
     void testMultipleDuplicates() throws IOException {
+        LanguageVersion java25 = mock();
+        Language java = mock();
+        when(java25.getLanguage()).thenReturn(java);
+        when(java.getId()).thenReturn("java");
+
         CPDReportRenderer renderer = new MarkdownRenderer();
         CpdTestUtils.CpdReportBuilder builder = new CpdTestUtils.CpdReportBuilder();
 
         FileId foo = CpdTestUtils.FOO_FILE_ID;
         FileId bar = CpdTestUtils.BAR_FILE_ID;
+
+        builder.setLanguageVersionOfFile(foo, java25).setLanguageVersionOfFile(bar, java25);
 
         int lineCount1 = 6;
         Mark mark1 = builder.createMark("public", foo, 48, lineCount1);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownSyntaxHighlightingLanguageTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownSyntaxHighlightingLanguageTest.java
@@ -1,0 +1,57 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cpd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.FieldSource;
+
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.document.FileId;
+
+class MarkdownSyntaxHighlightingLanguageTest {
+
+    private static final List<Arguments> MARKDOWN_FOR_LANGUAGE_ID = Arrays.asList(
+            Arguments.of("cpp", "cpp"),
+            Arguments.of("java", "java"),
+            Arguments.of("ecmascript", "js"),
+            Arguments.of("typescript", "ts")
+    );
+
+    @ParameterizedTest
+    @FieldSource("MARKDOWN_FOR_LANGUAGE_ID")
+    void testGetMarkdownLanguageTag(String langId, String expected) {
+        LanguageVersion langVer = mock();
+        Language lang = mock();
+        when(langVer.getLanguage()).thenReturn(lang);
+        when(lang.getId()).thenReturn(langId);
+
+        CpdTestUtils.CpdReportBuilder builder = new CpdTestUtils.CpdReportBuilder();
+
+        FileId foo = CpdTestUtils.FOO_FILE_ID;
+
+        builder.setLanguageVersionOfFile(foo, langVer);
+
+        int lineCount1 = 6;
+        Mark mark1 = builder.createMark("public", foo, 48, lineCount1);
+        Mark mark2 = builder.createMark("void", foo, 73, lineCount1);
+        builder.addMatch(new Match(75, mark1, mark2));
+
+        MarkdownRenderer subject = new MarkdownRenderer();
+        CPDReport report = builder.build();
+
+        String got = subject.getMarkdownLanguageTag(report, foo);
+
+        assertEquals(expected, got);
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownSyntaxHighlightingLanguageTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkdownSyntaxHighlightingLanguageTest.java
@@ -40,7 +40,7 @@ class MarkdownSyntaxHighlightingLanguageTest {
 
         FileId foo = CpdTestUtils.FOO_FILE_ID;
 
-        builder.setLanguageVersionOfFile(foo, langVer);
+        builder.setFileContent(foo, langVer);
 
         int lineCount1 = 6;
         Mark mark1 = builder.createMark("public", foo, 48, lineCount1);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLOldRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLOldRendererTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Collections;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -28,7 +27,7 @@ class XMLOldRendererTest {
     void testWithNoDuplication() throws IOException, ParserConfigurationException, SAXException {
         CPDReportRenderer renderer = new XMLOldRenderer();
         StringWriter sw = new StringWriter();
-        renderer.render(CpdTestUtils.makeReport(Collections.emptyList()), sw);
+        renderer.render(new CpdTestUtils.CpdReportBuilder().build(), sw);
         String report = sw.toString();
 
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<pmd-cpd/>\n",

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -23,6 +23,8 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
 
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
@@ -143,8 +145,10 @@ class XMLRendererTest {
 
         Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                                              .parse(new ByteArrayInputStream(report.getBytes(ENCODING)));
-        assertEquals(2, doc.getElementsByTagName("duplication").getLength());
-        assertEquals(4, doc.getElementsByTagName("file").getLength());
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        assertEquals(2, Integer.parseInt(xpath.evaluate("count(/pmd-cpd/duplication)", doc)), "duplication elements");
+        assertEquals(4, Integer.parseInt(xpath.evaluate("count(/pmd-cpd/duplication/file)", doc)), "file elements inside duplication");
+        assertEquals(2, Integer.parseInt(xpath.evaluate("count(/pmd-cpd/file[@totalNumberOfTokens])", doc)), "totalNumberOfTokens entries");
     }
 
     @Test
@@ -212,11 +216,11 @@ class XMLRendererTest {
         final CPDReportRenderer renderer = new XMLRenderer();
         CpdReportBuilder builder = new CpdReportBuilder();
         final FileId filename = CpdTestUtils.FOO_FILE_ID;
+        builder.setFileContent(filename, 888);
         final int lineCount = 2;
         final Mark mark1 = builder.createMark("public", filename, 1, lineCount, 2, 3);
         final Mark mark2 = builder.createMark("stuff", filename, 3, lineCount, 4, 5);
         builder.addMatch(new Match(75, mark1, mark2));
-        builder.recordNumTokens(filename, 888);
 
         final CPDReport report = builder.build();
 
@@ -238,11 +242,11 @@ class XMLRendererTest {
         final CPDReportRenderer renderer = new XMLRenderer();
         CpdReportBuilder builder = new CpdReportBuilder();
         final FileId filename = CpdTestUtils.FOO_FILE_ID;
+        builder.setFileContent(filename, 888);
         final int lineCount = 6;
         final Mark mark1 = builder.createMark("public", filename, 1, lineCount, 2, 3);
         final Mark mark2 = builder.createMark("stuff", filename, 73, lineCount, 4, 5);
         builder.addMatch(new Match(75, mark1, mark2));
-        builder.recordNumTokens(filename, 888);
 
         final CPDReport report = builder.build();
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -14,7 +14,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.Collections;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -54,7 +53,7 @@ class XMLRendererTest {
     void testWithNoDuplication() throws IOException, ParserConfigurationException, SAXException {
         CPDReportRenderer renderer = new XMLRenderer();
         StringWriter sw = new StringWriter();
-        renderer.render(CpdTestUtils.makeReport(Collections.emptyList()), sw);
+        renderer.render(new CpdTestUtils.CpdReportBuilder().build(), sw);
         String report = sw.toString();
         assertReportIsValidSchema(report);
 
@@ -299,7 +298,7 @@ class XMLRendererTest {
                 fileId);
         CPDReportRenderer renderer = new XMLRenderer();
         StringWriter sw = new StringWriter();
-        renderer.render(CpdTestUtils.makeReport(Collections.emptyList(), Collections.emptyMap(), Collections.singletonList(processingError)), sw);
+        renderer.render(new CpdTestUtils.CpdReportBuilder().addProcessingError(processingError).build(), sw);
         String report = sw.toString();
         assertReportIsValidSchema(report);
 
@@ -333,7 +332,7 @@ class XMLRendererTest {
                 fileId);
         CPDReportRenderer renderer = new XMLRenderer();
         StringWriter sw = new StringWriter();
-        renderer.render(CpdTestUtils.makeReport(Collections.emptyList(), Collections.emptyMap(), Collections.singletonList(processingError)), sw);
+        renderer.render(new CpdTestUtils.CpdReportBuilder().addProcessingError(processingError).build(), sw);
         String report = sw.toString();
         assertReportIsValidSchema(report);
 


### PR DESCRIPTION
## Describe the PR

Add syntax highlighting to MarkdownRenderer

## Related issues

- Fix #6308 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

