### PR TITLE
[kotlin] Fix #6648: Multi-dollar interpolation for regular strings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 *       text=auto
 *.java  text
+*.kt    text eol=lf
 *.xml   text
 *.jjt   text
 *.jj    text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 *       text=auto
 *.java  text
-*.kt    text eol=lf
 *.xml   text
 *.jjt   text
 *.jj    text

--- a/pmd-kotlin/src/main/antlr4/net/sourceforge/pmd/lang/kotlin/ast/Kotlin.g4
+++ b/pmd-kotlin/src/main/antlr4/net/sourceforge/pmd/lang/kotlin/ast/Kotlin.g4
@@ -565,8 +565,11 @@ stringLiteral
     | multiLineStringLiteral
     ;
 
+// Multi-dollar prefix support per KEEP-375 (stable in Kotlin 2.2):
+// https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0375-dollar-escape.md
+// N '$' chars before the quote means N '$' chars are required to start interpolation.
 lineStringLiteral
-    : QUOTE_OPEN (lineStringContent | lineStringExpression)* QUOTE_CLOSE
+    : MultiDollarPrefix? QUOTE_OPEN (lineStringContent | lineStringExpression)* QUOTE_CLOSE
     ;
 
 multiLineStringLiteral

--- a/pmd-kotlin/src/main/antlr4/net/sourceforge/pmd/lang/kotlin/ast/KotlinLexer.g4
+++ b/pmd-kotlin/src/main/antlr4/net/sourceforge/pmd/lang/kotlin/ast/KotlinLexer.g4
@@ -9,10 +9,20 @@ import UnicodeClasses;
 
 @members {
     /**
-     * For multi-dollar raw strings (e.g. $$$"""..."""), this stores the number of '$'
-     * required to start a template entry within this multi-line string.
+     * For multi-dollar string literals (e.g. {@code $$"..."} or {@code $$$"""..."""}),
+     * this stores the number of {@code $} characters required to start a string template
+     * entry within the current string literal.
      *
-     * Kotlin rules: only '$' runs of length >= prefix are treated as template starts.
+     * <p>Kotlin rule (KEEP-375, stable in Kotlin 2.2,
+     * <a href="https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0375-dollar-escape.md">spec</a>):
+     * a run of N {@code $} chars before the opening quote means interpolation requires exactly N
+     * {@code $} chars. A shorter run is literal; a longer run splits into literal dollars plus
+     * an interpolation start.
+     *
+     * <p><b>Performance note:</b> this is a single field, not a stack. Nested multi-dollar
+     * strings with different prefix counts (e.g. {@code $$"outer $${inner $$"nested"} end"})
+     * will overwrite this field; after the inner string closes the outer count is lost.
+     * This is a known limitation inherited from the original multi-line string handling.
      */
     private int multiLineMinDollars = 1;
 
@@ -366,11 +376,22 @@ MultiDollarPrefix
 mode LineString;
 
 QUOTE_CLOSE
-    : '"' -> popMode
+    : '"' { multiLineMinDollars = 1; } -> popMode
     ;
 
 LineStrRef
-    : FieldIdentifier
+    : '$'+ IdentifierOrSoftKey
+      {
+          int dollarCount = countLeadingDollars(getText());
+          if (dollarCount < multiLineMinDollars) {
+              setType(LineStrText);
+          } else if (dollarCount > multiLineMinDollars) {
+              int rewind = getText().length() - 1; // keep the first '$'
+              setText("$");
+              setType(LineStrText);
+              _input.seek(_input.index() - rewind);
+          }
+      }
     ;
 
 LineStrText
@@ -383,7 +404,20 @@ LineStrEscapedChar
     ;
 
 LineStrExprStart
-    : '${' -> pushMode(DEFAULT_MODE)
+    : '$'+ '{'
+      {
+          int dollarCount = countLeadingDollars(getText());
+          if (dollarCount < multiLineMinDollars) {
+              setType(LineStrText);
+          } else if (dollarCount > multiLineMinDollars) {
+              int rewind = getText().length() - 1; // keep the first '$'
+              setText("$");
+              setType(LineStrText);
+              _input.seek(_input.index() - rewind);
+          } else {
+              pushMode(DEFAULT_MODE);
+          }
+      }
     ;
 
 mode MultiLineString;
@@ -502,6 +536,7 @@ Inside_EQEQ: EQEQ  -> type(EQEQ);
 Inside_EQEQEQ: EQEQEQ  -> type(EQEQEQ);
 Inside_SINGLE_QUOTE: SINGLE_QUOTE  -> type(SINGLE_QUOTE);
 Inside_AMP: AMP  -> type(AMP);
+Inside_MultiDollarPrefix: '$'+ { multiLineMinDollars = getText().length(); } -> type(MultiDollarPrefix);
 Inside_QUOTE_OPEN: QUOTE_OPEN -> pushMode(LineString), type(QUOTE_OPEN);
 Inside_TRIPLE_QUOTE_OPEN: TRIPLE_QUOTE_OPEN -> pushMode(MultiLineString), type(TRIPLE_QUOTE_OPEN);
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserMultiLineStringTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserMultiLineStringTest.java
@@ -40,4 +40,9 @@ class KotlinParserMultiLineStringTest extends BaseKotlinTreeDumpTest {
     void testSingleDollarExpressionWithoutPrefix() {
         doTest("SingleDollarExprNoPrefix");
     }
+
+    @Test
+    void testMultiDollarLineStringRefAndExpr() {
+        doTest("MultiDollarLineStringRef");
+    }
 }

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTests.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTests.java
@@ -4,16 +4,79 @@
 
 package net.sourceforge.pmd.lang.kotlin.ast;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import org.junit.jupiter.api.Test;
 
 /**
- * Minimal test that parses a simple Kotlin snippet and see if there are no parsing issues.
+ * Miscellaneous Kotlin parser regression tests.
  */
 class KotlinParserTests extends BaseKotlinTreeDumpTest {
 
     @Test
     void testSimpleKotlin() {
         doTest("Simple");
+    }
+
+    // Regression tests for https://github.com/pmd/pmd/issues/6648
+    // Multi-dollar string interpolation (Kotlin 2.2, KEEP-375) in function and annotation args.
+
+    @Test
+    void multiDollarLineStringInFunctionArg() {
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "private fun clazz(name: String) = name\n"
+            + "val x = clazz($$\"java.util.Collections\\$SingletonList\")"
+        ));
+    }
+
+    @Test
+    void multiDollarLineStringInAnnotationArg() {
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "annotation class Scheduled(val fixedDelayString: String)\n"
+            + "@Scheduled(fixedDelayString = $$\"\\${app.interval:PT59M}\")\n"
+            + "fun execute() { }"
+        ));
+    }
+
+    // KEEP-375 spec examples: https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0375-dollar-escape.md
+
+    @Test
+    void specExampleLiteralDollarsInFormatString() {
+        // $$"..." — single $ not interpolation (needs 2), so %1$s is verbatim
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "fun tr(s: String) = s\n"
+            + "val x = tr($$\"Could not copy the file into the %1$s directory: %2$s\")"
+        ));
+    }
+
+    @Test
+    void specExampleDollarBlockLongerThanPrefix() {
+        // $$ starts interpolation; $$$ = one literal $ + $$ interpolation start
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "data class Item(val name: String, val price: Int)\n"
+            + "val item = Item(\"Foo\", 42)\n"
+            + "val s = $$\"$${item.name} costs $$${item.price}\""
+        ));
+    }
+
+    @Test
+    void specExampleEscapeNotCountingForInterpolation() {
+        // $$"$\$$hello" -> value $$$hello: first $ literal, \$ verbatim, last $ literal
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "val s = $$\"$\\$$hello\""
+        ));
+    }
+
+    @Test
+    void specExampleMultilineDollarPrefix() {
+        // $$"""...""" — single $ is literal (no backslash needed), $$ starts interpolation
+        assertDoesNotThrow(() -> KotlinParsingHelper.DEFAULT.parse(
+            "val title = \"example\"\n"
+            + "val schema = $$\"\"\"\n"
+            + "  \"$schema\": \"draft-2020\",\n"
+            + "  \"title\": \"$${title}\"\n"
+            + "\"\"\""
+        ));
     }
 
 }

--- a/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/ast/testdata/MultiDollarLineStringRef.kt
+++ b/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/ast/testdata/MultiDollarLineStringRef.kt
@@ -1,0 +1,8 @@
+class Foo {
+    fun foo() {
+        val myVar = "hello"
+        val s1 = "normal $myVar"
+        val s2 = $$"$$myVar and literal $end"
+        val s3 = $$"$${myVar.length} chars"
+    }
+}

--- a/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/ast/testdata/MultiDollarLineStringRef.txt
+++ b/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/ast/testdata/MultiDollarLineStringRef.txt
@@ -1,0 +1,196 @@
++- KotlinFile
+   +- PackageHeader
+   +- ImportList
+   +- TopLevelObject
+   |  +- Declaration
+   |  |  +- ClassDeclaration
+   |  |     +- T-CLASS
+   |  |     +- SimpleIdentifier
+   |  |     |  +- T-Identifier
+   |  |     +- ClassBody
+   |  |        +- T-LCURL
+   |  |        +- T-NL
+   |  |        +- ClassMemberDeclarations
+   |  |        |  +- ClassMemberDeclaration
+   |  |        |  |  +- Declaration
+   |  |        |  |     +- FunctionDeclaration
+   |  |        |  |        +- T-FUN
+   |  |        |  |        +- SimpleIdentifier
+   |  |        |  |        |  +- T-Identifier
+   |  |        |  |        +- FunctionValueParameters
+   |  |        |  |        |  +- T-LPAREN
+   |  |        |  |        |  +- T-RPAREN
+   |  |        |  |        +- FunctionBody
+   |  |        |  |           +- Block
+   |  |        |  |              +- T-LCURL
+   |  |        |  |              +- T-NL
+   |  |        |  |              +- Statements
+   |  |        |  |              |  +- Statement
+   |  |        |  |              |  |  +- Declaration
+   |  |        |  |              |  |     +- PropertyDeclaration
+   |  |        |  |              |  |        +- T-VAL
+   |  |        |  |              |  |        +- VariableDeclaration
+   |  |        |  |              |  |        |  +- SimpleIdentifier
+   |  |        |  |              |  |        |     +- T-Identifier
+   |  |        |  |              |  |        +- T-ASSIGNMENT
+   |  |        |  |              |  |        +- Expression
+   |  |        |  |              |  |           +- Disjunction
+   |  |        |  |              |  |              +- Conjunction
+   |  |        |  |              |  |                 +- Equality
+   |  |        |  |              |  |                    +- Comparison
+   |  |        |  |              |  |                       +- GenericCallLikeComparison
+   |  |        |  |              |  |                          +- InfixOperation
+   |  |        |  |              |  |                             +- ElvisExpression
+   |  |        |  |              |  |                                +- InfixFunctionCall
+   |  |        |  |              |  |                                   +- RangeExpression
+   |  |        |  |              |  |                                      +- AdditiveExpression
+   |  |        |  |              |  |                                         +- MultiplicativeExpression
+   |  |        |  |              |  |                                            +- AsExpression
+   |  |        |  |              |  |                                               +- PrefixUnaryExpression
+   |  |        |  |              |  |                                                  +- PostfixUnaryExpression
+   |  |        |  |              |  |                                                     +- PrimaryExpression
+   |  |        |  |              |  |                                                        +- StringLiteral
+   |  |        |  |              |  |                                                           +- LineStringLiteral
+   |  |        |  |              |  |                                                              +- T-QUOTE_OPEN
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrText
+   |  |        |  |              |  |                                                              +- T-QUOTE_CLOSE
+   |  |        |  |              |  +- Semis
+   |  |        |  |              |  |  +- T-NL
+   |  |        |  |              |  +- Statement
+   |  |        |  |              |  |  +- Declaration
+   |  |        |  |              |  |     +- PropertyDeclaration
+   |  |        |  |              |  |        +- T-VAL
+   |  |        |  |              |  |        +- VariableDeclaration
+   |  |        |  |              |  |        |  +- SimpleIdentifier
+   |  |        |  |              |  |        |     +- T-Identifier
+   |  |        |  |              |  |        +- T-ASSIGNMENT
+   |  |        |  |              |  |        +- Expression
+   |  |        |  |              |  |           +- Disjunction
+   |  |        |  |              |  |              +- Conjunction
+   |  |        |  |              |  |                 +- Equality
+   |  |        |  |              |  |                    +- Comparison
+   |  |        |  |              |  |                       +- GenericCallLikeComparison
+   |  |        |  |              |  |                          +- InfixOperation
+   |  |        |  |              |  |                             +- ElvisExpression
+   |  |        |  |              |  |                                +- InfixFunctionCall
+   |  |        |  |              |  |                                   +- RangeExpression
+   |  |        |  |              |  |                                      +- AdditiveExpression
+   |  |        |  |              |  |                                         +- MultiplicativeExpression
+   |  |        |  |              |  |                                            +- AsExpression
+   |  |        |  |              |  |                                               +- PrefixUnaryExpression
+   |  |        |  |              |  |                                                  +- PostfixUnaryExpression
+   |  |        |  |              |  |                                                     +- PrimaryExpression
+   |  |        |  |              |  |                                                        +- StringLiteral
+   |  |        |  |              |  |                                                           +- LineStringLiteral
+   |  |        |  |              |  |                                                              +- T-QUOTE_OPEN
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrText
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrRef
+   |  |        |  |              |  |                                                              +- T-QUOTE_CLOSE
+   |  |        |  |              |  +- Semis
+   |  |        |  |              |  |  +- T-NL
+   |  |        |  |              |  +- Statement
+   |  |        |  |              |  |  +- Declaration
+   |  |        |  |              |  |     +- PropertyDeclaration
+   |  |        |  |              |  |        +- T-VAL
+   |  |        |  |              |  |        +- VariableDeclaration
+   |  |        |  |              |  |        |  +- SimpleIdentifier
+   |  |        |  |              |  |        |     +- T-Identifier
+   |  |        |  |              |  |        +- T-ASSIGNMENT
+   |  |        |  |              |  |        +- Expression
+   |  |        |  |              |  |           +- Disjunction
+   |  |        |  |              |  |              +- Conjunction
+   |  |        |  |              |  |                 +- Equality
+   |  |        |  |              |  |                    +- Comparison
+   |  |        |  |              |  |                       +- GenericCallLikeComparison
+   |  |        |  |              |  |                          +- InfixOperation
+   |  |        |  |              |  |                             +- ElvisExpression
+   |  |        |  |              |  |                                +- InfixFunctionCall
+   |  |        |  |              |  |                                   +- RangeExpression
+   |  |        |  |              |  |                                      +- AdditiveExpression
+   |  |        |  |              |  |                                         +- MultiplicativeExpression
+   |  |        |  |              |  |                                            +- AsExpression
+   |  |        |  |              |  |                                               +- PrefixUnaryExpression
+   |  |        |  |              |  |                                                  +- PostfixUnaryExpression
+   |  |        |  |              |  |                                                     +- PrimaryExpression
+   |  |        |  |              |  |                                                        +- StringLiteral
+   |  |        |  |              |  |                                                           +- LineStringLiteral
+   |  |        |  |              |  |                                                              +- T-MultiDollarPrefix
+   |  |        |  |              |  |                                                              +- T-QUOTE_OPEN
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrRef
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrText
+   |  |        |  |              |  |                                                              +- LineStringContent
+   |  |        |  |              |  |                                                              |  +- T-LineStrText
+   |  |        |  |              |  |                                                              +- T-QUOTE_CLOSE
+   |  |        |  |              |  +- Semis
+   |  |        |  |              |  |  +- T-NL
+   |  |        |  |              |  +- Statement
+   |  |        |  |              |     +- Declaration
+   |  |        |  |              |        +- PropertyDeclaration
+   |  |        |  |              |           +- T-VAL
+   |  |        |  |              |           +- VariableDeclaration
+   |  |        |  |              |           |  +- SimpleIdentifier
+   |  |        |  |              |           |     +- T-Identifier
+   |  |        |  |              |           +- T-ASSIGNMENT
+   |  |        |  |              |           +- Expression
+   |  |        |  |              |           |  +- Disjunction
+   |  |        |  |              |           |     +- Conjunction
+   |  |        |  |              |           |        +- Equality
+   |  |        |  |              |           |           +- Comparison
+   |  |        |  |              |           |              +- GenericCallLikeComparison
+   |  |        |  |              |           |                 +- InfixOperation
+   |  |        |  |              |           |                    +- ElvisExpression
+   |  |        |  |              |           |                       +- InfixFunctionCall
+   |  |        |  |              |           |                          +- RangeExpression
+   |  |        |  |              |           |                             +- AdditiveExpression
+   |  |        |  |              |           |                                +- MultiplicativeExpression
+   |  |        |  |              |           |                                   +- AsExpression
+   |  |        |  |              |           |                                      +- PrefixUnaryExpression
+   |  |        |  |              |           |                                         +- PostfixUnaryExpression
+   |  |        |  |              |           |                                            +- PrimaryExpression
+   |  |        |  |              |           |                                               +- StringLiteral
+   |  |        |  |              |           |                                                  +- LineStringLiteral
+   |  |        |  |              |           |                                                     +- T-MultiDollarPrefix
+   |  |        |  |              |           |                                                     +- T-QUOTE_OPEN
+   |  |        |  |              |           |                                                     +- LineStringExpression
+   |  |        |  |              |           |                                                     |  +- T-LineStrExprStart
+   |  |        |  |              |           |                                                     |  +- Expression
+   |  |        |  |              |           |                                                     |  |  +- Disjunction
+   |  |        |  |              |           |                                                     |  |     +- Conjunction
+   |  |        |  |              |           |                                                     |  |        +- Equality
+   |  |        |  |              |           |                                                     |  |           +- Comparison
+   |  |        |  |              |           |                                                     |  |              +- GenericCallLikeComparison
+   |  |        |  |              |           |                                                     |  |                 +- InfixOperation
+   |  |        |  |              |           |                                                     |  |                    +- ElvisExpression
+   |  |        |  |              |           |                                                     |  |                       +- InfixFunctionCall
+   |  |        |  |              |           |                                                     |  |                          +- RangeExpression
+   |  |        |  |              |           |                                                     |  |                             +- AdditiveExpression
+   |  |        |  |              |           |                                                     |  |                                +- MultiplicativeExpression
+   |  |        |  |              |           |                                                     |  |                                   +- AsExpression
+   |  |        |  |              |           |                                                     |  |                                      +- PrefixUnaryExpression
+   |  |        |  |              |           |                                                     |  |                                         +- PostfixUnaryExpression
+   |  |        |  |              |           |                                                     |  |                                            +- PrimaryExpression
+   |  |        |  |              |           |                                                     |  |                                            |  +- SimpleIdentifier
+   |  |        |  |              |           |                                                     |  |                                            |     +- T-Identifier
+   |  |        |  |              |           |                                                     |  |                                            +- PostfixUnarySuffix
+   |  |        |  |              |           |                                                     |  |                                               +- NavigationSuffix
+   |  |        |  |              |           |                                                     |  |                                                  +- MemberAccessOperator
+   |  |        |  |              |           |                                                     |  |                                                  |  +- T-DOT
+   |  |        |  |              |           |                                                     |  |                                                  +- SimpleIdentifier
+   |  |        |  |              |           |                                                     |  |                                                     +- T-Identifier
+   |  |        |  |              |           |                                                     |  +- T-RCURL
+   |  |        |  |              |           |                                                     +- LineStringContent
+   |  |        |  |              |           |                                                     |  +- T-LineStrText
+   |  |        |  |              |           |                                                     +- T-QUOTE_CLOSE
+   |  |        |  |              |           +- T-NL
+   |  |        |  |              +- T-RCURL
+   |  |        |  +- Semis
+   |  |        |     +- T-NL
+   |  |        +- T-RCURL
+   |  +- Semis
+   |     +- T-NL
+   +- EOF


### PR DESCRIPTION
Kotlin 2.2 introduces multi-dollar string interpolation: a string prefixed with N dollar signs requires N dollars to start an interpolation sequence (e.g. `$$"..."` needs `$$` for interpolation).

Three grammar issues are fixed:
- Inside mode lacked MultiDollarPrefix, causing parse errors in function and annotation arguments
- LineString mode did not check multiLineMinDollars when matching LineStrRef and LineStrExprStart tokens
- lineStringLiteral parser rule was missing MultiDollarPrefix

Tests added:
- Regression tests for the two reported cases (function arg, annotation arg)
- KEEP-375 spec examples as parser smoke tests
- Tree dump test for LineStrRef and LineStrExprStart in multi-dollar context (moved to KotlinParserMultiLineStringTest)

Spec: https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0375-dollar-escape.md

## Related issues

- Refs #6003 
- Fix #6648 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

