### PR TITLE
[java] Fix #6710: Case insensitive comparison in UseStandardCharsets

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -125,6 +125,7 @@ The old names still work but are deprecated.
   * [#5477](https://github.com/pmd/pmd/issues/5477): \[java] JUnit5TestShouldBePackagePrivate is not applied when @Test method is only present in parent class
   * [#6606](https://github.com/pmd/pmd/issues/6606): \[java] UnusedPrivateField: False positive on JUnit Jupiter `@FieldSource`
   * [#6681](https://github.com/pmd/pmd/issues/6681): \[java] UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)
+  * [#6710](https://github.com/pmd/pmd/issues/6710): \[java] UseStandardCharsets: False negative when using lowercase standard charset names
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -7,11 +7,11 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
-import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
@@ -41,10 +41,11 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
     public RuleContext visit(ASTMethodCall call, Object data) {
         RuleContext ctx = (RuleContext) data;
 
-        if (CHARSET_FOR_NAME.matchesCall(call)
-                && STANDARD_CHARSET_EXISTS.contains(call.getArguments().get(0).getConstValue())
-        ) {
-            ctx.addViolation(call);
+        if (CHARSET_FOR_NAME.matchesCall(call)) {
+            String callArgument = (String) call.getArguments().get(0).getConstValue();
+            if (callArgument != null && STANDARD_CHARSET_EXISTS.contains(callArgument.toUpperCase(Locale.ROOT))) {
+                ctx.addViolation(call);
+            }
         }
 
         for (int i = 0; i < call.getArguments().size(); i++) {
@@ -66,17 +67,20 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
     }
 
     private void checkIthArgument(RuleContext ctx, InvocationNode call, int index) {
-        ASTExpression ex = call.getArguments().get(index);
-        if (STANDARD_CHARSET_EXISTS.contains(ex.getConstValue())) {
-            JMethodSig callSignature = call.getMethodType();
-            Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
-            long count = otherSignatures
-                    .filter(sig -> Modifier.isPublic(sig.getModifiers()))
-                    .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
-                    .filter(sig -> CHARSET.equals(sig.getFormalParameters().get(index).toString()))
-                    .count();
-            if (count > 0) {
-                ctx.addViolation(call);
+        Object callArgument = call.getArguments().get(index).getConstValue();
+        if (callArgument instanceof String) {
+            String stringArgument = (String) callArgument;
+            if (STANDARD_CHARSET_EXISTS.contains(stringArgument.toUpperCase(Locale.ROOT))) {
+                JMethodSig callSignature = call.getMethodType();
+                Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
+                long count = otherSignatures
+                        .filter(sig -> Modifier.isPublic(sig.getModifiers()))
+                        .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
+                        .filter(sig -> CHARSET.equals(sig.getFormalParameters().get(index).toString()))
+                        .count();
+                if (count > 0) {
+                    ctx.addViolation(call);
+                }
             }
         }
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -4,7 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
-
     <test-code>
         <description>fail, US-ASCII</description>
         <expected-problems>1</expected-problems>
@@ -273,6 +272,76 @@ public class Foo {
 
     public void foo(String x, Charset enc) {
     }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, String.getBytes(String) - UTF-8 mixed case</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("Utf-8");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, Charset.forName(String) - UTF-8 mixed case</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+        Charset.forName("Utf-8");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, Charset.forName(String) - charset name is passed as variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset(String foo) {
+        Charset.forName(foo);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, random call to a method with an int parameter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        bar(42);
+    }
+
+    public void bar(int x) {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, random call involving a variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String x) {
+        bar(x);
+    }
+
+    public void bar(String x) {}
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This PR changes UseStandardCharsetsRule.java to use a case insensitive comparison.

## Related issues

- Fix #6710

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

