### PR TITLE
[java] False positive for UnusedPrivateField referenced by @FieldSource

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -106,6 +106,7 @@ this is already done.
 * java-bestpractices
   * [#3212](https://github.com/pmd/pmd/issues/3212): \[java] Enhance UseStandardCharsets to flag some constructors of IO-related classes
   * [#3777](https://github.com/pmd/pmd/issues/3777): \[java] New rule: AssertStatementInTest
+  * [#6606](https://github.com/pmd/pmd/issues/6606): \[java] UnusedPrivateField: False positive on JUnit Jupiter `@FieldSource`
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -17,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -50,11 +52,13 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
             if (hasAnyAnnotation(type)) {
                 return null;
             }
-
+            Set<String> fieldsUsedByAnnotations = JavaRuleUtil.getMembersUsedByAnnotations(type.getRoot(),
+                "org.junit.jupiter.params.provider.FieldSource");
             for (ASTFieldDeclaration field : type.getDeclarations().filterIs(ASTFieldDeclaration.class)) {
                 if (!isIgnored(field)) {
                     for (ASTVariableId varId : field.getVarIds()) {
-                        if (JavaAstUtils.isNeverUsed(varId)) {
+                        if (!fieldsUsedByAnnotations.contains(varId.getName())
+                                && JavaAstUtils.isNeverUsed(varId)) {
                             asCtx(data).addViolation(varId, varId.getName());
                         }
                     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -12,14 +12,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-
-import net.sourceforge.pmd.lang.ast.NodeStream;
-import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.ast.ASTMemberValue;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
@@ -27,11 +21,11 @@ import net.sourceforge.pmd.lang.java.ast.MethodUsage;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.internal.AbstractIgnoredAnnotationRule;
+import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
-import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
  * This rule detects private methods, that are not used and can therefore be
@@ -58,7 +52,8 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         // - one to find annotations that potentially reference a method
         // - one to collect candidates, that is, potentially unused methods
         // - one to walk through all possible usages of methods, and delete used methods from the set
-        Set<String> methodsUsedByAnnotations = methodsUsedByAnnotations(file);
+        Set<String> methodsUsedByAnnotations = JavaRuleUtil.getMembersUsedByAnnotations(file,
+            "org.junit.jupiter.params.provider.MethodSource");
         Map<JExecutableSymbol, ASTMethodDeclaration> candidates = findCandidates(file, methodsUsedByAnnotations);
 
         file.descendants()
@@ -121,29 +116,9 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
                    ));
     }
 
-    private static Set<String> methodsUsedByAnnotations(ASTCompilationUnit file) {
-        return file.descendants(ASTAnnotation.class)
-            .crossFindBoundaries()
-            .toStream()
-            .flatMap(UnusedPrivateMethodRule::extractMethodsFromAnnotation)
-            .collect(Collectors.toSet());
-    }
 
-    private static Stream<String> extractMethodsFromAnnotation(ASTAnnotation a) {
-        return Stream.concat(
-            a.getFlatValues().toStream()
-                .map(ASTMemberValue::getConstValue)
-                .map(asInstanceOf(String.class))
-                .filter(StringUtils::isNotEmpty),
-            NodeStream.of(a)
-                .filter(it -> TypeTestUtil.isA("org.junit.jupiter.params.provider.MethodSource", it)
-                    && it.getFlatValue("value").isEmpty())
-                .ancestors(ASTMethodDeclaration.class)
-                .take(1)
-                .toStream()
-                .map(ASTMethodDeclaration::getName)
-        );
-    }
+
+
 
     private boolean hasExcludedName(ASTMethodDeclaration node) {
         return SERIALIZATION_METHODS.contains(node.getName());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -557,6 +557,7 @@ public final class JavaRuleUtil {
      *
      * @param unit compilation unit
      * @param parameterless parameterless annotation that references members of the same name
+     *                      as the annotated member
      * @return members potentially referenced by annotations
      */
     public static Set<String> getMembersUsedByAnnotations(ASTCompilationUnit unit, String parameterless) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.internal;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
 import static net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind.LONG;
 import static net.sourceforge.pmd.util.CollectionUtil.immutableSetOf;
 
@@ -11,9 +12,14 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamField;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.ast.NodeStream;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
@@ -21,6 +27,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
@@ -28,6 +35,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTList;
+import net.sourceforge.pmd.lang.java.ast.ASTMemberValue;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
@@ -541,5 +549,37 @@ public final class JavaRuleUtil {
         return TIME_METHODS.anyMatch(initializer);
     }
 
+    /**
+     * Finds names of members potentially referenced by annotations: either by their string
+     * values or by given parameterless annotation. Prefers false negatives to false positives,
+     * so in file containing {@code SuppressWarnings("foo")} field {@code foo} is considered as
+     * referenced.
+     *
+     * @param unit compilation unit
+     * @param parameterless parameterless annotation that references members of the same name
+     * @return members potentially referenced by annotations
+     */
+    public static Set<String> getMembersUsedByAnnotations(ASTCompilationUnit unit, String parameterless) {
+        return unit.descendants(ASTAnnotation.class)
+            .crossFindBoundaries()
+            .toStream()
+            .flatMap(a -> extractMethodsFromAnnotation(a, parameterless))
+            .collect(Collectors.toSet());
+    }
 
+    private static Stream<String> extractMethodsFromAnnotation(ASTAnnotation a, String parameterless) {
+        return Stream.concat(
+            a.getFlatValues().toStream()
+                .map(ASTMemberValue::getConstValue)
+                .map(asInstanceOf(String.class))
+                .filter(StringUtils::isNotEmpty),
+            NodeStream.of(a)
+                .filter(it -> TypeTestUtil.isA(parameterless, it)
+                    && it.getFlatValue("value").isEmpty())
+                .ancestors(ASTMethodDeclaration.class)
+                .take(1)
+                .toStream()
+                .map(ASTMethodDeclaration::getName)
+        );
+    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
@@ -922,12 +922,19 @@ public class Foo {
         <description>field used by FieldSource</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
+
+import net.sourceforge.pmd.util.CollectionUtil;
+
 public class Foo {
-    private String foo;
-    private String bar;
-    private String test;
+    private static List<String> foo = CollectionUtil.listOf("a", "b");
+    private static Supplier<Stream<String>> bar = () -> Stream.of("c", "d");
+    private static String[] test = {"e", "f"};
 
     @ParameterizedTest
     @FieldSource("foo")

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
@@ -917,4 +917,24 @@ public class Foo {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>field used by FieldSource</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+public class Foo {
+    private String foo;
+    private String bar;
+    private String test;
+
+    @ParameterizedTest
+    @FieldSource("foo")
+    @FieldSource("bar")
+    @FieldSource()
+    void test(String unused) { }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Reuses code that prevents private methods to be flagged as unused if they are referenced by `@MethodSource` to do the same for fields referenced by `@FieldSource`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6606 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

