### PR TITLE
[java] New rule: UnnecessaryBlock

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalClassStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -20,7 +21,7 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
     public RuleContext visit(ASTBlock block, Object data) {
         RuleContext ctx = (RuleContext) data;
 
-        if (doesntRestrictScope(block)) {
+        if (doesntRestrictScope(block) || blockDirectlyInBlock(block)) {
             ctx.addViolation(block);
         }
 
@@ -43,5 +44,11 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
 
     private boolean containsClassDeclaration(ASTBlock block) {
         return block.children(ASTLocalClassStatement.class).nonEmpty();
+    }
+
+    private boolean blockDirectlyInBlock(ASTBlock block) {
+        JavaNode parent = block.getParent();
+
+        return (parent instanceof ASTBlock) && (parent.getNumChildren() == 1);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -20,19 +20,17 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
     public RuleContext visit(ASTBlock block, Object data) {
         RuleContext ctx = (RuleContext) data;
 
-        if (!isInsideAnotherBlock(block)) {
-            return ctx;
+        if (doesntRestrictScope(block)) {
+            ctx.addViolation(block);
         }
-
-        if (containsVariableDeclaration(block)
-                || containsClassDeclaration(block)
-        ) {
-            return ctx;
-        }
-
-        ctx.addViolation(block);
 
         return ctx;
+    }
+
+    private boolean doesntRestrictScope(ASTBlock block) {
+        return isInsideAnotherBlock(block)
+                && !(containsVariableDeclaration(block)
+                    || containsClassDeclaration(block));
     }
 
     private boolean isInsideAnotherBlock(ASTBlock block) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -11,6 +11,9 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
+/**
+ * @since 7.25.0
+ */
 public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
 
     public UnnecessaryBlockRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -1,0 +1,42 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
+
+    public UnnecessaryBlockRule() {
+        super(ASTBlock.class);
+    }
+
+    @Override
+    public RuleContext visit(ASTBlock block, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (!isInsideAnotherBlock(block)) {
+            return ctx;
+        }
+
+        if (containsVariableDeclaration(block)) {
+            return ctx;
+        }
+
+        ctx.addViolation(block);
+
+        return ctx;
+    }
+
+    private boolean isInsideAnotherBlock(ASTBlock block) {
+        return block.getParent() instanceof ASTBlock;
+    }
+
+    private boolean containsVariableDeclaration(ASTBlock block) {
+        return block.children(ASTLocalVariableDeclaration.class).count() > 0;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalClassStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
@@ -23,7 +24,9 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
             return ctx;
         }
 
-        if (containsVariableDeclaration(block)) {
+        if (containsVariableDeclaration(block)
+                || containsClassDeclaration(block)
+        ) {
             return ctx;
         }
 
@@ -38,5 +41,9 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
 
     private boolean containsVariableDeclaration(ASTBlock block) {
         return block.children(ASTLocalVariableDeclaration.class).nonEmpty();
+    }
+
+    private boolean containsClassDeclaration(ASTBlock block) {
+        return block.children(ASTLocalClassStatement.class).nonEmpty();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockRule.java
@@ -37,6 +37,6 @@ public class UnnecessaryBlockRule extends AbstractJavaRulechainRule {
     }
 
     private boolean containsVariableDeclaration(ASTBlock block) {
-        return block.children(ASTLocalVariableDeclaration.class).count() > 0;
+        return block.children(ASTLocalVariableDeclaration.class).nonEmpty();
     }
 }

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1623,7 +1623,7 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryblock">
         <description>
-            This rule reports blocks that don't introduce a variable scope and are thus unnecessary.
+            This rule reports blocks that don't introduce a scope and are thus unnecessary.
         </description>
         <priority>3</priority>
         <example><![CDATA[

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1623,7 +1623,19 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryblock">
         <description>
-            You can remove the braces around this block without changing the program.
+Reports blocks that are unnecessary as they don't introduce a new scope.
+
+Unnecessary blocks can make code harder to read and may be misleading. They are often used
+to introduce a new variable scope, but if no variables or classes are declared within the
+block, it serves no purpose. Similarly, a block that is the only statement within another
+block is redundant. Removing them simplifies the code structure.
+
+* A block is considered unnecessary if:
+    * It is nested within another block and does not contain any local variable or local
+      class declarations.
+    * It is the only child of another block.
+* Blocks that are required by the language syntax (e.g., as the body of an `if`, `for`,
+  `while` statement, or a method body) are not reported.
         </description>
         <priority>3</priority>
         <example><![CDATA[

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1619,7 +1619,7 @@ public class Foo {
     <rule name="UnnecessaryBlock"
           language="java"
           since="7.25.0"
-          message="This block isn't necessary."
+          message="This block isn''t necessary."
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryblock">
         <description>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1623,25 +1623,35 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryblock">
         <description>
-            This rule reports blocks that don't introduce a scope and are thus unnecessary.
+            You can remove the braces around this block without changing the program.
         </description>
         <priority>3</priority>
         <example><![CDATA[
 public class Foo {
     public void bar() {
-        {
-            // Violation: This block is unnecessary as it doesn't introduce a new scope
+        { // Violation: This block is unnecessary as it doesn't introduce a new scope
             System.out.println("Hello");
         }
 
-        {
-            // No violation: This block is necessary to scope the variable "x"
+        { // No violation: This block is necessary to scope the variable "x"
             int x = 1;
             System.out.println(x);
         }
 
         // "x" can be redefined here because the previous "x" was scoped to the block above
         int x = 2;
+    }
+
+    public void baz() {
+        if (foo) {{ // Violation: Why the second block?
+            int i = 1;
+            System.out.println(i);
+        }}
+
+        if (foo) { // No violation: This is what the above should look like
+            int i = 1;
+            System.out.println(i);
+        }
     }
 }
         ]]>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1616,6 +1616,38 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="UnnecessaryBlock"
+          language="java"
+          since="7.25.0"
+          message="This block isn't necessary."
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryBlockRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryblock">
+        <description>
+            This rule reports blocks that don't introduce a variable scope and are thus unnecessary.
+        </description>
+        <priority>3</priority>
+        <example><![CDATA[
+public class Foo {
+    public void bar() {
+        {
+            // Violation: This block is unnecessary as it doesn't introduce a new scope
+            System.out.println("Hello");
+        }
+
+        {
+            // No violation: This block is necessary to scope the variable "x"
+            int x = 1;
+            System.out.println(x);
+        }
+
+        // "x" can be redefined here because the previous "x" was scoped to the block above
+        int x = 2;
+    }
+}
+        ]]>
+        </example>
+    </rule>
+
     <rule name="UnnecessaryBoxing"
           language="java"
           since="7.0.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockTest.java
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import net.sourceforge.pmd.test.PmdRuleTst;
 
-public class UnnecessaryBlockTest extends PmdRuleTst {
+class UnnecessaryBlockTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBlockTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class UnnecessaryBlockTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -194,6 +194,8 @@ public class Foo {
         <description>Double-Brace initialization is bad, but not a violation of this rule</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.*;
+
 public class Foo {
     public List<String> good() {
         return new ArrayList<String>(){{

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -195,7 +195,7 @@ public class Foo {
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
-    public List<String> bad() {
+    public List<String> good() {
         return new ArrayList<String>(){{
             add("a");
             add("b");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_1_1.xsd">
+
+    <test-code>
+        <description>Block is unnecessary</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3-5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public boolean bad(Object o) {
+        {
+            if(obj == null) return false;
+        }
+        return true;
+    }}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Class blocks and method blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>constructor blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Foo() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Loop bodies are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        for(int i = 0; i < 5; i++) {
+            System.out.println(i);
+        }
+        for(Object o : new ArrayList<Object>()) {}
+        while(true) {}
+        do {} while(true);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bodies of if are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        if(true) {}
+        if(true) {} else {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bodies of switch statement are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar(int i) {
+        switch(i) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>try blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        try {
+            System.out.println("hi");
+        } catch (Exception e) {
+            System.out.println("error");
+        } finally {
+            System.out.println("finally");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>lambda blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        Runnable r = () -> {
+            System.out.println("hi");
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>synchronized blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        synchronized(this) {
+            System.out.println("hi");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>initializer blocks are necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    {}
+
+    static {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Block is necessary, because it contains variable declaration</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean bad(Object o) {
+        {
+            if(obj == null) return false;
+            Object blub;
+        }
+        return true;
+    }}
+        ]]></code>
+    </test-code>
+
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -143,7 +143,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Block is necessary, because it contains variable declaration</description>
+        <description>Block is necessary, because it restricts scope of variable</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -153,7 +153,25 @@ public class Foo {
             Object blub;
         }
         return true;
-    }}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Block is necessary, because it restricts scope of local class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void good() {
+		{
+			class C { }
+		}
+		{
+			enum C { X }
+		}
+    }
+}
         ]]></code>
     </test-code>
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -175,4 +175,35 @@ public class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Unnecessary block created by typo</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bad(boolean foo) {
+        if (foo) {{
+            int i = 1;
+            System.out.println(i);
+        }}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Double-Brace initialization is bad, but not a violation of this rule</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public List<String> bad() {
+        return new ArrayList<String>(){{
+            add("a");
+            add("b");
+            add("c");
+        }};
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

New rule that flags unnecessary blocks. A block is necessary if it is the body of a method/control structure etc., or if it is used to restrict the scope of a variable. All other blocks are deemed unnecessary.

## Related issues

- Fix #6622 
- This rule would have caught the issues described in #6519 and #6491

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

