### PR TITLE
[java] Part of #4841: Deprecate unnecessary public methods in FieldDeclarationsShouldBeAtStartOfClassRule/CyclomaticComplexityRule/SwitchDensityRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -151,6 +151,10 @@ The old names still work but are deprecated.
 
 ### 🚨️ API Changes
 #### Deprecations
+* java
+    * {% jdoc !!java::lang.java.rule.codestyle.FieldDeclarationsShouldBeAtStartOfClassRule#visit(java::lang.java.ast.ASTTypeDeclaration,java.lang.Object) %} is an implementation detail of {% jdoc java::lang.java.rule.codestyle.FieldDeclarationsShouldBeAtStartOfClassRule %}. It will be removed in a later release.
+    * {% jdoc !!java::lang.java.rule.design.CyclomaticComplexityRule#visitTypeDecl(java::lang.java.ast.ASTTypeDeclaration,java.lang.Object) %} is an implementation detail of {% jdoc java::lang.java.rule.design.CyclomaticComplexityRule %}. It will be removed in a later release.
+    * {% jdoc !!java::lang.java.rule.design.SwitchDensityRule#visitSwitchLike(java::lang.java.ast.ASTSwitchLike,java.lang.Object) %} is an implementation detail of {% jdoc java::lang.java.rule.design.SwitchDensityRule %}. It will be removed in a later release.
 * kotlin
   * The constructor {%jdoc !!kotlin::lang.kotlin.ast.PmdKotlinParser#PmdKotlinParser() %} has been deprecated.
     Use {%jdoc !!kotlin::lang.kotlin.KotlinLanguageModule#getInstance() %},
@@ -218,6 +222,7 @@ The old names still work but are deprecated.
 * [#6660](https://github.com/pmd/pmd/pull/6660): \[kotlin] Fix #6659: Prevent parser hang via InterruptibleParserATNSimulator and parse timeout - [Peter Paul Bakker](https://github.com/stokpop) (@stokpop)
 * [#6661](https://github.com/pmd/pmd/pull/6661): \[java] Fix #6652: Support new-style instanceof (with pattern matching) in AvoidInstanceofChecksInCatchClause - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6670](https://github.com/pmd/pmd/pull/6670): \[kotlin] Add AST improvements, KotlinAstUtil - [Peter Paul Bakker](https://github.com/stokpop) (@stokpop)
+* [#6671](https://github.com/pmd/pmd/pull/6671): \[java] Part of #4841: Deprecate unnecessary public methods in FieldDeclarationsShouldBeAtStartOfClassRule/CyclomaticComplexityRule/SwitchDensityRule - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 * [#6680](https://github.com/pmd/pmd/pull/6680): \[java] Fix #5477: JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 
 ### 📦️ Dependency updates

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -50,11 +51,27 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
 
     @Override
     public Object visitJavaNode(JavaNode node, Object data) {
-        assert node instanceof ASTTypeDeclaration;
-        return visit((ASTTypeDeclaration) node, data);
+        ASTTypeDeclaration typeDeclaration = (ASTTypeDeclaration) node;
+        RuleContext ctx = (RuleContext) data;
+
+        visitTypeDeclaration(typeDeclaration, ctx);
+
+        return null;
     }
 
+    /**
+     * @deprecated since 7.25.0. This method should have never been public.
+     */
+    @Deprecated
     public Object visit(ASTTypeDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        visitTypeDeclaration(node, ctx);
+
+        return null;
+    }
+
+    private void visitTypeDeclaration(ASTTypeDeclaration node, RuleContext ctx) {
         boolean inStartOfClass = true;
         for (ASTBodyDeclaration declaration : node.getDeclarations()) {
             if (!isAllowedAtStartOfClass(declaration)) {
@@ -63,11 +80,10 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
             if (!inStartOfClass && declaration instanceof ASTFieldDeclaration) {
                 ASTFieldDeclaration field = (ASTFieldDeclaration) declaration;
                 if (!isInitializerOk(field)) {
-                    asCtx(data).addViolation(declaration);
+                    ctx.addViolation(declaration);
                 }
             }
         }
-        return null;
     }
 
     private boolean isAllowedAtStartOfClass(ASTBodyDeclaration declaration) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -59,13 +60,28 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
     @Override
     public Object visitJavaNode(JavaNode node, Object param) {
         if (node instanceof ASTTypeDeclaration) {
-            visitTypeDecl((ASTTypeDeclaration) node, param);
+            ASTTypeDeclaration typeDeclaration = (ASTTypeDeclaration) node;
+            RuleContext ctx = (RuleContext) param;
+
+            visitTypeDecl(typeDeclaration, ctx);
         }
         return null;
     }
 
+    /**
+     * @deprecated since 7.25.0. This method should have never been public.
+     */
+    @Deprecated
     public Object visitTypeDecl(ASTTypeDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
 
+        visitTypeDecl(node, ctx);
+
+        return null;
+
+    }
+
+    private void visitTypeDecl(ASTTypeDeclaration node, RuleContext ctx) {
         MetricOptions cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
         if (JavaMetrics.WEIGHED_METHOD_COUNT.supports(node)) {
@@ -79,26 +95,31 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
                                           " total",
                                           classWmc + " (highest " + classHighest + ")", };
 
-                asCtx(data).addViolation(node, (Object[]) messageParams);
+                ctx.addViolation(node, (Object[]) messageParams);
             }
         }
-        return data;
     }
 
 
     @Override
     public final Object visit(ASTMethodDeclaration node, Object data) {
-        visitMethodLike(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        visitMethodLike(node, ctx);
+
+        return null;
     }
 
     @Override
     public final Object visit(ASTConstructorDeclaration node, Object data) {
-        visitMethodLike(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        visitMethodLike(node, ctx);
+
+        return null;
     }
 
-    private void visitMethodLike(ASTExecutableDeclaration node, Object data) {
+    private void visitMethodLike(ASTExecutableDeclaration node, RuleContext ctx) {
         MetricOptions cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
         if (JavaMetrics.CYCLO.supports(node)) {
@@ -110,7 +131,7 @@ public class CyclomaticComplexityRule extends AbstractJavaRulechainRule {
 
                 String kindname = node instanceof ASTConstructorDeclaration ? "constructor" : "method";
 
-                asCtx(data).addViolation(node, kindname, opname, "", "" + cyclo);
+                ctx.addViolation(node, kindname, opname, "", "" + cyclo);
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
@@ -14,13 +14,14 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Switch Density - This is the number of statements over the number of
  * cases within a switch. The higher the value, the more work each case
  * is doing.
  *
- * <p>Its my theory, that when the Switch Density is high, you should start
+ * <p>It's my theory, that when the Switch Density is high, you should start
  * looking at Subclasses or State Pattern to alleviate the problem.</p>
  *
  * @author David Dixon-Peugh
@@ -42,15 +43,35 @@ public class SwitchDensityRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTSwitchStatement node, Object data) {
-        return visitSwitchLike(node, data);
+        RuleContext ctx = (RuleContext) data;
+
+        visitSwitchLike(node, ctx);
+
+        return null;
     }
 
     @Override
     public Object visit(ASTSwitchExpression node, Object data) {
-        return visitSwitchLike(node, data);
+        RuleContext ctx = (RuleContext) data;
+
+        visitSwitchLike(node, ctx);
+
+        return null;
     }
 
+    /**
+     * @deprecated since 7.25.0. This method should have never been public.
+     */
+    @Deprecated
     public Void visitSwitchLike(ASTSwitchLike node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        visitSwitchLike(node, ctx);
+
+        return null;
+    }
+
+    private void visitSwitchLike(ASTSwitchLike node, RuleContext ctx) {
         // note: this does not cross find boundaries.
         int stmtCount = node.descendants(ASTStatement.class).count();
         int labelCount = node.getBranches()
@@ -60,8 +81,7 @@ public class SwitchDensityRule extends AbstractJavaRulechainRule {
         // note: if labelCount is zero, double division will produce +Infinity or NaN, not ArithmeticException
         double density = stmtCount / (double) labelCount;
         if (density >= getProperty(REPORT_LEVEL)) {
-            asCtx(data).addViolation(node);
+            ctx.addViolation(node);
         }
-        return null;
     }
 }


### PR DESCRIPTION
## Describe the PR

This PR deprecates 3 methods I found in https://github.com/pmd/pmd/pull/6586:
* FieldDeclarationsShouldBeAtStartOfClassRule.visit(ASTTypeDeclaration, Object)
* CyclomaticComplexityRule.visitTypeDecl(ASTTypeDeclaration, Object)
* SwitchDensityRule.visitSwitchLike(ASTSwitchLike, Object)

There is no need for these methods to be public, so I deprecated them.

This also serves as a prototype for future work on #4814. Completely closing this issue will require a major release, but we can still do a lot, I believe.

## Related issues

- Related to #4814 

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

