### PR TITLE
[kotlin] Fix #6732: Add LocalVariableShadowsParameter rule

### DIFF
--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterRule.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterRule.java
@@ -31,7 +31,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
  * {@link KotlinAstUtil#isWithin}) is then compared against the combined set
  * of params from that function and all its enclosing functions.
  *
- * @since 7.25.0
+ * @since 7.26.0
  */
 public class LocalVariableShadowsParameterRule extends AbstractKotlinRule {
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterRule.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterRule.java
@@ -1,0 +1,113 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.kotlin.rule.bestpractices;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.kotlin.AbstractKotlinRule;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtLambdaLiteral;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtLambdaParameter;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtLambdaParameters;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtPropertyDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtVariableDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinVisitor;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinVisitorBase;
+import net.sourceforge.pmd.lang.kotlin.ast.internal.KotlinAstUtil;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * Detects local variable declarations and lambda explicit parameters that
+ * shadow a parameter of any enclosing named function.
+ *
+ * <p>Param names are collected once per function visit. Each property and
+ * lambda parameter directly inside that function (checked via
+ * {@link KotlinAstUtil#isWithin}) is then compared against the combined set
+ * of params from that function and all its enclosing functions.
+ *
+ * @since 7.25.0
+ */
+public class LocalVariableShadowsParameterRule extends AbstractKotlinRule {
+
+    private static final Visitor INSTANCE = new Visitor();
+
+    @Override
+    public KotlinVisitor<RuleContext, ?> buildVisitor() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(KtFunctionDeclaration.class);
+    }
+
+    private static final class Visitor extends KotlinVisitorBase<RuleContext, Void> {
+
+        @Override
+        public Void visitFunctionDeclaration(KtFunctionDeclaration func, RuleContext data) {
+            Set<String> shadowableParams = collectShadowableParams(func);
+            if (shadowableParams.isEmpty()) {
+                return null;
+            }
+            checkPropertyDeclarations(func, shadowableParams, data);
+            checkLambdaParameters(func, shadowableParams, data);
+            return null;
+        }
+
+        private static Set<String> collectShadowableParams(KtFunctionDeclaration func) {
+            Set<String> params = new HashSet<>(KotlinAstUtil.collectParamNames(func));
+            for (KtFunctionDeclaration outer : func.ancestors(KtFunctionDeclaration.class)) {
+                params.addAll(KotlinAstUtil.collectParamNames(outer));
+            }
+            return params;
+        }
+
+        private static void checkPropertyDeclarations(KtFunctionDeclaration func,
+                                                      Set<String> shadowableParams,
+                                                      RuleContext data) {
+            for (KtPropertyDeclaration propDecl : func.descendants(KtPropertyDeclaration.class)) {
+                if (!KotlinAstUtil.isWithin(propDecl, KtFunctionDeclaration.class, func)) {
+                    continue;
+                }
+                KtVariableDeclaration varDecl = propDecl.variableDeclaration();
+                if (varDecl == null) {
+                    continue;
+                }
+                String name = KotlinAstUtil.textOf(varDecl.simpleIdentifier());
+                if (name != null && shadowableParams.contains(name)) {
+                    data.addViolation(propDecl, name);
+                }
+            }
+        }
+
+        private static void checkLambdaParameters(KtFunctionDeclaration func,
+                                                  Set<String> shadowableParams,
+                                                  RuleContext data) {
+            for (KtLambdaLiteral lambda : func.descendants(KtLambdaLiteral.class)) {
+                if (!KotlinAstUtil.isWithin(lambda, KtFunctionDeclaration.class, func)) {
+                    continue;
+                }
+                KtLambdaParameters lambdaParams = lambda.lambdaParameters();
+                if (lambdaParams == null) {
+                    continue;
+                }
+                for (KtLambdaParameter param : lambdaParams.lambdaParameter()) {
+                    KtVariableDeclaration varDecl = param.variableDeclaration();
+                    if (varDecl == null) {
+                        continue;
+                    }
+                    String name = KotlinAstUtil.textOf(varDecl.simpleIdentifier());
+                    if (name != null && shadowableParams.contains(name)) {
+                        data.addViolation(param, name);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
+++ b/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
@@ -36,7 +36,7 @@ fun calculateLayout() // no violation
     </rule>
 
     <rule name="LocalVariableShadowsParameter"
-          since="7.25.0"
+          since="7.26.0"
           language="kotlin"
           message="Local variable ''{0}'' shadows a parameter of the enclosing function."
           class="net.sourceforge.pmd.lang.kotlin.rule.bestpractices.LocalVariableShadowsParameterRule"

--- a/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
+++ b/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
@@ -35,4 +35,30 @@ fun calculateLayout() // no violation
         </example>
     </rule>
 
+    <rule name="LocalVariableShadowsParameter"
+          since="7.25.0"
+          language="kotlin"
+          message="Local variable ''{0}'' shadows a parameter of the enclosing function."
+          class="net.sourceforge.pmd.lang.kotlin.rule.bestpractices.LocalVariableShadowsParameterRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_kotlin_bestpractices.html#localvariableshadowsparameter">
+        <description>
+            A local variable declaration uses the same name as a parameter of the enclosing function.
+            This shadows the parameter and may lead to confusion about which value is used.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+fun compute(result: Int): Int {
+    val result = 42  // violation - shadows parameter 'result'
+    return result
+}
+
+fun compute2(input: Int): Int {
+    val result = input + 1  // no violation - different name
+    return result
+}
+]]>
+        </example>
+    </rule>
+
 </ruleset>

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/LocalVariableShadowsParameterTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.kotlin.rule.bestpractices;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class LocalVariableShadowsParameterTest extends PmdRuleTst {
+    // test cases in xml/LocalVariableShadowsParameter.xml
+}

--- a/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/xml/LocalVariableShadowsParameter.xml
+++ b/pmd-kotlin/src/test/resources/net/sourceforge/pmd/lang/kotlin/rule/bestpractices/xml/LocalVariableShadowsParameter.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Local variable shadows function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable 'result' shadows a parameter of the enclosing function.</message>
+        </expected-messages>
+        <code><![CDATA[
+fun compute(result: Int): Int {
+    val result = 42
+    return result
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Local variable does not shadow any parameter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+fun compute(input: Int): Int {
+    val result = input + 1
+    return result
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Top-level property does not shadow anything</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+val result = 42
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Multiple parameters, one shadowed</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+fun combine(first: String, second: String): String {
+    val combined = first + second
+    val second = "override"
+    return combined + second
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Local variable in nested function shadows outer function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+fun outer(value: Int) {
+    fun inner(count: Int) {
+        val count = 0
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Function with no parameters cannot shadow</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+fun noParams(): Int {
+    val result = 42
+    return result
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Local variable inside inner block shadows outer function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+fun compute(result: Int): Int {
+    if (result > 0) {
+        val other = 1
+        val result = 42
+    }
+    return result
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Mutable var also shadows parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+fun increment(count: Int): Int {
+    var count = count + 1
+    return count
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>vararg parameter name can be shadowed by local variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+fun process(vararg items: String): List<String> {
+    val items = listOf("default")
+    return items
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Destructuring declaration does not trigger false positive</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+fun split(value: String): Pair<String, String> {
+    val (a, b) = value.split("/").let { it[0] to it[1] }
+    return a to b
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Extension function parameter shadowed by local variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+fun String.append(suffix: String): String {
+    val suffix = "!"
+    return this + suffix
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Local variable inside lambda shadows outer function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+fun process(result: Int): Int {
+    val transform = { x: Int ->
+        val other = x
+        val result = x + 1
+        result
+    }
+    return transform(result)
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Lambda explicit parameter with same name as function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+fun process(result: Int): Int {
+    val transform = { result: Int ->
+        result + 1
+    }
+    return transform(result)
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Lambda explicit parameter not shadowing any function parameter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+fun process(input: Int): Int {
+    val transform = { result: Int ->
+        result + 1
+    }
+    return transform(input)
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Lambda in nested function shadows outer function parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+fun outer(value: Int) {
+    fun inner(count: Int) {
+        val transform = { value: Int ->
+            value + count
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
Adds the `LocalVariableShadowsParameter` rule to the Kotlin best practices ruleset. Detects local variables and lambda explicit parameters that shadow a parameter of any enclosing named function.

Closes #6732.