### PR TITLE
[java] UnnecessaryBooleanAssertion: Use InvocationMatcher to find assertions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
@@ -95,12 +95,17 @@ public final class InvocationMatcher {
             return false;
         }
         if (expectedName != null && !node.getMethodName().equals(expectedName)
-            || argMatchers != null && ASTList.sizeOrZero(node.getArguments()) != argMatchers.size()) {
+                || argMatchers != null && ASTList.sizeOrZero(node.getArguments()) != argMatchers.size()) {
             return false;
         }
         OverloadSelectionResult info = node.getOverloadSelectionInfo();
-        return !info.isFailed() && matchQualifier(node)
-                && argsMatchOverload(info.getMethodType());
+        return matchQualifier(node)
+            && (info.isFailed() ? argsMatchByDefault(node) : argsMatchOverload(info.getMethodType()));
+    }
+
+    private boolean argsMatchByDefault(InvocationNode node) {
+        int count = ASTList.sizeOrZero(node.getArguments());
+        return argMatchers == null || argMatchers.isEmpty() && count == 0;
     }
 
     private boolean matchQualifier(InvocationNode node) {

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3334,7 +3334,11 @@ an error, use the `fail()` method and provide an indication message of why it di
     or pmd-java:matchesSig('org.junit.Assert#assertFalse(_*)')
     or pmd-java:matchesSig('org.junit.Assert#assertTrue(_*)')
     or pmd-java:matchesSig('org.junit.jupiter.api.Assertions#assertFalse(_*)')
-    or pmd-java:matchesSig('org.junit.jupiter.api.Assertions#assertTrue(_*)')]
+    or pmd-java:matchesSig('org.junit.jupiter.api.Assertions#assertTrue(_*)')
+    or pmd-java:matchesSig('org.testng.Assert#assertFalse(_*)')
+    or pmd-java:matchesSig('org.testng.Assert#assertTrue(_*)')
+    or pmd-java:matchesSig('org.springframework.test.util.AssertionErrors#assertFalse(_*)')
+    or pmd-java:matchesSig('org.springframework.test.util.AssertionErrors#assertTrue(_*)')]
         [ArgumentList
             [
                 BooleanLiteral or

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3329,17 +3329,12 @@ an error, use the `fail()` method and provide an indication message of why it di
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassDeclaration
-    [pmd-java:typeIs('junit.framework.TestCase')
-     or .//Annotation[pmd-java:typeIs('org.junit.Test')
-                   or pmd-java:typeIs('org.junit.jupiter.api.Test')
-                   or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-                   or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
-                   or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-                   or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-     ]
-    ]
-    //MethodCall[@MethodName = ('assertTrue', 'assertFalse')]
+//MethodCall[pmd-java:matchesSig('junit.framework.TestCase#assertFalse(_*)')
+    or pmd-java:matchesSig('junit.framework.TestCase#assertTrue(_*)')
+    or pmd-java:matchesSig('org.junit.Assert#assertFalse(_*)')
+    or pmd-java:matchesSig('org.junit.Assert#assertTrue(_*)')
+    or pmd-java:matchesSig('org.junit.jupiter.api.Assertions#assertFalse(_*)')
+    or pmd-java:matchesSig('org.junit.jupiter.api.Assertions#assertTrue(_*)')]
         [ArgumentList
             [
                 BooleanLiteral or

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureXPathTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureXPathTest.java
@@ -39,9 +39,23 @@ class MatchesSignatureXPathTest extends BaseXPathFunctionTest {
 
     @Test
     void testMatchSigUnresolved() {
+        Rule rule = makeXpathRuleFromXPath("//MethodCall[pmd-java:matchesSig('java.lang.String#foobar(int)')]");
+
+        assertFinds(rule, 0, "enum O {; { \"\".foobar(1); } }");
+    }
+
+    @Test
+    void testMatchSigUnresolvedNoArgs() {
         Rule rule = makeXpathRuleFromXPath("//MethodCall[pmd-java:matchesSig('java.lang.String#foobar()')]");
 
-        assertFinds(rule, 0, "enum O {; { \"\".foobar(); } }");
+        assertFinds(rule, 1, "enum O {; { \"\".foobar(); } }");
+    }
+
+    @Test
+    void testMatchSigUnresolvedAnyNumberOfArgs() {
+        Rule rule = makeXpathRuleFromXPath("//MethodCall[pmd-java:matchesSig('java.lang.String#foobar(_*)')]");
+
+        assertFinds(rule, 1, "enum O {; { \"\".foobar(); } }");
     }
 
     @Test

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryBooleanAssertion.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryBooleanAssertion.xml
@@ -2,7 +2,7 @@
 <test-data
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_1_1_0.xsd">
 
     <test-code>
         <description>failure case</description>
@@ -148,6 +148,25 @@ public class Foo {
     @Test
     void bar() {
         assertTrue(true);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestNG and Spring - failure case</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,7,8,9</expected-linenumbers>
+        <code><![CDATA[
+import org.testng.Assert;
+import org.springframework.test.util.AssertionErrors;
+public class Foo {
+    @Test
+    void bar() {
+        Assert.assertTrue(true);
+        Assert.assertFalse(true);
+        AssertionErrors.assertTrue(true);
+        AssertionErrors.assertFalse(true);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryBooleanAssertion.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryBooleanAssertion.xml
@@ -124,9 +124,10 @@ public class Foo {
     <test-code>
         <description>JUnit 4 - failure case</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
 import org.junit.Test;
+import static org.junit.Assert.*;
 public class Foo {
     @Test
     void bar() {
@@ -137,7 +138,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>JUnit 5 - failure case - @Test</description>
+        <description>JUnit Jupiter - failure case - @Test</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
@@ -145,6 +146,21 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Foo {
     @Test
+    void bar() {
+        assertTrue(true);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>failure in helper method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import static org.junit.Assert.*;
+public class FooUtil {
+
     void bar() {
         assertTrue(true);
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
@@ -80,7 +80,7 @@ public class Foo {
     private String foo() {
         name.indexOf("F");
         name.getChars(0, 1, new char[1], 0);
-        name.getBytes(0, 1, new char[1], 0);
+        name.getBytes(0, 1, new byte[1], 0);
         name.getBytes();
         name.getBytes("UTF8");
         return name.substring(1);


### PR DESCRIPTION

## Describe the PR

Rule: [UnnecessaryBooleanAssertion](https://docs.pmd-code.org/latest/pmd_rules_java_errorprone.html#unnecessarybooleanassertion)

Use more reliable detection of `assertTrue(true)` and `assertFalse(true)` -- there's no reason this shoul be only checked in test classes, OTOH a method in a test class called `assertTrue` is not necessarily one of the framework methods.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

