### PR TITLE
[doc] Fix capitalization of ANTLR in release notes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,14 +23,14 @@ This is a {{ site.pmd.release_type }} release.
 {% tocmaker is_release_notes_processor %}
 
 ### 🚀️ New and noteworthy
-#### Updated antlr library to 4.13.2
-We have updated the antlr library (parser generator) from 4.9.3 to the latest version 4.13.2,
+#### Updated ANTLR library to 4.13.2
+We have updated the ANTLR library (parser generator) from 4.9.3 to the latest version 4.13.2,
 in order to be able to use the latest version of Apex parser library.
 
-This is an incompatible update: In case you use custom language modules based on antlr, you
-need to make sure to regenerate all of your lexers and parsers with the new antlr version.
+This is an incompatible update: In case you use custom language modules based on ANTLR, you
+need to make sure to regenerate all of your lexers and parsers with the new ANTLR version.
 
-For the antlr based language modules, that PMD ships (kotlin and swift and various CPD modules),
+For the ANTLR based language modules, that PMD ships (kotlin and swift and various CPD modules),
 this is already done.
 
 #### 🌟️ Changed Rules


### PR DESCRIPTION
## Describe the PR

The preferred capitalization based on https://www.antlr.org/ is all caps.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

