### PR TITLE
Fix duplicated "the" in Java and Visualforce comments

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBMSMetadata.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBMSMetadata.java
@@ -499,7 +499,7 @@ public class DBMSMetadata {
 
             /*
              * From Javadoc .... Each procedure description
-             * has the the following columns: PROCEDURE_CAT
+             * has the following columns: PROCEDURE_CAT
              * String => procedure catalog (may be null)
              * PROCEDURE_SCHEM String => procedure schema
              * (may be null) PROCEDURE_NAME String =>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1497,7 +1497,7 @@ public final class TypeOps {
     /**
      * Two methods or constructors, M and N, have the same signature if
      * they have the same name, the same type parameters (if any) (§8.4.4),
-     * and, after adapting the formal parameter types of N to the the type
+     * and, after adapting the formal parameter types of N to the type
      * parameters of M, the same formal parameter types.
      *
      * Thrown exceptions are not part of the signature of a method.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
@@ -137,7 +137,7 @@ public final class ExprOps {
     }
 
     /**
-     * Returns true if the the argument expression is pertinent
+     * Returns true if the argument expression is pertinent
      * to applicability for the potentially applicable method m,
      * called at site 'invoc', as specified by JLS§15.12.2.2:
      *

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpression.java
@@ -143,7 +143,7 @@ public final class ASTExpression extends AbstractVfNode {
 
 
     /**
-     * Thrown in cases where the the Identifiers in this node aren't ALL successfully parsed in a call to
+     * Thrown in cases where the Identifiers in this node aren't ALL successfully parsed in a call to
      * {@link #getDataNodes()}
      */
     public static final class DataNodeStateException extends Exception {


### PR DESCRIPTION
Follow-up to #6679. Fixes four more `the the` duplicated-word typos that were not caught in the prior typo sweep:

- `pmd-core/.../DBMSMetadata.java` — `has the the following columns` → `has the following columns`
- `pmd-java/.../TypeOps.java` — `to the the type parameters` → `to the type parameters`
- `pmd-visualforce/.../ASTExpression.java` — `where the the Identifiers` → `where the Identifiers`
- `pmd-java/.../ExprOps.java` — `if the the argument expression` → `if the argument expression`

All four are inside doc comments; no runtime behavior changes. `git diff --check` is clean.