### PR TITLE
[java] Fix #6719: UseStandardCharsets UTF-32 on Java >= 22

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -126,6 +126,7 @@ The old names still work but are deprecated.
   * [#6606](https://github.com/pmd/pmd/issues/6606): \[java] UnusedPrivateField: False positive on JUnit Jupiter `@FieldSource`
   * [#6681](https://github.com/pmd/pmd/issues/6681): \[java] UnitTestShouldIncludeAssert: False positive with JUnitSoftAssertions Rule (JUnit 4)
   * [#6710](https://github.com/pmd/pmd/issues/6710): \[java] UseStandardCharsets: False negative when using lowercase standard charset names
+  * [#6719](https://github.com/pmd/pmd/issues/6719): \[java] UseStandardCharsets: False negative with Java 22+ and UTF-32 charsets
 * java-codestyle
   * [#2801](https://github.com/pmd/pmd/issues/2801): \[java] OnlyOneReturn should have a property to allow early exits (guard clauses)
   * [#6427](https://github.com/pmd/pmd/issues/6427): \[java] UnnecessaryCast: False positive for long cast before bit-shift operations on int/byte

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -4,13 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.util.CollectionUtil.immutableSetOf;
+
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.InvocationNode;
@@ -30,7 +31,8 @@ import net.sourceforge.pmd.reporting.RuleContext;
 public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
 
     private static final InvocationMatcher CHARSET_FOR_NAME = InvocationMatcher.parse("java.nio.charset.Charset#forName(java.lang.String)");
-    private static final Set<String> STANDARD_CHARSET_EXISTS = new HashSet<>(Arrays.asList("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16"));
+    private static final Set<String> STANDARD_CHARSETS = immutableSetOf("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16");
+    private static final Set<String> STANDARD_CHARSETS_JAVA_22 = immutableSetOf("UTF-32BE", "UTF-32LE", "UTF-32");
     private static final String CHARSET = "java.nio.charset.Charset";
 
     public UseStandardCharsetsRule() {
@@ -43,7 +45,7 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
 
         if (CHARSET_FOR_NAME.matchesCall(call)) {
             String callArgument = (String) call.getArguments().get(0).getConstValue();
-            if (callArgument != null && STANDARD_CHARSET_EXISTS.contains(callArgument.toUpperCase(Locale.ROOT))) {
+            if (callArgument != null && standardCharsetExists(call.getLanguageVersion(), callArgument)) {
                 ctx.addViolation(call);
             }
         }
@@ -70,7 +72,7 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
         Object callArgument = call.getArguments().get(index).getConstValue();
         if (callArgument instanceof String) {
             String stringArgument = (String) callArgument;
-            if (STANDARD_CHARSET_EXISTS.contains(stringArgument.toUpperCase(Locale.ROOT))) {
+            if (standardCharsetExists(call.getLanguageVersion(), stringArgument)) {
                 JMethodSig callSignature = call.getMethodType();
                 Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
                 long count = otherSignatures
@@ -115,5 +117,11 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
             }
         }
         return true;
+    }
+
+    private boolean standardCharsetExists(LanguageVersion languageVersion, String charset) {
+        return STANDARD_CHARSETS.contains(charset.toUpperCase(Locale.ROOT))
+                || (languageVersion.compareToVersion("22") >= 0
+                        && STANDARD_CHARSETS_JAVA_22.contains(charset.toUpperCase(Locale.ROOT)));
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -345,4 +345,116 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>fail, Charset.forName(String), UTF-32BE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+        Charset.forName("UTF-32BE");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, Charset.forName(String), UTF-32LE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+        Charset.forName("UTF-32LE");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, Charset.forName(String), UTF-32</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+        Charset.forName("UTF-32");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, String.getBytes(String), UTF-32BE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("UTF-32BE");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, String.getBytes(String), UTF-32LE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("UTF-32LE");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, String.getBytes(String), UTF-32</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("UTF-32");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, Charset.forName(String), UTF-32, Java &lt; 22</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+        Charset.forName("UTF-32");
+    }
+}
+        ]]></code>
+        <source-type>java 21</source-type>
+    </test-code>
+
+    <test-code>
+        <description>ok, String.getBytes(String), UTF-32, Java &lt; 22</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void charset(String foo) {
+        foo.getBytes("UTF-32");
+    }
+}
+        ]]></code>
+        <source-type>java 21</source-type>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Since Java 22, `java.nio.charset.StandardCharsets` includes UTF-32 (and variants). Update `UseStandardCharsets` to reflect that.

## Related issues

- Fix #6719 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

