### PR TITLE
[test] Split up AbstractRuleSetFactoryTest.testAllPMDBuiltInRulesMeetConventions()

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -115,6 +115,7 @@ this is already done.
 * [#6605](https://github.com/pmd/pmd/pull/6605): \[java] Fix #6308: Add syntax highlighting to MarkdownRenderer - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6621](https://github.com/pmd/pmd/pull/6621): \[core] Fix #4972: Update antlr from 4.9.3 to 4.13.2 - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6623](https://github.com/pmd/pmd/pull/6623): \[java] Cleanup: Remove TODO from ModifierOwner.getVisibility() - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#6646](https://github.com/pmd/pmd/pull/6646): \[test] Split up AbstractRuleSetFactoryTest.testAllPMDBuiltInRulesMeetConventions() - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6654](https://github.com/pmd/pmd/pull/6654): \[swift] Fix invalid swift token OSXApplicationExtension - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 ### 📦️ Dependency updates

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -256,6 +256,34 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
+     * no rules have a suppression regex
+     */
+    @ParameterizedTest
+    @MethodSource("getRuleSetFileNames")
+    void testAllPMDBuiltInRulesHaveNoSuppressionRegex(String fileName) {
+        List<String> messages = new ArrayList<>();
+
+        RuleSet ruleSet = loadRuleSetByFileName(fileName);
+        for (Rule rule : ruleSet.getRules()) {
+            // Skip references
+            if (rule instanceof RuleReference) {
+                continue;
+            }
+
+            // Should not have violation suppress regex property
+            if (rule.getProperty(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR).isPresent()) {
+                messages.add("Rule " + fileName + "/" + rule.getName() + " should not have '" + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "', this is intended for end user customization only.\n");
+            }
+        }
+
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules should NOT have a " + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + " property (" + messages.size() + " do)\n" + String.join("\n", messages));
+        }
+    }
+
+    /**
+     * Checks all rulesets of all languages on the classpath and verifies that
      * all required attributes for all rules are specified.
      *
      * @throws Exception
@@ -264,7 +292,6 @@ public abstract class AbstractRuleSetFactoryTest {
     @ParameterizedTest
     @MethodSource("getRuleSetFileNames")
     void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
-        int invalidRegexSuppress = 0;
         int invalidXPathSuppress = 0;
         StringBuilder messages = new StringBuilder();
         RuleSet ruleSet = loadRuleSetByFileName(fileName);
@@ -275,17 +302,6 @@ public abstract class AbstractRuleSetFactoryTest {
                 continue;
             }
 
-            // Should not have violation suppress regex property
-            if (rule.getProperty(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR).isPresent()) {
-                invalidRegexSuppress++;
-                messages.append("Rule ")
-                        .append(fileName)
-                        .append("/")
-                        .append(rule.getName())
-                        .append(" should not have '")
-                        .append(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name())
-                        .append("', this is intended for end user customization only.\n");
-            }
             // Should not have violation suppress xpath property
             if (rule.getProperty(Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR).isPresent()) {
                 invalidXPathSuppress++;
@@ -294,11 +310,9 @@ public abstract class AbstractRuleSetFactoryTest {
         }
         // We do this at the end to ensure we test ALL the rules before failing
         // the test
-        if (invalidRegexSuppress > 0
-                || invalidXPathSuppress > 0) {
+        if (invalidXPathSuppress > 0) {
             fail("All built-in PMD rules need no '"
-                    + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "' property (" + invalidRegexSuppress
-                    + " are invalid), and no '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
+                    + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
                     + invalidXPathSuppress + " are invalid)\n" + messages);
         }
     }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -220,21 +220,15 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
-     * all required attributes for all rules are specified.
-     *
-     * @throws Exception
-     *             any error
+     * all rules have a valid classname
      */
     @ParameterizedTest
     @MethodSource("getRuleSetFileNames")
-    void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
-        int invalidClassName = 0;
-        int invalidRegexSuppress = 0;
-        int invalidXPathSuppress = 0;
-        StringBuilder messages = new StringBuilder();
+    void testAllPMDBuiltInRulesHaveValidClassName(String fileName) {
+        List<String> messages = new ArrayList<>();
+
         RuleSet ruleSet = loadRuleSetByFileName(fileName);
         for (Rule rule : ruleSet.getRules()) {
-
             // Skip references
             if (rule instanceof RuleReference) {
                 continue;
@@ -248,21 +242,39 @@ public abstract class AbstractRuleSetFactoryTest {
             }
 
             // Proper class name/packaging?
-            String expectedClassName = "net.sourceforge.pmd.lang." + language.getId() + ".rule." + group
-                    + "." + rule.getName() + "Rule";
-            if (!rule.getRuleClass().equals(expectedClassName)
-                    && !validXPathClassNames.contains(rule.getRuleClass())) {
-                invalidClassName++;
-                messages.append("Rule ")
-                        .append(fileName)
-                        .append("/")
-                        .append(rule.getName())
-                        .append(" seems to have an invalid 'class' value (")
-                        .append(rule.getRuleClass())
-                        .append("), it should be:")
-                        .append(expectedClassName)
-                        .append('\n');
+            String expectedClassName = "net.sourceforge.pmd.lang." + language.getId() + ".rule." + group + "." + rule.getName() + "Rule";
+            if (!rule.getRuleClass().equals(expectedClassName) && !validXPathClassNames.contains(rule.getRuleClass())) {
+                messages.add("Rule " + fileName + "/" + rule.getName() + " seems to have an invalid 'class' value (" + rule.getRuleClass() + "), it should be: " + expectedClassName + '\n');
             }
+        }
+
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules need a class name meeting conventions (" + messages.size() + " are invalid)\n" + String.join("\n", messages));
+        }
+    }
+
+    /**
+     * Checks all rulesets of all languages on the classpath and verifies that
+     * all required attributes for all rules are specified.
+     *
+     * @throws Exception
+     *             any error
+     */
+    @ParameterizedTest
+    @MethodSource("getRuleSetFileNames")
+    void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
+        int invalidRegexSuppress = 0;
+        int invalidXPathSuppress = 0;
+        StringBuilder messages = new StringBuilder();
+        RuleSet ruleSet = loadRuleSetByFileName(fileName);
+        for (Rule rule : ruleSet.getRules()) {
+
+            // Skip references
+            if (rule instanceof RuleReference) {
+                continue;
+            }
+
             // Should not have violation suppress regex property
             if (rule.getProperty(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR).isPresent()) {
                 invalidRegexSuppress++;
@@ -282,9 +294,9 @@ public abstract class AbstractRuleSetFactoryTest {
         }
         // We do this at the end to ensure we test ALL the rules before failing
         // the test
-        if (invalidClassName > 0 || invalidRegexSuppress > 0
+        if (invalidRegexSuppress > 0
                 || invalidXPathSuppress > 0) {
-            fail("All built-in PMD rules need a class name meeting conventions (" + invalidClassName + " are invalid), no '"
+            fail("All built-in PMD rules need no '"
                     + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "' property (" + invalidRegexSuppress
                     + " are invalid), and no '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
                     + invalidXPathSuppress + " are invalid)\n" + messages);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -153,6 +153,34 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
+     * all rules have a 'since' attribute.
+     */
+    @ParameterizedTest
+    @MethodSource("getRuleSetFileNames")
+    void testAllPMDBuiltInRulesHaveSince(String fileName) {
+        List<String> messages = new ArrayList<>();
+
+        RuleSet ruleSet = loadRuleSetByFileName(fileName);
+        for (Rule rule : ruleSet.getRules()) {
+            // Skip references
+            if (rule instanceof RuleReference) {
+                continue;
+            }
+
+            // Is since missing ?
+            if (rule.getSince() == null) {
+                messages.add("Rule " + fileName + "/" + rule.getName() + " is missing 'since' attribute\n");
+            }
+        }
+
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules need 'since' attribute (" + messages.size() + " are missing)\n" + String.join("\n", messages));
+        }
+    }
+
+    /**
+     * Checks all rulesets of all languages on the classpath and verifies that
      * all required attributes for all rules are specified.
      *
      * @throws Exception
@@ -161,7 +189,6 @@ public abstract class AbstractRuleSetFactoryTest {
     @ParameterizedTest
     @MethodSource("getRuleSetFileNames")
     void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
-        int invalidSinceAttributes = 0;
         int invalidExternalInfoURL = 0;
         int invalidClassName = 0;
         int invalidRegexSuppress = 0;
@@ -182,15 +209,6 @@ public abstract class AbstractRuleSetFactoryTest {
                 group = group.substring(0, group.indexOf('-'));
             }
 
-            // Is since missing ?
-            if (rule.getSince() == null) {
-                invalidSinceAttributes++;
-                messages.append("Rule ")
-                        .append(fileName)
-                        .append("/")
-                        .append(rule.getName())
-                        .append(" is missing 'since' attribute\n");
-            }
             // Is URL valid ?
             if (rule.getExternalInfoUrl() == null || "".equalsIgnoreCase(rule.getExternalInfoUrl())) {
                 invalidExternalInfoURL++;
@@ -254,10 +272,9 @@ public abstract class AbstractRuleSetFactoryTest {
         }
         // We do this at the end to ensure we test ALL the rules before failing
         // the test
-        if (invalidSinceAttributes > 0 || invalidExternalInfoURL > 0 || invalidClassName > 0 || invalidRegexSuppress > 0
+        if (invalidExternalInfoURL > 0 || invalidClassName > 0 || invalidRegexSuppress > 0
                 || invalidXPathSuppress > 0) {
-            fail("All built-in PMD rules need 'since' attribute (" + invalidSinceAttributes
-                    + " are missing), a proper ExternalURLInfo (" + invalidExternalInfoURL
+            fail("All built-in PMD rules need a proper ExternalURLInfo (" + invalidExternalInfoURL
                     + " are invalid), a class name meeting conventions (" + invalidClassName + " are invalid), no '"
                     + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "' property (" + invalidRegexSuppress
                     + " are invalid), and no '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -284,16 +284,13 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
-     * all required attributes for all rules are specified.
-     *
-     * @throws Exception
-     *             any error
+     * no rules have a suppression XPath
      */
     @ParameterizedTest
     @MethodSource("getRuleSetFileNames")
-    void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
-        int invalidXPathSuppress = 0;
-        StringBuilder messages = new StringBuilder();
+    void testAllPMDBuiltInRulesHaveNoSuppressionXPath(String fileName) {
+        List<String> messages = new ArrayList<>();
+
         RuleSet ruleSet = loadRuleSetByFileName(fileName);
         for (Rule rule : ruleSet.getRules()) {
 
@@ -304,16 +301,12 @@ public abstract class AbstractRuleSetFactoryTest {
 
             // Should not have violation suppress xpath property
             if (rule.getProperty(Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR).isPresent()) {
-                invalidXPathSuppress++;
-                messages.append("Rule ").append(fileName).append("/").append(rule.getName()).append(" should not have '").append(Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name()).append("', this is intended for end user customization only.").append(System.lineSeparator());
+                messages.add("Rule " + fileName + "/" + rule.getName() + " should not have '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "', this is intended for end user customization only.\n");
             }
         }
-        // We do this at the end to ensure we test ALL the rules before failing
-        // the test
-        if (invalidXPathSuppress > 0) {
-            fail("All built-in PMD rules need no '"
-                    + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
-                    + invalidXPathSuppress + " are invalid)\n" + messages);
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules should NOT have a '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property (" + messages.size() + " do)\n" + String.join("\n", messages));
         }
     }
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -181,6 +181,45 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
+     * all rules have the correct externalInfoUrl
+     */
+    @ParameterizedTest
+    @MethodSource("getRuleSetFileNames")
+    void testAllPMDBuiltInRulesHaveCorrectExternalInfoUrl(String fileName) {
+        List<String> messages = new ArrayList<>();
+
+        RuleSet ruleSet = loadRuleSetByFileName(fileName);
+        for (Rule rule : ruleSet.getRules()) {
+            // Skip references
+            if (rule instanceof RuleReference) {
+                continue;
+            }
+
+            Language language = rule.getLanguage();
+
+            // Is URL correct ?
+            if (rule.getExternalInfoUrl() == null || "".equalsIgnoreCase(rule.getExternalInfoUrl())) {
+                messages.add("Rule " + fileName + "/" + rule.getName() + " is missing 'externalInfoURL' attribute\n");
+            } else {
+                String expectedExternalInfoURL = "https://docs.pmd-code.org/.+/pmd_rules_"
+                        + language.getId() + "_"
+                        + IOUtil.getFilenameBase(fileName)
+                        + ".html#"
+                        + rule.getName().toLowerCase(Locale.ROOT);
+                if (rule.getExternalInfoUrl() == null || !rule.getExternalInfoUrl().matches(expectedExternalInfoURL)) {
+                    messages.add("Rule " + fileName + "/" + rule.getName() + " seems to have an invalid 'externalInfoURL' value (" + rule.getExternalInfoUrl() + "), it should be: " + expectedExternalInfoURL + '\n');
+                }
+            }
+        }
+
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules need a proper ExternalURLInfo (" + messages.size() + " are incorrect)\n" + String.join("\n", messages));
+        }
+    }
+
+    /**
+     * Checks all rulesets of all languages on the classpath and verifies that
      * all required attributes for all rules are specified.
      *
      * @throws Exception
@@ -189,7 +228,6 @@ public abstract class AbstractRuleSetFactoryTest {
     @ParameterizedTest
     @MethodSource("getRuleSetFileNames")
     void testAllPMDBuiltInRulesMeetConventions(String fileName) throws Exception {
-        int invalidExternalInfoURL = 0;
         int invalidClassName = 0;
         int invalidRegexSuppress = 0;
         int invalidXPathSuppress = 0;
@@ -209,34 +247,6 @@ public abstract class AbstractRuleSetFactoryTest {
                 group = group.substring(0, group.indexOf('-'));
             }
 
-            // Is URL valid ?
-            if (rule.getExternalInfoUrl() == null || "".equalsIgnoreCase(rule.getExternalInfoUrl())) {
-                invalidExternalInfoURL++;
-                messages.append("Rule ")
-                        .append(fileName)
-                        .append("/")
-                        .append(rule.getName())
-                        .append(" is missing 'externalInfoURL' attribute\n");
-            } else {
-                String expectedExternalInfoURL = "https://docs.pmd-code.org/.+/pmd_rules_"
-                        + language.getId() + "_"
-                        + IOUtil.getFilenameBase(fileName)
-                        + ".html#"
-                        + rule.getName().toLowerCase(Locale.ROOT);
-                if (rule.getExternalInfoUrl() == null
-                        || !rule.getExternalInfoUrl().matches(expectedExternalInfoURL)) {
-                    invalidExternalInfoURL++;
-                    messages.append("Rule ")
-                            .append(fileName)
-                            .append("/")
-                            .append(rule.getName())
-                            .append(" seems to have an invalid 'externalInfoURL' value (")
-                            .append(rule.getExternalInfoUrl())
-                            .append("), it should be:")
-                            .append(expectedExternalInfoURL)
-                            .append('\n');
-                }
-            }
             // Proper class name/packaging?
             String expectedClassName = "net.sourceforge.pmd.lang." + language.getId() + ".rule." + group
                     + "." + rule.getName() + "Rule";
@@ -272,10 +282,9 @@ public abstract class AbstractRuleSetFactoryTest {
         }
         // We do this at the end to ensure we test ALL the rules before failing
         // the test
-        if (invalidExternalInfoURL > 0 || invalidClassName > 0 || invalidRegexSuppress > 0
+        if (invalidClassName > 0 || invalidRegexSuppress > 0
                 || invalidXPathSuppress > 0) {
-            fail("All built-in PMD rules need a proper ExternalURLInfo (" + invalidExternalInfoURL
-                    + " are invalid), a class name meeting conventions (" + invalidClassName + " are invalid), no '"
+            fail("All built-in PMD rules need a class name meeting conventions (" + invalidClassName + " are invalid), no '"
                     + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "' property (" + invalidRegexSuppress
                     + " are invalid), and no '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
                     + invalidXPathSuppress + " are invalid)\n" + messages);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/rule/AbstractRuleSetFactoryTest.java
@@ -129,6 +129,30 @@ public abstract class AbstractRuleSetFactoryTest {
 
     /**
      * Checks all rulesets of all languages on the classpath and verifies that
+     * all rules are in alphabetical order.
+     */
+    @ParameterizedTest
+    @MethodSource("getRuleSetFileNames")
+    void testAllPMDBuiltInRuleSetsAreSorted(String fileName) {
+        List<String> messages = new ArrayList<>();
+
+        String lastName = null;
+        RuleSet ruleSet = loadRuleSetByFileName(fileName);
+        for (Rule rule : ruleSet.getRules()) {
+            if (lastName != null && String.CASE_INSENSITIVE_ORDER.compare(rule.getName(), lastName) < 0) {
+                messages.add(rule.getName() + " should be before " + lastName);
+            }
+            lastName = rule.getName();
+        }
+
+        // We do this at the end to ensure we test ALL the rules before failing the test
+        if (!messages.isEmpty()) {
+            fail("All built-in PMD rules need to be alphabetically sorted (" + messages.size() + " misplaced)\n" + String.join("\n", messages));
+        }
+    }
+
+    /**
+     * Checks all rulesets of all languages on the classpath and verifies that
      * all required attributes for all rules are specified.
      *
      * @throws Exception
@@ -142,9 +166,7 @@ public abstract class AbstractRuleSetFactoryTest {
         int invalidClassName = 0;
         int invalidRegexSuppress = 0;
         int invalidXPathSuppress = 0;
-        int invalidOrder = 0;
         StringBuilder messages = new StringBuilder();
-        String lastName = null;
         RuleSet ruleSet = loadRuleSetByFileName(fileName);
         for (Rule rule : ruleSet.getRules()) {
 
@@ -152,13 +174,6 @@ public abstract class AbstractRuleSetFactoryTest {
             if (rule instanceof RuleReference) {
                 continue;
             }
-            if (lastName != null
-                    && String.CASE_INSENSITIVE_ORDER.compare(rule.getName(), lastName) < 0) {
-                invalidOrder++;
-                messages.append(rule.getName()).append(" should be before ")
-                    .append(lastName).append("\n");
-            }
-            lastName = rule.getName();
 
             Language language = rule.getLanguage();
             String group = fileName.substring(fileName.lastIndexOf('/') + 1);
@@ -240,14 +255,13 @@ public abstract class AbstractRuleSetFactoryTest {
         // We do this at the end to ensure we test ALL the rules before failing
         // the test
         if (invalidSinceAttributes > 0 || invalidExternalInfoURL > 0 || invalidClassName > 0 || invalidRegexSuppress > 0
-                || invalidXPathSuppress > 0 || invalidOrder > 0) {
+                || invalidXPathSuppress > 0) {
             fail("All built-in PMD rules need 'since' attribute (" + invalidSinceAttributes
                     + " are missing), a proper ExternalURLInfo (" + invalidExternalInfoURL
                     + " are invalid), a class name meeting conventions (" + invalidClassName + " are invalid), no '"
                     + Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR.name() + "' property (" + invalidRegexSuppress
                     + " are invalid), and no '" + Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR.name() + "' property ("
-                    + invalidXPathSuppress + " are invalid) and be alphabetically sorted ("
-                    + invalidOrder + " misplaced)\n" + messages);
+                    + invalidXPathSuppress + " are invalid)\n" + messages);
         }
     }
 


### PR DESCRIPTION
## Describe the PR

Recently I got the following test failure:
```
org.opentest4j.AssertionFailedError: All built-in PMD rules need 'since' attribute (0 are missing), a proper ExternalURLInfo (0 are invalid), a class name meeting conventions (0 are invalid), no 'violationSuppressRegex' property (0 are invalid), and no 'violationSuppressXPath' property (0 are invalid) and be alphabetically sorted (1 misplaced)
```
... and because I didn't scroll right (nor down), I was like "err... what do you want to tell me?"

This PR breaks up the test into six separate tests. This way, you only get the message about what is actually wrong.

testAllPMDBuiltInRuleSetsAreSorted now checks RuleRefs, too.

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

