### PR TITLE
[java] Fix #5477: JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -107,6 +107,7 @@ this is already done.
 * java-bestpractices
   * [#3212](https://github.com/pmd/pmd/issues/3212): \[java] Enhance UseStandardCharsets to flag some constructors of IO-related classes
   * [#3777](https://github.com/pmd/pmd/issues/3777): \[java] New rule: AssertStatementInTest
+  * [#5477](https://github.com/pmd/pmd/issues/5477): \[java] JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class
   * [#6606](https://github.com/pmd/pmd/issues/6606): \[java] UnusedPrivateField: False positive on JUnit Jupiter `@FieldSource`
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
@@ -157,6 +158,7 @@ this is already done.
 * [#6654](https://github.com/pmd/pmd/pull/6654): \[swift] Fix invalid swift token OSXApplicationExtension - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#6658](https://github.com/pmd/pmd/pull/6658): \[doc] Fix capitalization of ANTLR in release notes - [Zbynek Konecny](https://github.com/zbynek) (@zbynek)
 * [#6661](https://github.com/pmd/pmd/pull/6661): \[java] Fix #6652: Support new-style instanceof (with pattern matching) in AvoidInstanceofChecksInCatchClause - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
+* [#6680](https://github.com/pmd/pmd/pull/6680): \[java] Fix #5477: JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class - [UncleOwen](https://github.com/UncleOwen) (@UncleOwen)
 
 ### 📦️ Dependency updates
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateRule.java
@@ -1,0 +1,50 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PROTECTED;
+import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PUBLIC;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Class;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Method;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * @since 6.35.0 (as XPath) / 7.25.0 (as Java)
+ */
+public class JUnit5TestShouldBePackagePrivateRule extends AbstractJavaRulechainRule {
+
+    public JUnit5TestShouldBePackagePrivateRule() {
+        super(ASTClassDeclaration.class, ASTMethodDeclaration.class);
+    }
+
+    @Override
+    public Object visit(ASTClassDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isJUnit5Class(node) && (node.hasVisibility(V_PROTECTED) || node.hasVisibility(V_PUBLIC))) {
+            ctx.addViolation(node);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isJUnit5Method(node)
+                && (node.hasVisibility(V_PROTECTED) || node.hasVisibility(V_PUBLIC))
+                && !node.getEnclosingType().isInterface()
+        ) {
+            ctx.addViolation(node);
+        }
+
+        return null;
+    }
+}

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -836,7 +836,7 @@ public class GoodTest {
           language="java"
           since="6.35.0"
           message="JUnit 5 tests should be package-private."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.JUnit5TestShouldBePackagePrivateRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate">
         <description><![CDATA[
 Reports JUnit 5 test classes and methods that are not package-private.
@@ -848,37 +848,6 @@ Test methods are identified as those which use `@Test`, `@RepeatedTest`,
 `@TestFactory`, `@TestTemplate` or `@ParameterizedTest`.
             ]]></description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//ClassDeclaration[
-    (: a Junit 5 test class, ie, it has methods with the annotation :)
-    @Interface = false() and
-    ClassBody/MethodDeclaration
-    [ModifierList/Annotation[
-               pmd-java:typeIs('org.junit.jupiter.api.Test')
-            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-    ]]
-]/(
-       self::*[@Abstract = false() and @Visibility = ("public", "protected")]
-|      ClassBody/MethodDeclaration
-       [@Visibility = ("public", "protected")]
-       [ModifierList/Annotation[
-               pmd-java:typeIs('org.junit.jupiter.api.Test')
-            or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
-            or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-       ]]
-)
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
             <![CDATA[
 class MyTest { // not public, that's fine

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/Junit5ParentWithTest.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/Junit5ParentWithTest.java
@@ -2,11 +2,11 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.lang.java.rule.errorprone.junit5testnoprivatemodifier;
+package net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests;
 
 import org.junit.jupiter.api.Test;
 
-public abstract class ParentWithTest {
+public abstract class Junit5ParentWithTest {
     @Test
     void testRegular() {
         // nothing

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
@@ -4,11 +4,16 @@
 
 package net.sourceforge.pmd.lang.java.rule.internal;
 
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Class;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import net.sourceforge.pmd.lang.java.JavaParsingHelper;
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 
@@ -23,4 +28,104 @@ class TestFrameworksUtilTest {
         assertThat(TestFrameworksUtil.isProbableAssertCall(m)).isTrue();
     }
 
+    @Nested
+    class IsJUnit5Class {
+        @Test
+        void aBasicClassIsNotAJUnit5Class() {
+            ASTCompilationUnit root = java.parse("class A {}");
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.Test; class A { @Test void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithARepeatedTestIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.RepeatedTest; class A { @RepeatedTest(10) void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestFactoryIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.TestFactory; class A { @TestFactory Collection<DynamicTest> foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestTemplateIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.TestTemplate; class A { @TestTemplate void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithAParameterizedTestIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.params.ParameterizedTest; class A { @ParameterizedTest void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestIsAJUnit5ClassEvenIfTheTestIsInAParentClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.Junit5ParentWithTest; class A extends Junit5ParentWithTest {}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void anInterfaceWithATestIsANotJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.Test; interface A { @Test default void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void anAbstractClassWithATestIsANotJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.Test; abstract class A { @Test void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aNestedClassWithATestIsANotJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.Test; class A { class B { @Test void foo() {} } }"
+            );
+            ASTClassDeclaration classDecl = root.descendants(ASTClassDeclaration.class).last();
+
+            assertFalse(isJUnit5Class(classDecl));
+        }
+    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -147,4 +147,15 @@ MyTests // <--violation: line 4
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>test class should have default visibility, even if the test methods are in a parent class</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.Junit5ParentWithTest;
+
+public class Child extends Junit5ParentWithTest {}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnit5TestNoPrivateModifier.xml
@@ -91,9 +91,9 @@ private class Child extends Parent {}
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
-import net.sourceforge.pmd.lang.java.rule.errorprone.junit5testnoprivatemodifier.ParentWithTest;
+import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.Junit5ParentWithTest;
 
-private class Child extends ParentWithTest {}
+private class Child extends Junit5ParentWithTest {}
         ]]></code>
     </test-code>
 


### PR DESCRIPTION
## Describe the PR

Fixes JUnit5TestShouldBePackagePrivate by converting it from XPath to Java. That allows us to use the infrastructure introduced in https://github.com/pmd/pmd/pull/6604

## Related issues

- Fix #5477

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

