### PR TITLE
[chore] Fix typos in comments and documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ A Jekyll-based theme designed for documentation and help systems. See the link f
     bash build-docs.sh
 
 This will run bundler to fetch and potentially update the ruby gems.
-And then it will execute jekyll and build a offline site.
+And then it will execute jekyll and build an offline site.
 Open the file `_site/index.html` with your browser to see the site.
 
 ## Building using Bundler

--- a/docs/pages/pmd/devdocs/building/building_general.md
+++ b/docs/pages/pmd/devdocs/building/building_general.md
@@ -102,7 +102,7 @@ See also <https://central.sonatype.org/publish/publish-portal-snapshots/>.
 
 ## General Development Tips
 
-* Use a IDE, see one of the other guides
+* Use an IDE, see one of the other guides
   * [Building PMD with IntelliJ IDEA](pmd_devdocs_building_intellij.html)
   * [Building PMD with Eclipse](pmd_devdocs_building_eclipse.html)
   * [Building PMD with Netbeans](pmd_devdocs_building_netbeans.html)

--- a/docs/pages/pmd/devdocs/contributing/writing_documentation.md
+++ b/docs/pages/pmd/devdocs/contributing/writing_documentation.md
@@ -162,7 +162,7 @@ For a more exhaustive list, see [Pages - Frontmatter](http://idratherbewriting.c
 
 See [Alerts](http://idratherbewriting.com/documentation-theme-jekyll/mydoc_alerts.html).
 
-For example, a info-box can be created like this:
+For example, an info-box can be created like this:
 
     {%raw%}{% include note.html content="This is a note." %}{%endraw%}
 

--- a/docs/pages/pmd/userdocs/tools/ide-plugins.md
+++ b/docs/pages/pmd/userdocs/tools/ide-plugins.md
@@ -276,7 +276,7 @@ source file in your project.
 
 ### JBuilder
 
-Was once a IDE by Borland (later Embarcadero): see <https://en.wikipedia.org/wiki/JBuilder> and
+Was once an IDE by Borland (later Embarcadero): see <https://en.wikipedia.org/wiki/JBuilder> and
 <https://web.archive.org/web/20090228184200/http://www.embarcadero.com/products/jbuilder/>
 
 Source code for the plugin is here: <https://github.com/pmd/pmd-misc/tree/main/pmd-jbuilder/>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -140,7 +140,7 @@ public class CPDConfiguration extends AbstractConfiguration {
                 method.invoke(renderer, encoding.name());
             }
         } catch (IntrospectionException | ReflectiveOperationException ignored) {
-            // ignored - maybe this renderer doesn't have a encoding property
+            // ignored - maybe this renderer doesn't have an encoding property
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
@@ -193,7 +193,7 @@ public class DBType {
                     } catch (Exception notInJarWithPath) {
                         notInJarWithPath.printStackTrace();
                         notFoundOnFilesystemWithExtensionTackedOn.printStackTrace();
-                        throw new RuntimeException(" Could not locate DBTYpe settings : " + matchString,
+                        throw new RuntimeException(" Could not locate DBType settings : " + matchString,
                                 notInJarWithPath);
                     }
                 }

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -2156,7 +2156,7 @@ public class Foo {
         <description>
 <![CDATA[
 When declaring and initializing array fields or variables, it is not necessary to explicitly create a new array
-using `new`. Instead one can simply define the initial content of the array as a expression in curly braces.
+using `new`. Instead, one can simply define the initial content of the array as an expression in curly braces.
 
 E.g. `int[] x = new int[] { 1, 2, 3 };` can be written as `int[] x = { 1, 2, 3 };`.
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -901,9 +901,9 @@ class InvalidLogMessageFormatTest {
     }
 
     public static void main(String[] args) {
-        foo(arg -> LOGGER.error("Foo", arg)); // missing violation: extra argument, that is not a exception
+        foo(arg -> LOGGER.error("Foo", arg)); // missing violation: extra argument, that is not an exception
         // explicit cast helps type resolution
-        foo((String arg) -> LOGGER.error("Foo", arg)); // violation: extra argument, that is not a exception
+        foo((String arg) -> LOGGER.error("Foo", arg)); // violation: extra argument, that is not an exception
         foo((String arg) -> LOGGER.error("Foo {}", arg)); // no violation: correct number of arguments
         foo(arg -> LOGGER.error("Foo {}", arg)); // no violation: correct number of arguments
         foo(arg -> LOGGER.error("Foo {} {}", arg)); // violation: missing argument


### PR DESCRIPTION
## Describe the PR

The spelling check finds a typo in unrelated PRs since `typos` was last updated => this aims to fix it. Also fixes a few typos that are not covered by the tool.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [n/a] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

