### PR TITLE
LocalVariableCouldBeFinalRule: Revert API change

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -103,6 +103,7 @@ this is already done.
 * java
   * [#5721](https://github.com/pmd/pmd/issues/5721): \[java] StackOverflowError in 7.17.0 with nested wildcard generics
   * [#5746](https://github.com/pmd/pmd/issues/5746): \[java] Separate test sources and resources
+  * [#6688](https://github.com/pmd/pmd/issues/6688): \[java] LocalVariableCouldBeFinalRule API changed
 * java-bestpractices
   * [#3212](https://github.com/pmd/pmd/issues/3212): \[java] Enhance UseStandardCharsets to flag some constructors of IO-related classes
   * [#3777](https://github.com/pmd/pmd/issues/3777): \[java] New rule: AssertStatementInTest

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -26,7 +26,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
     }
 
     @Override
-    public RuleContext visit(ASTLocalVariableDeclaration node, Object data) {
+    public Object visit(ASTLocalVariableDeclaration node, Object data) {
         RuleContext ctx = (RuleContext) data;
 
         if (node.isFinal()) { // also for implicit finals, like resources, or lombok.val
@@ -43,7 +43,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
                 ctx.addViolation(vid, vid.getName());
             }
         }
-        return ctx;
+        return null;
     }
 
     private RuleContext specialCaseForInit(ASTLocalVariableDeclaration node, RuleContext ctx) {


### PR DESCRIPTION
## Describe the PR

In https://github.com/pmd/pmd/commit/133c2e1b8c4aa251fe1da28e5463d3ba4ef018bc I changed the public API of LocalVariableCouldBePublic.visit(). This was not caught by japicmp-0.25.6, but is caught by 0.25.7. Fortunately, this commit hasn't made it into a release yet.

This PR reverts this change.

## Related issues

- Fixes #6688
- See https://github.com/pmd/pmd/issues/6602
- See https://github.com/pmd/pmd/pull/6668

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

