### PR TITLE
[java] Fix #6681: UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -109,6 +109,7 @@ this is already done.
   * [#3777](https://github.com/pmd/pmd/issues/3777): \[java] New rule: AssertStatementInTest
   * [#5477](https://github.com/pmd/pmd/issues/5477): \[java] JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class
   * [#6606](https://github.com/pmd/pmd/issues/6606): \[java] UnusedPrivateField: False positive on JUnit Jupiter `@FieldSource`
+  * [#6681](https://github.com/pmd/pmd/issues/6681): \[java] UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTClassLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -38,10 +39,13 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
-        boolean usesSoftAssertExtension = usesSoftAssertExtension(method.getEnclosingType());
+        ASTTypeDeclaration enclosingType = method.getEnclosingType();
+        // marks the usage of a SoftAssertionExtension (JUnit 5+) or SoftAssertionRule (JUnit 4)
+        // effects are the same -> no explicit call to .assertAll() necessary
+        boolean usesSoftAssertionEnvironment = usesSoftAssertExtension(enclosingType) || usesSoftAssertRule(enclosingType);
         Set<String> extraAsserts = getProperty(EXTRA_ASSERT_METHOD_NAMES);
         Predicate<ASTMethodCall> isAssertCall = TestFrameworksUtil::isProbableAssertCall;
-        if (usesSoftAssertExtension) {
+        if (usesSoftAssertionEnvironment) {
             isAssertCall = isAssertCall.or(TestFrameworksUtil::isSoftAssert);
         }
 
@@ -73,5 +77,12 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
                 .filterIs(ASTClassLiteral.class)
                 .map(ASTClassLiteral::getTypeNode)
                 .any(c -> TypeTestUtil.isA("org.assertj.core.api.junit.jupiter.SoftAssertionsExtension", c));
+    }
+
+    private boolean usesSoftAssertRule(ASTTypeDeclaration typeDeclaration) {
+        return typeDeclaration.getDeclarations(ASTFieldDeclaration.class)
+                .filter(x -> x.isAnnotationPresent("org.junit.Rule"))
+                .map(ASTFieldDeclaration::getTypeNode)
+                .any(type -> TypeTestUtil.isA("org.assertj.core.api.JUnitSoftAssertions", type));
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnitTestShouldIncludeAssert.xml
@@ -497,7 +497,7 @@ public class FooTest {
     public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Test
-    void testFoo() {
+    public void testFoo() {
         softly.assertThat("doesn't matter").isEqualTo("doesn't matter");
     }
 }


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6681 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature (fixed previously broken test)
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

