### PR TITLE
[java] Fix #4350: Fix ClassNamingConventions by teaching TestFrameworkUtil about type resolution

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -121,6 +121,7 @@ The old names still work but are deprecated.
   * [#6681](https://github.com/pmd/pmd/issues/6681): \[java] UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
+  * [#4350](https://github.com/pmd/pmd/issues/4350): \[java] ClassNamingConventions: testClassPattern not applied to class that inherits all its @Test methods
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte
   * [#6602](https://github.com/pmd/pmd/issues/6602): \[java] LocalVariableCouldBeFinal: False negative when multiple variables are declared at once
   * [#6622](https://github.com/pmd/pmd/issues/6622): \[java] New rule: UnnecessaryBlock

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -121,7 +121,7 @@ The old names still work but are deprecated.
   * [#6681](https://github.com/pmd/pmd/issues/6681): \[java] UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
-  * [#4350](https://github.com/pmd/pmd/issues/4350): \[java] ClassNamingConventions: testClassPattern not applied to class that inherits all its @Test methods
+  * [#4350](https://github.com/pmd/pmd/issues/4350): \[java] ClassNamingConventions: testClassPattern not applied to class that inherits all its @<!-- -->Test methods
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte
   * [#6602](https://github.com/pmd/pmd/issues/6602): \[java] LocalVariableCouldBeFinal: False negative when multiple variables are declared at once
   * [#6622](https://github.com/pmd/pmd/issues/6622): \[java] New rule: UnnecessaryBlock

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -106,7 +106,13 @@ public final class TestFrameworksUtil {
     }
 
     private static boolean isTestNgMethod(ASTMethodDeclaration method) {
-        return method.isAnnotationPresent(TEST_NG_TEST_ANNOT);
+        return isTestNgMethod(method.getSymbol());
+    }
+
+    private static boolean isTestNgMethod(JMethodSymbol methodSymbol) {
+        return methodSymbol.getDeclaredAnnotations().stream().anyMatch(
+                it -> TEST_NG_TEST_ANNOT.equals(it.getBinaryName())
+        );
     }
 
     public static boolean isJUnit4Method(ASTMethodDeclaration method) {
@@ -178,6 +184,14 @@ public final class TestFrameworksUtil {
 
         return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
                 && typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
+                        .findAny().isPresent();
+    }
+
+    public static boolean isTestNGClass(ASTClassDeclaration node) {
+        JClassType typeMirror = node.getTypeMirror();
+
+        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
+                && typeMirror.streamMethods(TestFrameworksUtil::isTestNgMethod)
                         .findAny().isPresent();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -164,11 +164,8 @@ public final class TestFrameworksUtil {
             && TypeTestUtil.isA(JUNIT3_CLASS_NAME, node);
     }
 
-    public static boolean isTestClass(ASTTypeDeclaration node) {
-        return node.isRegularClass() && !node.isAbstract() && !node.isNested()
-            && (isJUnit3Class(node)
-            || node.getDeclarations(ASTMethodDeclaration.class)
-                   .any(TestFrameworksUtil::isTestMethod));
+    public static boolean isTestClass(ASTClassDeclaration node) {
+        return isJUnit3Class(node) || isJUnit4Class(node) || isJUnit5Class(node) || isTestNGClass(node);
     }
 
     public static boolean isJUnit4Class(ASTClassDeclaration node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -110,8 +110,13 @@ public final class TestFrameworksUtil {
     }
 
     public static boolean isJUnit4Method(ASTMethodDeclaration method) {
-        return method.isAnnotationPresent(JUNIT4_TEST_ANNOT)
-                && method.getVisibility() == Visibility.V_PUBLIC;
+        return isJUnit4Method(method.getSymbol());
+    }
+
+    private static boolean isJUnit4Method(JMethodSymbol methodSymbol) {
+        return methodSymbol.getDeclaredAnnotations().stream().anyMatch(
+                it -> JUNIT4_TEST_ANNOT.equals(it.getBinaryName())
+        );
     }
 
     public static boolean isJUnit5Method(ASTMethodDeclaration method) {
@@ -158,6 +163,14 @@ public final class TestFrameworksUtil {
             && (isJUnit3Class(node)
             || node.getDeclarations(ASTMethodDeclaration.class)
                    .any(TestFrameworksUtil::isTestMethod));
+    }
+
+    public static boolean isJUnit4Class(ASTClassDeclaration node) {
+        JClassType typeMirror = node.getTypeMirror();
+
+        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
+                && typeMirror.streamMethods(TestFrameworksUtil::isJUnit4Method)
+                        .findAny().isPresent();
     }
 
     public static boolean isJUnit5Class(ASTClassDeclaration node) {

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/JUnit4ParentWithTest.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/JUnit4ParentWithTest.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests;
+
+import org.junit.Test;
+
+public abstract class JUnit4ParentWithTest {
+    @Test
+    public void testRegular() {
+        // nothing
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.internal;
 
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit4Class;
 import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Class;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,6 +27,67 @@ class TestFrameworksUtilTest {
         ASTCompilationUnit root = java.parse("class A { { assertThat(1); } }");
         ASTMethodCall m = root.descendants(ASTMethodCall.class).toList().get(0);
         assertThat(TestFrameworksUtil.isProbableAssertCall(m)).isTrue();
+    }
+
+    @Nested
+    class IsJUnit4Class {
+        @Test
+        void aBasicClassIsNotAJUnit4Class() {
+            ASTCompilationUnit root = java.parse("public class A {}");
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit4Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestIsAJUnit4Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.Test; public class A { @Test public void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit4Class(classDecl));
+        }
+
+        @Test
+        void aClassWithATestIsAJUnit4ClassEvenIfTheTestIsInAParentClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.JUnit4ParentWithTest; public class A extends JUnit4ParentWithTest {}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit4Class(classDecl));
+        }
+
+        @Test
+        void anInterfaceWithATestIsANotJUnit4Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.Test; public interface A { @Test public default void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit4Class(classDecl));
+        }
+
+        @Test
+        void anAbstractClassWithATestIsANotJUnit4Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.Test; public abstract class A { @Test public void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isJUnit4Class(classDecl));
+        }
+
+        @Test
+        void aNestedClassWithATestIsANotJUnit4Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.Test; public class A { class B { @Test public void foo() {} } }"
+            );
+            ASTClassDeclaration classDecl = root.descendants(ASTClassDeclaration.class).last();
+
+            assertFalse(isJUnit4Class(classDecl));
+        }
     }
 
     @Nested

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.internal;
 
 import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit4Class;
 import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5Class;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isTestNGClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -190,4 +191,56 @@ class TestFrameworksUtilTest {
             assertFalse(isJUnit5Class(classDecl));
         }
     }
+
+    @Nested
+    class IsTestNGClass {
+        @Test
+        void aBasicClassIsNotATestNGClass() {
+            ASTCompilationUnit root = java.parse("public class A {}");
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isTestNGClass(classDecl));
+        }
+
+        @Test
+        void aClassWithATestIsATestNGClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.testng.annotations.Test; public class A { @Test public void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isTestNGClass(classDecl));
+        }
+
+        @Test
+        void anInterfaceWithATestIsANotTestNGClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.testng.annotations.Test; public interface A { @Test public default void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isTestNGClass(classDecl));
+        }
+
+        @Test
+        void anAbstractClassWithATestIsANotTestNGClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.testng.annotations.Test; public abstract class A { @Test public void foo() {} }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isTestNGClass(classDecl));
+        }
+
+        @Test
+        void aNestedClassWithATestIsANotTestNGClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.testng.annotations.Test; class A { class B { @Test public void foo() {} } }"
+            );
+            ASTClassDeclaration classDecl = root.descendants(ASTClassDeclaration.class).last();
+
+            assertFalse(isTestNGClass(classDecl));
+        }
+    }
+
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -317,7 +317,7 @@ import junit.framework.TestCase;
 public class Foo extends TestCase {
     public void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -330,7 +330,7 @@ public class Foo {
     @Test
     public void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -343,7 +343,7 @@ class Foo {
     @Test
     void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -355,7 +355,7 @@ class FooTest {
     @Test
     void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -368,7 +368,7 @@ class TestFoo {
     @Test
     void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -383,7 +383,7 @@ class Foo {
     @ValueSource(ints = {1})
     void testBar(int i) { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -396,7 +396,7 @@ public class Foo {
     @Test
     public void testBar() {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -406,7 +406,7 @@ public class Foo {
 public class FooTest {
     public void testBar() { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -425,7 +425,7 @@ class MyTests {
         void secondCheck() {}
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -434,7 +434,7 @@ class MyTests {
         <code><![CDATA[
 import junit.framework.TestCase;
 public class ExampleTestCase extends TestCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -443,7 +443,7 @@ public class ExampleTestCase extends TestCase { }
         <code><![CDATA[
 import junit.framework.TestCase;
 public class ExampleIT extends TestCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -452,7 +452,7 @@ public class ExampleIT extends TestCase { }
         <code><![CDATA[
 import junit.framework.TestCase;
 public class ExampleITCase extends TestCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -461,7 +461,7 @@ public class ExampleITCase extends TestCase { }
         <code><![CDATA[
 import junit.framework.TestCase;
 public class ITExample extends TestCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -472,7 +472,7 @@ public class ITExample extends TestCase { }
 public interface TestInterface {
   void test();
 }
-]]></code>
+        ]]></code>
     </test-code>
 
 
@@ -497,6 +497,54 @@ foo // <--violation: line 2
     tehehe // <--violation: line 14
     { }
 }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test class (JUnit 5/6) with test only in parent class #4350</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+abstract class Parent {
+    @Test
+    void testBar() { }
+}
+
+class Foo extends Parent {}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test class (JUnit4) with test only in parent class #4350</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.Test;
+
+abstract class Parent {
+    @Test
+    void testBar() { }
+}
+
+class Foo extends Parent {}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test class (TestNG) with test only in parent class #4350</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import org.testng.annotations.Test;
+
+abstract class Parent {
+    @Test
+    void testBar() { }
+}
+
+class Foo extends Parent {}
         ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

* Use type resolution in `TestFrameworksUtil.isJUnit4Method()` and `.isTestNgMethod()` so that they can find tests in superclasses (JUnit 5/6 was already done in https://github.com/pmd/pmd/pull/6604)
* Change `.isTestClass()` to use `isJunitXClass()` and `isTestNGClass()`

## Related issues

- Fix #4350

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

