### PR TITLE
[swift] Fix invalid swift token OSXApplicationExtension

### DIFF
--- a/pmd-swift/src/main/antlr4/net/sourceforge/pmd/lang/swift/ast/Swift.g4
+++ b/pmd-swift/src/main/antlr4/net/sourceforge/pmd/lang/swift/ast/Swift.g4
@@ -969,7 +969,7 @@ contextSensitiveKeyword :
  'associativity' | 'convenience' | 'dynamic' | 'didSet' | 'final' | 'get' | 'infix' | 'indirect' |
  'lazy' | 'left' | 'mutating' | 'none' | 'nonmutating' | 'optional' | 'operator' | 'override' | 'postfix' | 'precedence' |
  'prefix' | 'Protocol' | 'required' | 'right' | 'set' | 'Type' | 'unowned' | 'weak' | 'willSet' |
- 'iOS' | 'iOSApplicationExtension' | 'OSX' | 'OSXApplicationExtension­' | 'watchOS' | 'x86_64' |
+ 'iOS' | 'iOSApplicationExtension' | 'OSX' | 'OSXApplicationExtension-' | 'watchOS' | 'x86_64' |
  'arm' | 'arm64' | 'i386' | 'os' | 'arch' | 'safe' | 'tvOS' | 'file' | 'line' | 'default' | 'Self' | 'var' |
  'some'
  ;

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
@@ -35,7 +35,6 @@ final class SwiftNameDictionary extends AntlrNameDictionary {
         case "unowned(unsafe)": return "unowned-unsafe";
         case "getter:": return "getter";
         case "setter:": return "setter";
-        case "OSXApplicationExtension\u00AD": return "OSXApplicationExtension-";
         default: return null;
         }
     }


### PR DESCRIPTION
Needed for upgrading antlr, see #4972 / #6621

Note: Unfortunately, the generated parser is public API - removing a token is a breaking change. We need #5136 but for the antlr based language modules.

So, this means, the hyphen on `OSXApplicationExtension-` has to stay, so that this is a token on its own (there is already `OSXApplicationExtension`).

Eventually, these tokens should be removed, they are not keywords and not even context sensitive keywords in swift.
