### PR TITLE
[java] AvoidSynchronizedStatement: Improve rule doc

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -89,7 +89,20 @@ public class Foo {
         class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
         externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#avoidsynchronizedstatement">
     <description>
-      Synchronization will pin virtual threads and can cause performance problems.
+      Reports any synchronization statements.
+
+      Virtual threads (introduced by Java 21 via [JEP 444](https://openjdk.org/jeps/444)) are pinned to their
+      carrier thread when executing code protected by synchronized (either synchronized blocks or synchronized
+      methods). When the virtual threads are blocked by I/O and need to wait, the carrier thread stays unavailable
+      for other virtual threads. If this happens with all carrier threads, no new virtual threads can be
+      executed and this can cause performance problems.
+
+      With Java 24 ([JEP 491](https://openjdk.org/jeps/491)) virtual threads can release their carrier thread,
+      when they are blocked by I/O inside a synchronized block. The situation, that all carrier threads are
+      exhausted, should be much less likely.
+
+      Note: Thread pinning still occurs, if the virtual thread is calling native methods inside a synchronized
+      block.
     </description>
     <priority>3</priority>
     <properties>
@@ -108,16 +121,32 @@ public class Foo {
         }
         // more code that doesn't need mutual exclusion
     }
+
     // Prefer this:
     Lock instanceLock = new ReentrantLock();
-
     void foo() {
         // code that doesn't need mutual exclusion
+        instanceLock.lock();
         try {
-            instanceLock.lock();  // or instanceLock.tryLock(long time, TimeUnit unit)
             // code that requires mutual exclusion
         } finally {
             instanceLock.unlock();
+        }
+        // more code that doesn't need mutual exclusion
+    }
+
+    // Or prefer this with tryLock:
+    Lock instanceLock = new ReentrantLock();
+    void foo() {
+        // code that doesn't need mutual exclusion
+        if (instanceLock.tryLock(10, TimeUnit.SECONDS)) {
+            try {
+                // code that requires mutual exclusion
+            } finally {
+                instanceLock.unlock();
+            }
+        } else {
+            // unable to acquire the lock
         }
         // more code that doesn't need mutual exclusion
     }

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -19,6 +19,8 @@ Rules that flag issues when dealing with multiple threads of execution.
 Method-level synchronization will pin virtual threads and can cause performance problems. Additionally, it can cause
 problems when new code is added to the method.  Block-level ReentrantLock helps to ensure that only the code that
 needs mutual exclusion will be locked.
+
+See also {% rule AvoidSynchronizedStatement %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -40,14 +42,16 @@ public class Foo {
         // more code, that doesn't need synchronization
         // ...
     }
+
     // Prefer this:
     Lock instanceLock = new ReentrantLock();
 
     void bar() {
         // code, that doesn't need synchronization
         // ...
+        instanceLock.lock();
         try {
-            instanceLock.lock();  // or instanceLock.tryLock(long time, TimeUnit unit)
+            // code, that requires synchronization
             if (!sharedData.has("bar")) {
                 sharedData.add("bar");
             }
@@ -58,6 +62,30 @@ public class Foo {
         // ...
     }
 
+    // Or prefer this with tryLock:
+    Lock instanceLock = new ReentrantLock();
+
+    void bar() {
+        // code, that doesn't need synchronization
+        // ...
+        if (instanceLock.tryLock(10, TimeUnit.SECONDS)) {
+            try {
+                // code, that requires synchronization
+                if (!sharedData.has("bar")) {
+                    sharedData.add("bar");
+                }
+            } finally {
+                instanceLock.unlock();
+            }
+        } else {
+            // unable to acquire the lock
+        }
+        // more code, that doesn't need synchronization
+        // ...
+    }
+]]>
+        </example>
+        <example><![CDATA[
     // Try to avoid this for static methods:
     static synchronized void fooStatic() {
     }
@@ -68,8 +96,8 @@ public class Foo {
     static void barStatic() {
         // code, that doesn't need synchronization
         // ...
+        CLASS_LOCK.lock();
         try {
-            CLASS_LOCK.lock();
             // code, that requires synchronization
         } finally {
             CLASS_LOCK.unlock();
@@ -92,7 +120,7 @@ public class Foo {
       Reports any synchronization statements.
 
       Virtual threads (introduced by Java 21 via [JEP 444](https://openjdk.org/jeps/444)) are pinned to their
-      carrier thread when executing code protected by synchronized (either synchronized blocks or synchronized
+      carrier thread when executing code protected by `synchronized` (either synchronized blocks or synchronized
       methods). When the virtual threads are blocked by I/O and need to wait, the carrier thread stays unavailable
       for other virtual threads. If this happens with all carrier threads, no new virtual threads can be
       executed and this can cause performance problems.


### PR DESCRIPTION
## Describe the PR

Refs https://github.com/pmd/pmd/pull/5175#issuecomment-4150557437

While it's not wrong to put "lock.lock()" inside the try, the best practice documented in https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/concurrent/locks/ReentrantLock.html puts it directly before the try.

Also added an explicit example of tryLock() usage.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

