### PR TITLE
[java] Fix #1102: improve consistency of utility class detection across rules

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,9 @@ this is already done.
 #### Changed Rules
 * The rule {% rule java/codestyle/OnlyOneReturn %} has a new property `allowGuardIfs`. When this property is
   true, then guard ifs at the beginning of a method are allowed their return statements don't count.
+* The rules {% rule java/design/UseUtilityClass %} and {% rule java/codestyle/ClassNamingConventions %} now use the
+  same definition of what a utility class is. The most significant change is, that classes with main() methods are
+  no longer considered utility classes by `UseUtilityClass`.
 * We are continuously working to improve the precision of violation reporting for various rules.
   The goal is to ensure that rules report issues on the correct line and highlight only the relevant lines.
   For example, instead of flagging an entire class declaration (including its body), we now generally report only
@@ -101,6 +104,7 @@ this is already done.
   * [#4972](https://github.com/pmd/pmd/issues/4972): \[core] Update ANTLR to 4.13.2
   * [#6308](https://github.com/pmd/pmd/issues/6308): \[core] CPD Markdown format: Add syntax highlighting
 * java
+  * [#1102](https://github.com/pmd/pmd/issues/1102): \[java] Improve consistency of utility class detection across rules
   * [#5721](https://github.com/pmd/pmd/issues/5721): \[java] StackOverflowError in 7.17.0 with nested wildcard generics
   * [#5746](https://github.com/pmd/pmd/issues/5746): \[java] Separate test sources and resources
   * [#6688](https://github.com/pmd/pmd/issues/6688): \[java] LocalVariableCouldBeFinalRule API changed

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -52,7 +52,7 @@ this is already done.
 * The rule {% rule java/codestyle/OnlyOneReturn %} has a new property `allowGuardIfs`. When this property is
   true, then guard ifs at the beginning of a method are allowed their return statements don't count.
 * The rules {% rule java/design/UseUtilityClass %} and {% rule java/codestyle/ClassNamingConventions %} now use the
-  same definition of what a utility class is. The most significant change is, that classes with main() methods are
+  same definition of what a utility class is. The most significant change is, that classes with `main()` methods are
   no longer considered utility classes by `UseUtilityClass`.
 * We are continuously working to improve the precision of violation reporting for various rules.
   The goal is to ensure that rules report issues on the correct line and highlight only the relevant lines.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -4,25 +4,20 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
-import static net.sourceforge.pmd.lang.java.ast.JModifier.STATIC;
 import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PRIVATE;
-import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.isMainMethod;
+import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isUtilityClass;
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
-import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTMemberValuePair;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
-import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
@@ -35,49 +30,12 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTClassDeclaration klass, Object data) {
-        if (klass.isInterface()
-            || klass.isAbstract()
-            || klass.getSuperClassTypeNode() != null
-            || klass.getSuperInterfaceTypeNodes().nonEmpty()
-        ) {
-            return data;
-        }
+        RuleContext ctx = (RuleContext) data;
 
-        if (allNonPrivateMembersAreStatic(klass) && hasWrongKindOfConstructor(klass)) {
-            asCtx(data).addViolation(klass);
+        if (isUtilityClass(klass) && hasWrongKindOfConstructor(klass)) {
+            ctx.addViolation(klass);
         }
         return null;
-    }
-
-    private boolean allNonPrivateMembersAreStatic(ASTClassDeclaration klass) {
-        boolean hasNonPrivateMembers = false;
-
-        for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
-            if (isMainMethod(declaration)) {
-                return false;
-            }
-
-            if (declaration instanceof ASTFieldDeclaration
-                    || declaration instanceof ASTMethodDeclaration
-                    || declaration instanceof ASTClassDeclaration
-            ) {
-                ModifierOwner modifierOwner = (ModifierOwner) declaration;
-
-                if (modifierOwner.getVisibility() != V_PRIVATE) {
-                    hasNonPrivateMembers = true;
-                }
-                if (!modifierOwner.hasModifiers(STATIC)) {
-                    return false;
-                }
-            } else if (declaration instanceof ASTInitializer) {
-                ASTInitializer initializer = (ASTInitializer) declaration;
-
-                if (!initializer.isStatic()) {
-                    return false;
-                }
-            }
-        }
-        return hasNonPrivateMembers;
     }
 
     private boolean hasWrongKindOfConstructor(ASTClassDeclaration klass) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UseUtilityClassRule.java
@@ -6,9 +6,8 @@ package net.sourceforge.pmd.lang.java.rule.design;
 
 import static net.sourceforge.pmd.lang.java.ast.JModifier.STATIC;
 import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PRIVATE;
+import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.isMainMethod;
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
-
-import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
@@ -16,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTMemberValuePair;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
@@ -26,10 +26,8 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
-    private static final Set<String> IGNORED_CLASS_ANNOT = setOf(
-        "lombok.experimental.UtilityClass",
-        "org.junit.runner.RunWith" // for suites and such
-    );
+    private static final String LOMBOK_UTILITY_CLASS = "lombok.experimental.UtilityClass";
+    private static final String LOMBOK_NO_ARGS_CONSTRUCTOR = "lombok.NoArgsConstructor";
 
     public UseUtilityClassRule() {
         super(ASTClassDeclaration.class);
@@ -37,9 +35,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTClassDeclaration klass, Object data) {
-        if (JavaAstUtils.hasAnyAnnotation(klass, IGNORED_CLASS_ANNOT)
-            || TypeTestUtil.isA("junit.framework.TestSuite", klass) // suite method is ok
-            || klass.isInterface()
+        if (klass.isInterface()
             || klass.isAbstract()
             || klass.getSuperClassTypeNode() != null
             || klass.getSuperInterfaceTypeNodes().nonEmpty()
@@ -57,6 +53,10 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
         boolean hasNonPrivateMembers = false;
 
         for (ASTBodyDeclaration declaration : klass.getDeclarations()) {
+            if (isMainMethod(declaration)) {
+                return false;
+            }
+
             if (declaration instanceof ASTFieldDeclaration
                     || declaration instanceof ASTMethodDeclaration
                     || declaration instanceof ASTClassDeclaration
@@ -67,6 +67,12 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
                     hasNonPrivateMembers = true;
                 }
                 if (!modifierOwner.hasModifiers(STATIC)) {
+                    return false;
+                }
+            } else if (declaration instanceof ASTInitializer) {
+                ASTInitializer initializer = (ASTInitializer) declaration;
+
+                if (!initializer.isStatic()) {
                     return false;
                 }
             }
@@ -88,7 +94,8 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
         // account for default ctor
         hasNonPrivateCtor |= !hasAnyCtor
                 && klass.getVisibility() != V_PRIVATE
-                && !hasLombokPrivateCtor(klass);
+                && !hasLombokPrivateCtor(klass)
+                && !JavaAstUtils.hasAnyAnnotation(klass, setOf(LOMBOK_UTILITY_CLASS));
 
         return hasNonPrivateCtor;
     }
@@ -97,7 +104,7 @@ public class UseUtilityClassRule extends AbstractJavaRulechainRule {
         // check if there's a lombok no arg private constructor, if so skip the rest of the rules
 
         return parent.getDeclaredAnnotations()
-                     .filter(t -> TypeTestUtil.isA("lombok.NoArgsConstructor", t))
+                     .filter(t -> TypeTestUtil.isA(LOMBOK_NO_ARGS_CONSTRUCTOR, t))
                      .flatMap(ASTAnnotation::getMembers)
                      // to set the access level of a constructor in lombok, you set the access property on the annotation
                      .filterMatching(ASTMemberValuePair::getName, "access")

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -231,7 +231,7 @@ public final class JavaRuleUtil {
 
             if (declNode instanceof ASTFieldDeclaration
                     || declNode instanceof ASTMethodDeclaration
-                    || declNode instanceof ASTClassDeclaration
+                    || declNode instanceof ASTTypeDeclaration
             ) {
                 ModifierOwner modifierOwner = (ModifierOwner) declNode;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -72,7 +72,7 @@ public final class JavaRuleUtil {
         "_#hashCode()",
         "_#equals(java.lang.Object)",
         "java.lang.String#_(_*)",
-        // actually not all of them, probs only stream of some type
+        // actually not all of them, probably only stream of some type
         // arg which doesn't implement Closeable...
         "java.util.stream.Stream#_(_*)",
         "java.util.stream.IntStream#_(_*)",
@@ -167,7 +167,7 @@ public final class JavaRuleUtil {
 
 
     /**
-     * Returns true if the expression is a stringbuilder (or stringbuffer)
+     * Returns true if the expression is a StringBuilder (or StringBuffer)
      * append call, or a constructor call for one of these classes.
      *
      * <p>If it is a constructor call, returns false if this is a call to
@@ -198,7 +198,7 @@ public final class JavaRuleUtil {
      *     <li>ALL member functions, member variables, nested classes, and initializers are static.</li>
      *     <li>The class has at least one member function, member variable, or nested class that is not private.</li>
      *     <li>The class is neither abstract nor an interface.</li>
-     *     <li>The class has no superclasses and implements no interfacees. (This might change in the future.)</li>
+     *     <li>The class has no superclasses and implements no interfaces. (This might change in the future.)</li>
      *     <li>The class has no main method.</li>
      * </ul>
      */
@@ -300,7 +300,7 @@ public final class JavaRuleUtil {
      * @throws AssertionError If the word is empty or not capitalized
      */
     public static boolean containsCamelCaseWord(String camelCaseString, String capitalizedWord) {
-        assert capitalizedWord.length() > 0 && Character.isUpperCase(capitalizedWord.charAt(0))
+        assert !capitalizedWord.isEmpty() && Character.isUpperCase(capitalizedWord.charAt(0))
             : "Not a capitalized string \"" + capitalizedWord + "\"";
 
         int index = camelCaseString.indexOf(capitalizedWord);
@@ -315,7 +315,7 @@ public final class JavaRuleUtil {
     }
 
     private static boolean isSetterCall(ASTMethodCall call) {
-        return call.getArguments().size() > 0 && startsWithCamelCaseWord(call.getMethodName(), "set");
+        return !call.getArguments().isEmpty() && startsWithCamelCaseWord(call.getMethodName(), "set");
     }
 
     public static boolean isGetterCall(ASTMethodCall call) {
@@ -396,11 +396,11 @@ public final class JavaRuleUtil {
 
     /**
      * Whether the node or one of its descendants is an expression with
-     * side effects. Conservatively, any method call is a potential side-effect,
+     * side effects. Conservatively, any method call is a potential side effect,
      * as well as assignments to fields or array elements. We could relax
      * this assumption with (much) more data-flow logic, including a memory model.
      *
-     * <p>By default assignments to locals are not counted as side-effects,
+     * <p>By default, assignments to locals are not counted as side effects,
      * unless the lhs is in the given set of symbols.
      *
      * @param node             A node
@@ -440,7 +440,7 @@ public final class JavaRuleUtil {
     }
 
     /**
-     * Whether the invocation has no side-effects. Very conservative.
+     * Whether the invocation has no side effects. Very conservative.
      */
     private static boolean isPure(ASTMethodCall call) {
         return isGetterCall(call) || KNOWN_PURE_METHODS.anyMatch(call);
@@ -561,7 +561,7 @@ public final class JavaRuleUtil {
     }
 
     /**
-     * Time methods cannot be moved ever, even when there are no side-effects.
+     * Time methods cannot be moved ever, even when there are no side effects.
      * The side effect they depend on is the program being executed. Are they
      * the only methods like that?
      */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -30,6 +30,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
@@ -40,6 +41,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMemberValue;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
@@ -231,7 +233,9 @@ public final class JavaRuleUtil {
 
             if (declNode instanceof ASTFieldDeclaration
                     || declNode instanceof ASTMethodDeclaration
-                    || declNode instanceof ASTTypeDeclaration
+                    || declNode instanceof ASTClassDeclaration
+                    || declNode instanceof ASTRecordDeclaration
+                    || declNode instanceof ASTEnumDeclaration
             ) {
                 ModifierOwner modifierOwner = (ModifierOwner) declNode;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -197,7 +197,7 @@ public final class JavaRuleUtil {
      * <ul>
      *     <li>ALL member functions, member variables, nested classes, and initializers are static.</li>
      *     <li>The class has at least one member function, member variable, or nested class that is not private.</li>
-     *     <li>The class is neither abstract nor an interface.</li>
+     *     <li>The class is a concrete class (neither abstract nor an interface).</li>
      *     <li>The class has no superclasses and implements no interfaces. (This might change in the future.)</li>
      *     <li>The class has no main method.</li>
      * </ul>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.internal;
 
 import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
+import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.isMainMethod;
 import static net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind.LONG;
 import static net.sourceforge.pmd.util.CollectionUtil.immutableSetOf;
 
@@ -191,46 +192,65 @@ public final class JavaRuleUtil {
     }
 
     /**
-     * Returns true if the node is a utility class, according to this
-     * custom definition.
+     * Returns true if the node is a utility class, according to this custom definition. <br />
+     * A class is a utility class, if and only if it fulfills ALL of the following criteria:
+     * <ul>
+     *     <li>ALL member functions, member variables, nested classes, and initializers are static.</li>
+     *     <li>The class has at least one member function, member variable, or nested class that is not private.</li>
+     *     <li>The class is neither abstract nor an interface.</li>
+     *     <li>The class has no superclasses and implements no interfacees. (This might change in the future.)</li>
+     *     <li>The class has no main method.</li>
+     * </ul>
      */
     public static boolean isUtilityClass(ASTTypeDeclaration node) {
-        if (!node.isRegularClass()) {
+        if (!(node instanceof ASTClassDeclaration)) {
             return false;
         }
 
         ASTClassDeclaration classNode = (ASTClassDeclaration) node;
 
+        // abstract classes and interfaces aren't utility classes.
+        if (classNode.isInterface() || classNode.isAbstract()) {
+            return false;
+        }
+
         // A class with a superclass or interfaces should not be considered
         if (classNode.getSuperClassTypeNode() != null
-            || !classNode.getSuperInterfaceTypeNodes().isEmpty()) {
+                || !classNode.getSuperInterfaceTypeNodes().isEmpty()
+        ) {
             return false;
         }
 
         // A class without declarations shouldn't be reported
-        boolean hasAny = false;
+        boolean hasNonPrivateMembers = false;
 
         for (ASTBodyDeclaration declNode : classNode.getDeclarations()) {
-            if (declNode instanceof ASTFieldDeclaration
-                || declNode instanceof ASTMethodDeclaration) {
+            if (isMainMethod(declNode)) {
+                return false;
+            }
 
-                hasAny = isNonPrivate(declNode) && !JavaAstUtils.isMainMethod(declNode);
-                if (!((ModifierOwner) declNode).hasModifiers(JModifier.STATIC)) {
+            if (declNode instanceof ASTFieldDeclaration
+                    || declNode instanceof ASTMethodDeclaration
+                    || declNode instanceof ASTClassDeclaration
+            ) {
+                ModifierOwner modifierOwner = (ModifierOwner) declNode;
+
+                if (modifierOwner.getVisibility() != Visibility.V_PRIVATE) {
+                    hasNonPrivateMembers = true;
+                }
+                if (!modifierOwner.hasModifiers(JModifier.STATIC)) {
                     return false;
                 }
-
             } else if (declNode instanceof ASTInitializer) {
-                if (!((ASTInitializer) declNode).isStatic()) {
+                ASTInitializer initializer = (ASTInitializer) declNode;
+
+                if (!initializer.isStatic()) {
                     return false;
                 }
             }
         }
 
-        return hasAny;
-    }
-
-    private static boolean isNonPrivate(ASTBodyDeclaration decl) {
-        return ((ModifierOwner) decl).getVisibility() != Visibility.V_PRIVATE;
+        return hasNonPrivateMembers;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -193,12 +193,12 @@ public final class JavaRuleUtil {
 
     /**
      * Returns true if the node is a utility class, according to this custom definition. <br />
-     * A class is a utility class, if and only if it fulfills ALL of the following criteria:
+     * A class is a utility class, if and only if it fulfills ALL the following criteria:
      * <ul>
      *     <li>ALL member functions, member variables, nested classes, and initializers are static.</li>
      *     <li>The class has at least one member function, member variable, or nested class that is not private.</li>
      *     <li>The class is a concrete class (neither abstract nor an interface).</li>
-     *     <li>The class has no superclasses and implements no interfaces. (This might change in the future.)</li>
+     *     <li>The class has no superclasses and implements no interfaces.</li>
      *     <li>The class has no main method.</li>
      * </ul>
      */

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -261,10 +261,13 @@ public class Foo extends Bar{
             on those. E.g. setting the property `utilityClassPattern` to
             `[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)` reports any utility class, whose name
             does not end in "Util(s)", "Helper" or "Constants".
-            
-            For this rule, a utility class is defined as: a concrete class that does not
-            inherit from a super class or implement any interface and only has static fields
-            or methods.
+
+            A class is a utility class, if and only if it fulfills ALL the following criteria:
+            * ALL member functions, member variables, nested classes, and initializers are static.
+            * The class has at least one member function, member variable, or nested class that is not private.
+            * The class is a concrete class (neither abstract nor an interface).
+            * The class has no superclasses and implements no interfaces.
+            * The class has no main method.
 
             This rule detects test classes using the following convention: Test classes are top-level classes, that
             either inherit from JUnit 3 TestCase or have at least one method annotated with the Test annotations from

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1495,10 +1495,16 @@ public class MyClass {
           class="net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#useutilityclass">
         <description>
-For classes that only have static members, consider making them utility classes.
-Note that this doesn't apply to abstract classes, since their subclasses may
-well include non-static methods.  Also, if you want this class to be a utility class,
-remember to add a private constructor to prevent instantiation.
+A class is a utility class, if and only if it fulfills ALL the following criteria:
+* ALL member functions, member variables, nested classes, and initializers are static.
+* The class has at least one member function, member variable, or nested class that is not private.
+* The class is a concrete class (neither abstract nor an interface).
+* The class has no superclasses and implements no interfaces.
+* The class has no main method.
+
+Utility classes should not be instantiable. Make sure that the only constructor is a
+private no-args constructor to enforce this.
+
 (Note, that this use was known before PMD 5.1.0 as UseSingleton).
         </description>
         <priority>3</priority>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1505,7 +1505,7 @@ A class is a utility class, if and only if it fulfills ALL the following criteri
 Utility classes should not be instantiable. Make sure that the only constructor is a
 private no-args constructor to enforce this.
 
-(Note, that this use was known before PMD 5.1.0 as UseSingleton).
+(Note, that this rule was known before PMD 5.1.0 as UseSingleton).
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -152,6 +153,46 @@ class JavaRuleUtilTest extends BaseParserTest {
             ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
 
             assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only a nested interface is a utility class - nested interfaces are implicitly static")
+        void testNestedInterface() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    public interface NestedInterface {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only a nested enum is a utility class - nested enums are implicitly static")
+        void testNestedEnum() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    public enum NestedEnum { A };\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only a nested record is a utility class - nested records are implicitly static")
+        @Disabled("Why doesn't this parse?")
+        void testNestedRecord() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    public record NestedRecord() {}\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
         }
 
         @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -183,7 +182,6 @@ class JavaRuleUtilTest extends BaseParserTest {
 
         @Test
         @DisplayName("a class with only a nested record is a utility class - nested records are implicitly static")
-        @Disabled("Why doesn't this parse?")
         void testNestedRecord() {
             ASTCompilationUnit root = java.parse(
                     "public class A {\n"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -5,14 +5,19 @@
 package net.sourceforge.pmd.lang.java.rule.internal;
 
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.containsCamelCaseWord;
+import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isUtilityClass;
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.startsWithCamelCaseWord;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import net.sourceforge.pmd.lang.java.BaseParserTest;
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 
 class JavaRuleUtilTest extends BaseParserTest {
 
@@ -40,4 +45,179 @@ class JavaRuleUtilTest extends BaseParserTest {
         assertThrows(AssertionError.class, () -> containsCamelCaseWord("fnei", "a"), "not capitalized");
     }
 
+    @Nested
+    class IsUtilityClass {
+
+        @Test
+        @DisplayName("a class with only static members is a utility class")
+        void testPositive() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                    + "    private static String privateStaticMemberVariable = \"foo\";\n"
+                    + "    public static String staticMemberVariable = \"foo\";\n"
+                    + "    private static void privateStaticMemberFunction() {};\n"
+                    + "    public static void staticMemberFunction() {};\n"
+                    + "    private static class PrivateStaticNestedClass {};\n"
+                    + "    public static class StaticNestedClass {};\n"
+                    + "    static {}\n"
+                    + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only static member variables is a utility class")
+        void testStaticMemberVariables() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static String privateStaticMemberVariable = \"foo\";\n"
+                            + "    public static String staticMemberVariable = \"foo\";\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with a non-static member variable is NOT a utility class")
+        void testMemberVariable() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static String privateStaticMemberVariable = \"foo\";\n"
+                            + "    public static String staticMemberVariable = \"foo\";\n"
+                            + "    private String instanceVariable = \"bar\";\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only static member functions is a utility class")
+        void testStaticMemberFunctions() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static void privateStaticMemberFunction() {};\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "    public void memberFunction() {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with a non-static member function is NOT a utility class")
+        void testMemberFunction() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static void privateStaticMemberFunction() {};\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "    public void memberFunction() {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with only static member classes is a utility class")
+        void testStaticMemberClasses() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static class PrivateStaticNestedClass {};\n"
+                            + "    public static class StaticNestedClass {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with a non-static member class is NOT a utility class")
+        void testMemberClass() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static class PrivateStaticNestedClass {};\n"
+                            + "    public static class StaticNestedClass {};\n"
+                            + "    class MemberClass {};"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with a non-static initializers is NOT a utility class")
+        void testNonStaticInitializer() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    private static void privateStaticMemberFunction() {};\n"
+                            + "    {}\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("an empty class is NOT a utility class")
+        void testEmpty() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("an interface is NOT a utility class")
+        void testInterface() {
+            ASTCompilationUnit root = java.parse(
+                    "public interface A {\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("an abstract class is NOT a utility class")
+        void testAbstractClass() {
+            ASTCompilationUnit root = java.parse(
+                    "public abstract class A {\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+
+        @Test
+        @DisplayName("a class with a main method is NOT a utility class")
+        void testMainMethod() {
+            ASTCompilationUnit root = java.parse(
+                    "public class A {\n"
+                            + "    public static void main(String... args) {};\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertFalse(isUtilityClass(classDecl));
+        }
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -53,14 +53,14 @@ class JavaRuleUtilTest extends BaseParserTest {
         void testPositive() {
             ASTCompilationUnit root = java.parse(
                     "public class A {\n"
-                    + "    private static String privateStaticMemberVariable = \"foo\";\n"
-                    + "    public static String staticMemberVariable = \"foo\";\n"
-                    + "    private static void privateStaticMemberFunction() {};\n"
-                    + "    public static void staticMemberFunction() {};\n"
-                    + "    private static class PrivateStaticNestedClass {};\n"
-                    + "    public static class StaticNestedClass {};\n"
-                    + "    static {}\n"
-                    + "}"
+                            + "    private static String privateStaticMemberVariable = \"foo\";\n"
+                            + "    public static String staticMemberVariable = \"foo\";\n"
+                            + "    private static void privateStaticMemberFunction() {};\n"
+                            + "    public static void staticMemberFunction() {};\n"
+                            + "    private static class PrivateStaticNestedClass {};\n"
+                            + "    public static class StaticNestedClass {};\n"
+                            + "    static {}\n"
+                            + "}"
             );
             ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
 
@@ -103,12 +103,11 @@ class JavaRuleUtilTest extends BaseParserTest {
                     "public class A {\n"
                             + "    private static void privateStaticMemberFunction() {};\n"
                             + "    public static void staticMemberFunction() {};\n"
-                            + "    public void memberFunction() {};\n"
                             + "}"
             );
             ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
 
-            assertFalse(isUtilityClass(classDecl));
+            assertTrue(isUtilityClass(classDecl));
         }
 
         @Test

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -14,9 +14,7 @@
 public class Foo {
     public Foo() { }
     public static void doSomething() {}
-    public static void main(String args[]) {
-        doSomething();
-    }
+    public static void doSomethingElse(String args[]) {}
 }
         ]]></code>
     </test-code>
@@ -426,9 +424,7 @@ Foo // <--violation: line 2
 {
     public Foo() { }
     public static void doSomething() {}
-    public static void main(String args[]) {
-        doSomething();
-    }
+    public static void doSomethingElse(String args[]) {}
 }
         ]]></code>
     </test-code>
@@ -523,6 +519,46 @@ public class Foo {
     public static void foo() {};
 
     public static class Bar {};
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>non-static initializer</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private static void privateStaticMemberFunction() {};
+    {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>mix of a static field, a static member function, a static nested class, and a static initializer</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static final int SOME_CONSTANT = 42;
+
+    public static void foo() {};
+
+    public static class Bar {};
+
+    static {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>with a main method, this isn't a utility class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void main(String... args) {};
+
+    public static void staticMemberFunction() {};
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This PR standardizes what `UseUtilityClassRule` and `JavaRuleUtil.isUtilityClass()` (used by `ClassNamingConventionsRule`) mean by the term "utility class."

The new common definition is:
> A class is a utility class, if and only if it fulfills ALL of the following criteria:
> * ALL member functions, member variables, nested classes, and initializers are static.
> * The class has at least one member function, member variable, or nested class that is not private.
> * The class is neither abstract nor an interface.
> * The class has no superclasses and implements no interfaces. ~(This might change in the future.)~
> * The class has no main method.


## Related issues

- Fix #1102 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

