### PR TITLE
chore(deps-dev): bump build-tools from 37 to 38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>37</pmd.build-tools.version>
+        <pmd.build-tools.version>38</pmd.build-tools.version>
 
         <pmd-designer.version>7.19.2</pmd-designer.version>
 


### PR DESCRIPTION
## Describe the PR

This enables the rule UnusedPrivateMethod for tests. I didn't notice any violation to be fixed.

## Related issues

- Refs pmd/build-tools#158
- Refs #6619 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

