### PR TITLE
WIP: Remove the visibility check from TestFrameworksUtil.isJUnit4Method.

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -110,8 +110,7 @@ public final class TestFrameworksUtil {
     }
 
     public static boolean isJUnit4Method(ASTMethodDeclaration method) {
-        return method.isAnnotationPresent(JUNIT4_TEST_ANNOT)
-                && method.getVisibility() == Visibility.V_PUBLIC;
+        return method.isAnnotationPresent(JUNIT4_TEST_ANNOT);
     }
 
     public static boolean isJUnit5Method(ASTMethodDeclaration method) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
@@ -483,7 +483,8 @@ class FooTest {
         ]]></code>
     </test-code>
 
-    <test-code>
+    <test-code disabled="true">
+<!--        See https://github.com/pmd/pmd/issues/6681 for why this is disabled-->
         <description>#1435 Treat AssertJ soft assertion rule for JUnit 4 as assert expressions</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -497,7 +498,7 @@ public class FooTest {
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Test
-    void testFoo() {
+    public void testFoo() {
         softly.assertThat("doesn't matter").isEqualTo("doesn't matter");
     }
 }


### PR DESCRIPTION
This PR exists only so that I can see the regression report.