### PR TITLE
[java] OverridingThreadRun: Fix false negatives with other methods and anonymous classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -169,13 +169,19 @@ public final class TypeTestUtil {
 
     private static boolean isA(@NonNull String canonicalName, @NonNull JTypeMirror thisType, @Nullable UnresolvedClassStore unresolvedStore) {
         OptionalBool exactMatch = isExactlyAOrAnon(canonicalName, thisType);
-        if (exactMatch != OptionalBool.NO) {
-            return exactMatch == OptionalBool.YES; // otherwise anon, and we return false
+        if (exactMatch == OptionalBool.YES) {
+            return true;
         }
+        JTypeMirror closestNamedSuperclass = thisType;
+        if (exactMatch == OptionalBool.UNKNOWN && thisType instanceof JClassType) {
+            closestNamedSuperclass = ((JClassType) thisType).getSuperClass();
+        }
+        if (closestNamedSuperclass == null) {
+            return false;
+        }
+        JTypeDeclSymbol closestNamedSuperclassSymbol = closestNamedSuperclass.getSymbol();
 
-        JTypeDeclSymbol thisClass = thisType.getSymbol();
-
-        if (thisClass != null && thisClass.isUnresolved()) {
+        if (closestNamedSuperclassSymbol != null && closestNamedSuperclassSymbol.isUnresolved()) {
             // we can't get any useful info from this, isSubtypeOf would return true
             // do not test for equality, we already checked isExactlyA, which has its fallback
             return false;
@@ -184,7 +190,7 @@ public final class TypeTestUtil {
         TypeSystem ts = thisType.getTypeSystem();
         @Nullable JTypeMirror otherType = TypesFromReflection.loadType(ts, canonicalName, unresolvedStore);
 
-        return isA(otherType, thisType);
+        return isA(otherType, closestNamedSuperclass);
     }
 
     /**
@@ -283,8 +289,8 @@ public final class TypeTestUtil {
         if (canonical == null) {
             return OptionalBool.UNKNOWN; // anonymous
         }
-        canonicalName = StringUtils.deleteWhitespace(canonicalName);
-        return OptionalBool.definitely(canonical.equals(canonicalName));
+        String cleanCanonicalName = StringUtils.deleteWhitespace(canonicalName);
+        return OptionalBool.definitely(canonical.equals(cleanCanonicalName));
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -11,7 +11,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.InternalApiBridge;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
@@ -172,14 +175,20 @@ public final class TypeTestUtil {
         if (exactMatch == OptionalBool.YES) {
             return true;
         }
-        JTypeMirror closestNamedSuperclass = thisType;
+        // Look for canonicalName in supertypes.
+        // In case of anonymous classes start from direct supertype (class or interface)
+        // so that isA("Foo$1", anonymous) is false ("Foo$1" is not a canonical name).
+        JTypeMirror closestNamedSupertype = thisType;
         if (exactMatch == OptionalBool.UNKNOWN && thisType instanceof JClassType) {
-            closestNamedSuperclass = ((JClassType) thisType).getSuperClass();
+            ASTTypeDeclaration typeDecl = ((JClassType) thisType).getSymbol().tryGetNode();
+            JavaNode anonNode = typeDecl == null ? null : typeDecl.getParent();
+            if (anonNode instanceof ASTConstructorCall) {
+                closestNamedSupertype = ((ASTConstructorCall) anonNode).getTypeMirror();
+            } else {
+                return false;
+            }
         }
-        if (closestNamedSuperclass == null) {
-            return false;
-        }
-        JTypeDeclSymbol closestNamedSuperclassSymbol = closestNamedSuperclass.getSymbol();
+        JTypeDeclSymbol closestNamedSuperclassSymbol = closestNamedSupertype.getSymbol();
 
         if (closestNamedSuperclassSymbol != null && closestNamedSuperclassSymbol.isUnresolved()) {
             // we can't get any useful info from this, isSubtypeOf would return true
@@ -190,7 +199,7 @@ public final class TypeTestUtil {
         TypeSystem ts = thisType.getTypeSystem();
         @Nullable JTypeMirror otherType = TypesFromReflection.loadType(ts, canonicalName, unresolvedStore);
 
-        return isA(otherType, closestNamedSuperclass);
+        return isA(otherType, closestNamedSupertype);
     }
 
     /**

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -376,8 +376,8 @@ public static Foo getFoo() {
             <property name="xpath">
                 <value>
                     <![CDATA[
-//ClassDeclaration[ pmd-java:typeIs('java.lang.Thread') ]/ClassBody
-    /MethodDeclaration[@Name="run"][count(//FormalParameter)=0]
+(//AnonymousClassDeclaration|//ClassDeclaration)[ pmd-java:typeIs('java.lang.Thread') ]/ClassBody
+    /MethodDeclaration[@Name="run"][FormalParameters/@Size=0]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -361,7 +361,7 @@ public static Foo getFoo() {
     <rule name="OverridingThreadRun"
           language="java"
           since="7.24.0"
-          message="Don't override Thread.run() method, use Runnable instead"
+          message="Don''t override Thread.run() method, use Runnable instead"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#overridingthreadrun">
         <description>

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -376,7 +376,7 @@ public static Foo getFoo() {
             <property name="xpath">
                 <value>
                     <![CDATA[
-(//AnonymousClassDeclaration|//ClassDeclaration)[ pmd-java:typeIs('java.lang.Thread') ]/ClassBody
+//(AnonymousClassDeclaration|ClassDeclaration)[ pmd-java:typeIs('java.lang.Thread') ]/ClassBody
     /MethodDeclaration[@Name="run"][FormalParameters/@Size=0]
 ]]>
                 </value>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
@@ -229,6 +229,7 @@ class TypeTestUtilTest extends BaseParserTest {
 
         assertTrue(anon.getSymbol().isAnonymousClass(), "Anon class");
         assertTrue(TypeTestUtil.isA(Runnable.class, anon), "Should be a Runnable");
+        assertTrue(TypeTestUtil.isA(Runnable.class.getName(), anon), "Should be a Runnable (by name)");
 
         // This is not a canonical name, so we give up early
         assertFalse(TypeTestUtil.isA(SomeClassWithAnon.class.getName() + "$1", anon));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
@@ -2,7 +2,7 @@
 <test-data
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_1_1_1.xsd">
 
     <test-code>
         <description>Overriding run</description>
@@ -12,6 +12,25 @@
             public class Foo extends Thread {
                 @Override
                 public void run() {
+                }
+
+                public static void main(String[] args) {
+                    new Foo().start();
+                }
+            }
+        </code>
+    </test-code>
+    <test-code>
+        <description>Overriding anonymous run</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code>
+            public class Foo  {
+                public void run() {
+                    new Thread() {
+                        @Override
+                        public void run() { }
+                    }.start();
                 }
             }
         </code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/OverridingThreadRun.xml
@@ -8,6 +8,9 @@
         <description>Overriding run</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>Don't override Thread.run() method, use Runnable instead</message>
+        </expected-messages>
         <code>
             public class Foo extends Thread {
                 @Override


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

* Fixed XPath as suggested by @adangel in https://github.com/pmd/pmd/pull/6555#issuecomment-4345721327
* Fixed `pmd-java:isA` check for anonymous classes. I believe the behavior changed in https://github.com/pmd/pmd/commit/32491584 , but I don't know what specific issues did that commit fix, maybe @oowekyala has some insights

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Follow-up for https://github.com/pmd/pmd/pull/6555

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

