### PR TITLE
chore(deps-dev): Update tmp from 0.2.5 to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,11 +586,10 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -848,7 +847,7 @@
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
-        "tmp": "^0.2.4"
+        "tmp": "^0.2.6"
       }
     },
     "figures": {
@@ -1114,9 +1113,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true
     },
     "tr46": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "all-contributors-cli": "^6.26.1"
   },
   "overrides": {
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.6"
   }
 }


### PR DESCRIPTION
## Describe the PR

This fixes the pesky security vulnerability that just popped up. Not that the vulnerability is not in PMD itself, it is in (a dependency of) the all-contributors script we use to update the list of contributors

## Related issues

- Fix https://github.com/pmd/pmd/security/dependabot/103

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

