### PR TITLE
[core] RuleSetWriter: fix indent-number attribute

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetWriter.java
@@ -56,6 +56,7 @@ public class RuleSetWriter {
     private Document document;
     private Set<String> ruleSetFileNames;
 
+
     public RuleSetWriter(OutputStream outputStream) {
         this.outputStream = outputStream;
     }
@@ -65,7 +66,18 @@ public class RuleSetWriter {
     }
 
     public void write(RuleSet ruleSet) {
+        write(ruleSet, 3);
+    }
+
+    void write(RuleSet ruleSet, int indentation) {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
+            // Set the context classloader to be the platform classloader, so that we don't
+            // find the TransformerFactory from Saxon (which is on the classpath), but fallback
+            // to Java's built-in one. That one supports the "indent-number" attribute, Saxon does not.
+            // TODO: PMD 8: Use ClassLoader.getPlatformClassLoader()
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader().getParent());
+
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
@@ -77,7 +89,7 @@ public class RuleSetWriter {
 
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
             try {
-                transformerFactory.setAttribute("indent-number", 3);
+                transformerFactory.setAttribute("indent-number", indentation);
             } catch (IllegalArgumentException iae) {
                 // ignore it, specific to one parser
                 LOG.debug("Couldn't set indentation", iae);
@@ -91,6 +103,8 @@ public class RuleSetWriter {
             transformer.transform(new DOMSource(document), new StreamResult(outputStream));
         } catch (DOMException | FactoryConfigurationError | ParserConfigurationException | TransformerException e) {
             throw new RuntimeException(e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetWriterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetWriterTest.java
@@ -8,15 +8,19 @@ import static net.sourceforge.pmd.util.CollectionUtil.mapOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Random;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import net.sourceforge.pmd.lang.rule.RuleSet.RuleSetBuilder;
 import net.sourceforge.pmd.lang.rule.internal.RuleSetReference;
@@ -70,6 +74,28 @@ class RuleSetWriterTest extends RulesetFactoryTestBase {
 
         String written = out.toString(StandardCharsets.UTF_8.name());
         assertTrue(written.contains("<exclude name=\"MockRule2\""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", "   ", "     "})
+    void indentationTests(String indentationSpaces) throws Exception {
+        RuleSet braces = new RuleSetLoader().loadFromResource("net/sourceforge/pmd/lang/rule/TestRuleset1.xml");
+        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+                .withName("ruleset")
+                .withDescription("ruleset description")
+                .addRuleSetByReference(braces, true, "MockRule2")
+                .build();
+
+        writer.write(ruleSet, indentationSpaces.length());
+        String written = out.toString(StandardCharsets.UTF_8.name());
+        String descriptionTag = "<description>";
+        String lineWithDescription = Arrays.stream(written.split("\\R"))
+                .filter(s -> s.contains(descriptionTag))
+                .findFirst().orElse(null);
+        assertNotNull(lineWithDescription, "No line with " + descriptionTag + " found!");
+        String prefix = indentationSpaces + descriptionTag;
+        assertTrue(lineWithDescription.startsWith(prefix),
+                "Wrong indentation. Expected '" + prefix + "...', but got: '" + lineWithDescription + "'");
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

From the logs of the pmd-eclipse-plugin:

```
    09:55:38.787 [WorkbenchTestable] DEBUG net.sourceforge.pmd.RuleSetWriter - Couldn't set indentation
    java.lang.IllegalArgumentException: Unrecognized configuration feature: indent-number
        at net.sf.saxon.Configuration.setConfigurationProperty(Configuration.java:4326)
        at net.sf.saxon.jaxp.SaxonTransformerFactory.setAttribute(SaxonTransformerFactory.java:330)
        at net.sourceforge.pmd.RuleSetWriter.write(RuleSetWriter.java:75)
        at net.sourceforge.pmd.eclipse.runtime.writer.impl.RuleSetWriterImpl.write(RuleSetWriterImpl.java:37)
        at net.sourceforge.pmd.eclipse.runtime.preferences.impl.PreferencesManagerImpl.storeRuleSetInStateLocation(PreferencesManagerImpl.java:691)
        at net.sourceforge.pmd.eclipse.runtime.preferences.impl.PreferencesManagerImpl.setRuleSet(PreferencesManagerImpl.java:300)
```

This probably stopped working a long time ago. The reason is: We have Saxon on the classpath (used for our XPath-based rules) and this doesn't support "indent-number" attribute. But the built-in XML transformer of Java does...

Incidentally, Saxon uses by default 3 spaces for indentation, which we also chose. So there is no real difference, but the exception is annoying.

With this PR, this Illegal Argument Exception doesn't appear anymore.

## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

