### PR TITLE
[java] Cleanup: Remove TODO from ModifierOwner.getVisibility()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ModifierOwner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ModifierOwner.java
@@ -50,9 +50,6 @@ public interface ModifierOwner extends Annotatable {
      * There cannot be any conflict with {@link #hasModifiers(JModifier, JModifier...)}} on
      * well-formed code (e.g. for any {@code n}, {@code (n.getVisibility() == V_PROTECTED) ==
      * n.hasModifiers(PROTECTED)})
-     *
-     * <p>TODO a public method of a private class can be considered to be private
-     * we could probably add another method later on that takes this into account
      */
     default Visibility getVisibility() {
         Set<JModifier> effective = getModifiers().getEffectiveModifiers();


### PR DESCRIPTION
## Describe the PR

The thing that is TODO is already done.
It is getEffectiveVisibility() directly below.

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

