### PR TITLE
[core] Fix #4972: Update ANTLR from 4.9.3 to 4.13.2

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,16 @@ This is a {{ site.pmd.release_type }} release.
 {% tocmaker is_release_notes_processor %}
 
 ### 🚀️ New and noteworthy
+#### Updated antlr library to 4.13.2
+We have updated the antlr library (parser generator) from 4.9.3 to the latest version 4.13.2,
+in order to be able to use the latest version of Apex parser library.
+
+This is an incompatible update: In case you use custom language modules based on antlr, you
+need to make sure to regenerate all of your lexers and parsers with the new antlr version.
+
+For the antlr based language modules, that PMD ships (kotlin and swift and various CPD modules),
+this is already done.
+
 #### 🌟️ Changed Rules
 * The rule {% rule java/codestyle/OnlyOneReturn %} has a new property `allowGuardIfs`. When this property is
   true, then guard ifs at the beginning of a method are allowed their return statements don't count.
@@ -73,6 +83,7 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 * core
+  * [#4972](https://github.com/pmd/pmd/issues/4972): \[core] Update antlr to 4.13.2
   * [#6308](https://github.com/pmd/pmd/issues/6308): \[core] CPD Markdown format: Add syntax highlighting
 * java
   * [#5721](https://github.com/pmd/pmd/issues/5721): \[java] StackOverflowError in 7.17.0 with nested wildcard generics
@@ -102,6 +113,8 @@ This is a {{ site.pmd.release_type }} release.
 * [#6597](https://github.com/pmd/pmd/pull/6597): \[java] Fix #3212: Enhance UseStandardCharsets - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6601](https://github.com/pmd/pmd/pull/6601): \[java] Fix #4288: Document that CallSuperFirst and CallSuperLast are android only - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6605](https://github.com/pmd/pmd/pull/6605): \[java] Fix #6308: Add syntax highlighting to MarkdownRenderer - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#6621](https://github.com/pmd/pmd/pull/6621): \[core] Fix #4972: Update antlr from 4.9.3 to 4.13.2 - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#6654](https://github.com/pmd/pmd/pull/6654): \[swift] Fix invalid swift token OSXApplicationExtension - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 ### 📦️ Dependency updates
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>io.github.apex-dev-tools</groupId>
             <artifactId>apex-parser</artifactId>
-            <version>4.4.1</version>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.summit</groupId>

--- a/pmd-swift/src/main/antlr4/net/sourceforge/pmd/lang/swift/ast/Swift.g4
+++ b/pmd-swift/src/main/antlr4/net/sourceforge/pmd/lang/swift/ast/Swift.g4
@@ -969,7 +969,7 @@ contextSensitiveKeyword :
  'associativity' | 'convenience' | 'dynamic' | 'didSet' | 'final' | 'get' | 'infix' | 'indirect' |
  'lazy' | 'left' | 'mutating' | 'none' | 'nonmutating' | 'optional' | 'operator' | 'override' | 'postfix' | 'precedence' |
  'prefix' | 'Protocol' | 'required' | 'right' | 'set' | 'Type' | 'unowned' | 'weak' | 'willSet' |
- 'iOS' | 'iOSApplicationExtension' | 'OSX' | 'OSXApplicationExtension­' | 'watchOS' | 'x86_64' |
+ 'iOS' | 'iOSApplicationExtension' | 'OSX' | 'OSXApplicationExtension-' | 'watchOS' | 'x86_64' |
  'arm' | 'arm64' | 'i386' | 'os' | 'arch' | 'safe' | 'tvOS' | 'file' | 'line' | 'default' | 'Self' | 'var' |
  'some'
  ;

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
@@ -35,7 +35,6 @@ final class SwiftNameDictionary extends AntlrNameDictionary {
         case "unowned(unsafe)": return "unowned-unsafe";
         case "getter:": return "getter";
         case "setter:": return "setter";
-        case "OSXApplicationExtension\u00AD": return "OSXApplicationExtension-";
         default: return null;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <pmd.plugin.version>3.28.0</pmd.plugin.version>
         <ant.version>1.10.17</ant.version>
         <javadoc.plugin.version>3.12.0</javadoc.plugin.version>
-        <antlr.version>4.9.3</antlr.version>
+        <antlr.version>4.13.2</antlr.version>
         <slf4j.version>1.7.36</slf4j.version>
         <saxon.version>12.9</saxon.version>
 


### PR DESCRIPTION
## Describe the PR

- Update antlr from 4.9.3 to 4.13.2 (this PR)
- pmd-apex: Update apex-parser from 4.4.1 to 5.0.0 via #6612 (included here)
- pmd-swift: Fix grammar via #6654 (included here)

## Questions

Is updating apex-parser a breaking change that requires a major version?
I haven't investigated why `SwiftNameDictionary` needs the added slash. I just know that this makes the test green. Is this a sign of a bigger problem?

-> yes. Actually these are tokens/keywords that don't exist and should be removed. But we can't due to #6655.

## Related issues

- Fix #4972

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

