### PR TITLE
[java] Fix #559: Improve UseUtilityClassRule to trigger also on static members

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -48,8 +48,6 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
         boolean hasNonPrivateMethods = false;
         boolean hasNonPrivateFields = false;
         boolean hasNonPrivateNestedClasses = false;
-        boolean hasNonPrivateCtor = false;
-        boolean hasAnyCtor = false;
         for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
             if (declaration instanceof ASTFieldDeclaration) {
                 ASTFieldDeclaration fieldDeclaration = (ASTFieldDeclaration) declaration;
@@ -59,14 +57,6 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                 }
                 if (!fieldDeclaration.isStatic()) {
                     return null;
-                }
-            }
-            if (declaration instanceof ASTConstructorDeclaration) {
-                ASTConstructorDeclaration constructorDeclaration = (ASTConstructorDeclaration) declaration;
-
-                hasAnyCtor = true;
-                if (constructorDeclaration.getVisibility() != V_PRIVATE) {
-                    hasNonPrivateCtor = true;
                 }
             }
 
@@ -93,16 +83,29 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             }
         }
 
-        // account for default ctor
-        hasNonPrivateCtor |= !hasAnyCtor
-            && klass.getVisibility() != V_PRIVATE
-            && !hasLombokPrivateCtor(klass);
-
-
-        if ((hasNonPrivateMethods || hasNonPrivateFields || hasNonPrivateNestedClasses) && hasNonPrivateCtor) {
+        if ((hasNonPrivateMethods || hasNonPrivateFields || hasNonPrivateNestedClasses) && hasWrongKindOfConstructor(klass)) {
             asCtx(data).addViolation(klass);
         }
         return null;
+    }
+
+    private boolean hasWrongKindOfConstructor(ASTClassDeclaration klass) {
+        boolean hasNonPrivateCtor = false;
+        boolean hasAnyCtor = false;
+
+        for (ASTConstructorDeclaration constructorDeclaration : klass.getDeclarations(ASTConstructorDeclaration.class)) {
+            hasAnyCtor = true;
+            if (constructorDeclaration.getVisibility() != V_PRIVATE) {
+                hasNonPrivateCtor = true;
+            }
+        }
+
+        // account for default ctor
+        hasNonPrivateCtor |= !hasAnyCtor
+                && klass.getVisibility() != V_PRIVATE
+                && !hasLombokPrivateCtor(klass);
+
+        return hasNonPrivateCtor;
     }
 
     private boolean hasLombokPrivateCtor(ASTClassDeclaration parent) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -47,6 +47,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
         boolean hasNonPrivateMethods = false;
         boolean hasNonPrivateFields = false;
+        boolean hasNonPrivateNestedClasses = false;
         boolean hasNonPrivateCtor = false;
         boolean hasAnyCtor = false;
         for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
@@ -79,6 +80,17 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                     return null;
                 }
             }
+
+            if (declaration instanceof ASTClassDeclaration) {
+                ASTClassDeclaration classDeclaration = (ASTClassDeclaration) declaration;
+
+                if (classDeclaration.getVisibility() != V_PRIVATE) {
+                    hasNonPrivateNestedClasses = true;
+                }
+                if (!classDeclaration.isStatic()) {
+                    return null;
+                }
+            }
         }
 
         // account for default ctor
@@ -87,7 +99,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             && !hasLombokPrivateCtor(klass);
 
 
-        if ((hasNonPrivateMethods || hasNonPrivateFields) && hasNonPrivateCtor) {
+        if ((hasNonPrivateMethods || hasNonPrivateFields || hasNonPrivateNestedClasses) && hasNonPrivateCtor) {
             asCtx(data).addViolation(klass);
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -45,8 +45,8 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             return data;
         }
 
-        boolean hasAnyMethods = false;
-        boolean hasAnyFields = false;
+        boolean hasNonPrivateMethods = false;
+        boolean hasNonPrivateFields = false;
         boolean hasNonPrivateCtor = false;
         boolean hasAnyCtor = false;
         for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
@@ -54,7 +54,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                 ASTFieldDeclaration fieldDeclaration = (ASTFieldDeclaration) declaration;
 
                 if (fieldDeclaration.getVisibility() != V_PRIVATE) {
-                    hasAnyFields = true;
+                    hasNonPrivateFields = true;
                 }
                 if (!fieldDeclaration.isStatic()) {
                     return null;
@@ -73,7 +73,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                 ASTMethodDeclaration methodDeclaration = (ASTMethodDeclaration) declaration;
 
                 if (methodDeclaration.getVisibility() != V_PRIVATE) {
-                    hasAnyMethods = true;
+                    hasNonPrivateMethods = true;
                 }
                 if (!methodDeclaration.isStatic()) {
                     return null;
@@ -87,7 +87,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             && !hasLombokPrivateCtor(klass);
 
 
-        if ((hasAnyMethods || hasAnyFields) && hasNonPrivateCtor) {
+        if ((hasNonPrivateMethods || hasNonPrivateFields) && hasNonPrivateCtor) {
             asCtx(data).addViolation(klass);
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -61,12 +61,12 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                     || declaration instanceof ASTMethodDeclaration
                     || declaration instanceof ASTClassDeclaration
             ) {
-                ModifierOwner fieldDeclaration = (ModifierOwner) declaration;
+                ModifierOwner modifierOwner = (ModifierOwner) declaration;
 
-                if (fieldDeclaration.getVisibility() != V_PRIVATE) {
+                if (modifierOwner.getVisibility() != V_PRIVATE) {
                     hasNonPrivateMembers = true;
                 }
-                if (!fieldDeclaration.hasModifiers(STATIC)) {
+                if (!modifierOwner.hasModifiers(STATIC)) {
                     return false;
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PRIVATE;
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
 import java.util.Set;
@@ -17,7 +18,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMemberValuePair;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
-import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -46,25 +46,36 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
         }
 
         boolean hasAnyMethods = false;
+        boolean hasAnyFields = false;
         boolean hasNonPrivateCtor = false;
         boolean hasAnyCtor = false;
         for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
-            if (declaration instanceof ASTFieldDeclaration
-                && !((ASTFieldDeclaration) declaration).isStatic()) {
-                return null;
+            if (declaration instanceof ASTFieldDeclaration) {
+                ASTFieldDeclaration fieldDeclaration = (ASTFieldDeclaration) declaration;
+
+                if (fieldDeclaration.getVisibility() != V_PRIVATE) {
+                    hasAnyFields = true;
+                }
+                if (!fieldDeclaration.isStatic()) {
+                    return null;
+                }
             }
             if (declaration instanceof ASTConstructorDeclaration) {
+                ASTConstructorDeclaration constructorDeclaration = (ASTConstructorDeclaration) declaration;
+
                 hasAnyCtor = true;
-                if (((ASTConstructorDeclaration) declaration).getVisibility() != Visibility.V_PRIVATE) {
+                if (constructorDeclaration.getVisibility() != V_PRIVATE) {
                     hasNonPrivateCtor = true;
                 }
             }
 
             if (declaration instanceof ASTMethodDeclaration) {
-                if (((ASTMethodDeclaration) declaration).getVisibility() != Visibility.V_PRIVATE) {
+                ASTMethodDeclaration methodDeclaration = (ASTMethodDeclaration) declaration;
+
+                if (methodDeclaration.getVisibility() != V_PRIVATE) {
                     hasAnyMethods = true;
                 }
-                if (!((ASTMethodDeclaration) declaration).isStatic()) {
+                if (!methodDeclaration.isStatic()) {
                     return null;
                 }
             }
@@ -72,11 +83,11 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
         // account for default ctor
         hasNonPrivateCtor |= !hasAnyCtor
-            && klass.getVisibility() != Visibility.V_PRIVATE
+            && klass.getVisibility() != V_PRIVATE
             && !hasLombokPrivateCtor(klass);
 
 
-        if (hasAnyMethods && hasNonPrivateCtor) {
+        if ((hasAnyMethods || hasAnyFields) && hasNonPrivateCtor) {
             asCtx(data).addViolation(klass);
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.lang.java.ast.JModifier.STATIC;
 import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PRIVATE;
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
@@ -18,6 +19,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMemberValuePair;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -45,48 +47,31 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
             return data;
         }
 
-        boolean hasNonPrivateMethods = false;
-        boolean hasNonPrivateFields = false;
-        boolean hasNonPrivateNestedClasses = false;
-        for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
-            if (declaration instanceof ASTFieldDeclaration) {
-                ASTFieldDeclaration fieldDeclaration = (ASTFieldDeclaration) declaration;
-
-                if (fieldDeclaration.getVisibility() != V_PRIVATE) {
-                    hasNonPrivateFields = true;
-                }
-                if (!fieldDeclaration.isStatic()) {
-                    return null;
-                }
-            }
-
-            if (declaration instanceof ASTMethodDeclaration) {
-                ASTMethodDeclaration methodDeclaration = (ASTMethodDeclaration) declaration;
-
-                if (methodDeclaration.getVisibility() != V_PRIVATE) {
-                    hasNonPrivateMethods = true;
-                }
-                if (!methodDeclaration.isStatic()) {
-                    return null;
-                }
-            }
-
-            if (declaration instanceof ASTClassDeclaration) {
-                ASTClassDeclaration classDeclaration = (ASTClassDeclaration) declaration;
-
-                if (classDeclaration.getVisibility() != V_PRIVATE) {
-                    hasNonPrivateNestedClasses = true;
-                }
-                if (!classDeclaration.isStatic()) {
-                    return null;
-                }
-            }
-        }
-
-        if ((hasNonPrivateMethods || hasNonPrivateFields || hasNonPrivateNestedClasses) && hasWrongKindOfConstructor(klass)) {
+        if (allNonPrivateMembersAreStatic(klass) && hasWrongKindOfConstructor(klass)) {
             asCtx(data).addViolation(klass);
         }
         return null;
+    }
+
+    private boolean allNonPrivateMembersAreStatic(ASTClassDeclaration klass) {
+        boolean hasNonPrivateMembers = false;
+
+        for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
+            if (declaration instanceof ASTFieldDeclaration
+                    || declaration instanceof ASTMethodDeclaration
+                    || declaration instanceof ASTClassDeclaration
+            ) {
+                ModifierOwner fieldDeclaration = (ModifierOwner) declaration;
+
+                if (fieldDeclaration.getVisibility() != V_PRIVATE) {
+                    hasNonPrivateMembers = true;
+                }
+                if (!fieldDeclaration.hasModifiers(STATIC)) {
+                    return false;
+                }
+            }
+        }
+        return hasNonPrivateMembers;
     }
 
     private boolean hasWrongKindOfConstructor(ASTClassDeclaration klass) {

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1491,11 +1491,11 @@ public class MyClass {
     <rule name="UseUtilityClass"
           language="java"
           since="0.3"
-          message="All methods are static. Consider adding a private no-args constructor to prevent instantiation."
+          message="All members are static. Consider adding a private no-args constructor to prevent instantiation."
           class="net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#useutilityclass">
         <description>
-For classes that only have static methods, consider making them utility classes.
+For classes that only have static members, consider making them utility classes.
 Note that this doesn't apply to abstract classes, since their subclasses may
 well include non-static methods.  Also, if you want this class to be a utility class,
 remember to add a private constructor to prevent instantiation.
@@ -1505,8 +1505,10 @@ remember to add a private constructor to prevent instantiation.
         <example>
 <![CDATA[
 public class MaybeAUtility {
-  public static void foo() {}
-  public static void bar() {}
+    public static final int SOME_CONST = 42;
+
+    public static void foo() {}
+    public static void bar() {}
 }
 ]]>
         </example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -415,4 +415,40 @@ public class Outer extends Object {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>only static fields</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static final int SOME_CONSTANT = 42;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>both static and non-static fields</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static final int SOME_CONSTANT = 42;
+
+    public final int instance_const = 1337;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>mix of static fields and static member function</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static final int SOME_CONSTANT = 42;
+
+    public static void foo() {};
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -468,4 +468,22 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Class has state, but no public accessors</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private final int x;
+
+    private Foo(int x) {
+        this.x = x;
+    }
+
+    public static Foo fooFactory(int x) {
+        return new Foo(x);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -434,7 +434,7 @@ Foo // <--violation: line 2
     </test-code>
 
     <test-code>
-        <description>only static fields</description>
+        <description>#559 only static fields</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>1</expected-linenumbers>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -486,4 +486,44 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>only static nested classes</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static class Bar {};
+
+    public static enum Baz { X };
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>both static and non-static nested classes</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static class Bar {};
+
+    public class Baz {};
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>mix of a static field, a static member function, and a static nested class</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static final int SOME_CONSTANT = 42;
+
+    public static void foo() {};
+
+    public static class Bar {};
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -8,7 +8,7 @@
         <description>should be utility class since all static, public constructor</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>All methods are static. Consider adding a private no-args constructor to prevent instantiation.</message>
+            <message>All members are static. Consider adding a private no-args constructor to prevent instantiation.</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {


### PR DESCRIPTION
Long title: [java] Fix #559: Improve UseUtilityClassRule to trigger also on classes that have only static member variables, only static nested classes, or any mix of static member variables, static methods and static nested classes.

## Describe the PR

While the issue asked for a new rule, I think this fits very well into the existing rule. Also did some minor refactoring to the existing code.

## Related issues

- Fix #559 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

