### PR TITLE
[doc] basic.xml has been gone for a long time

### DIFF
--- a/docs/pages/pmd/userdocs/installation.md
+++ b/docs/pages/pmd/userdocs/installation.md
@@ -68,8 +68,7 @@ modifiers on Java sources with `-R category/java/codestyle.xml/UnnecessaryModifi
 sources. Alternatively You can use the `-d` or `--dir` flag, which is equivalent.
 
 {% include note.html
-   content="At the moment the formerly provided rulesets (eg `rulesets/java/basic.xml`) are deprecated,
-   though you can still use them. PMD includes a quickstart ruleset for some languages (currently, Java)
+   content="PMD includes a quickstart ruleset for some languages (currently, Java)
    as base configurations, which you can reference as e.g. `rulesets/java/quickstart.xml`. You're strongly
    encouraged to [create your own ruleset](pmd_userdocs_making_rulesets.html) from the start though." %}
 


### PR DESCRIPTION
## Describe the PR

pmd_userdocs_installation.html still mentioned `basic.xml`, which [has been gone](https://github.com/pmd/pmd/commit/9977c0ffeb60f919d61448bca7e78c9b11eecd59) since PMD 7.0.0

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

