### PR TITLE
[java] Fix #2846: New Rule: WrongTestAnnotation

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -24,9 +24,18 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚀️ New and noteworthy
 
+### 🌟️ New and Changed Rules
+#### New Rules
+* The new Java rule {% rule java/errorprone/WrongTestAnnotation %} detects when test annotations from the wrong
+  testing framework (JUnit 4, JUnit Jupiter, or TestNG) are used in your code, preventing tests from being silently
+  skipped due to framework mismatches. This helps avoid the silent failure where tests compile but don't execute
+  because the test runner doesn't recognize the annotation.
+
 ### 🐛️ Fixed Issues
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
+* java-errorprone
+  * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/WrongTestAnnotationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/WrongTestAnnotationRule.java
@@ -1,0 +1,90 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJunit4ConfigAnnotation;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJunit4TestAnnotation;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJunit5ConfigAnnotation;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJunit5TestAnnotation;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isTestNGConfigAnnotation;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isTestNGTestAnnotation;
+import static net.sourceforge.pmd.properties.PropertyFactory.conventionalEnumListProperty;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * @since 7.26.0
+ */
+public class WrongTestAnnotationRule extends AbstractJavaRulechainRule {
+
+    private static final PropertyDescriptor<List<TestFrameworks>> FRAMEWORKS_DESCRIPTOR
+            = conventionalEnumListProperty("testFrameworks", TestFrameworks.class)
+                    .desc("List of test frameworks your codebase uses.")
+                    .defaultValues(TestFrameworks.J_UNIT_JUPITER)
+                    .build();
+
+
+    public WrongTestAnnotationRule() {
+        super(ASTAnnotation.class);
+
+        definePropertyDescriptor(FRAMEWORKS_DESCRIPTOR);
+    }
+
+    @Override
+    public Object visit(ASTAnnotation node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (!getProperty(FRAMEWORKS_DESCRIPTOR).contains(TestFrameworks.J_UNIT_JUPITER)
+                && (isJunit5TestAnnotation(node) || isJunit5ConfigAnnotation(node))
+        ) {
+            addViolation(ctx, node, TestFrameworks.J_UNIT_JUPITER);
+        }
+
+        if (!getProperty(FRAMEWORKS_DESCRIPTOR).contains(TestFrameworks.J_UNIT4)
+                && (isJunit4TestAnnotation(node) || isJunit4ConfigAnnotation(node))
+        ) {
+            addViolation(ctx, node, TestFrameworks.J_UNIT4);
+        }
+
+        if (!getProperty(FRAMEWORKS_DESCRIPTOR).contains(TestFrameworks.TEST_N_G)
+                && (isTestNGTestAnnotation(node) || isTestNGConfigAnnotation(node))
+        ) {
+            addViolation(ctx, node, TestFrameworks.TEST_N_G);
+        }
+
+        return null;
+    }
+
+    private void addViolation(RuleContext ctx, ASTAnnotation node, TestFrameworks testFramework) {
+        ctx.addViolation(
+                node,
+                node.getTypeMirror().getSymbol().getBinaryName(),
+                readableName(testFramework),
+                getProperty(FRAMEWORKS_DESCRIPTOR).stream().map(this::readableName).collect(Collectors.joining(", "))
+        );
+    }
+
+    private String readableName(TestFrameworks testFramework) {
+        switch (testFramework) {
+        case J_UNIT_JUPITER: return "JUnit Jupiter";
+        case J_UNIT4: return "JUnit 4";
+        case TEST_N_G: return "TestNG";
+        }
+
+        throw new IllegalArgumentException("Unknown test framework: " + testFramework);
+    }
+
+    private enum TestFrameworks {
+        J_UNIT_JUPITER,
+        J_UNIT4,
+        TEST_N_G
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.internal;
 
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
+import static net.sourceforge.pmd.util.CollectionUtil.union;
 
 import java.util.Set;
 
@@ -49,26 +50,42 @@ public final class TestFrameworksUtil {
                                                                "junit.framework.Assert",
                                                                "junit.framework.TestCase");
 
+    private static final Set<String> JUNIT5_CONFIGURATION_ANNOTATIONS =
+            setOf(
+                    "org.junit.jupiter.api.BeforeEach",
+                    "org.junit.jupiter.api.BeforeAll",
+                    "org.junit.jupiter.api.AfterEach",
+                    "org.junit.jupiter.api.AfterAll"
+            );
+
+    private static final Set<String> JUNIT4_CONFIGURATION_ANNOTATIONS =
+            setOf(
+                    "org.junit.Before",
+                    "org.junit.BeforeClass",
+                    "org.junit.After",
+                    "org.junit.AfterClass"
+            );
+
+    private static final Set<String> TEST_NG_CONFIGURATION_ANNOTATIONS =
+            setOf(
+                    "org.testng.annotations.AfterClass",
+                    "org.testng.annotations.AfterGroups",
+                    "org.testng.annotations.AfterMethod",
+                    "org.testng.annotations.AfterSuite",
+                    "org.testng.annotations.AfterTest",
+                    "org.testng.annotations.BeforeClass",
+                    "org.testng.annotations.BeforeGroups",
+                    "org.testng.annotations.BeforeMethod",
+                    "org.testng.annotations.BeforeSuite",
+                    "org.testng.annotations.BeforeTest"
+            );
+
     private static final Set<String> TEST_CONFIGURATION_ANNOTATIONS =
-        setOf("org.junit.Before",
-                "org.junit.BeforeClass",
-                "org.junit.After",
-                "org.junit.AfterClass",
-                "org.junit.jupiter.api.BeforeEach",
-                "org.junit.jupiter.api.BeforeAll",
-                "org.junit.jupiter.api.AfterEach",
-                "org.junit.jupiter.api.AfterAll",
-                "org.testng.annotations.AfterClass",
-                "org.testng.annotations.AfterGroups",
-                "org.testng.annotations.AfterMethod",
-                "org.testng.annotations.AfterSuite",
-                "org.testng.annotations.AfterTest",
-                "org.testng.annotations.BeforeClass",
-                "org.testng.annotations.BeforeGroups",
-                "org.testng.annotations.BeforeMethod",
-                "org.testng.annotations.BeforeSuite",
-                "org.testng.annotations.BeforeTest"
-        );
+            union(
+                    JUNIT5_CONFIGURATION_ANNOTATIONS,
+                    JUNIT4_CONFIGURATION_ANNOTATIONS,
+                    TEST_NG_CONFIGURATION_ANNOTATIONS
+            );
 
     private TestFrameworksUtil() {
         // utility class
@@ -142,6 +159,26 @@ public final class TestFrameworksUtil {
 
     public static boolean isJunit4TestAnnotation(ASTAnnotation annot) {
         return TypeTestUtil.isA(JUNIT4_TEST_ANNOT, annot);
+    }
+
+    public static boolean isJunit4ConfigAnnotation(ASTAnnotation annot) {
+        return JUNIT4_CONFIGURATION_ANNOTATIONS.stream().anyMatch(name -> TypeTestUtil.isA(name, annot));
+    }
+
+    public static boolean isJunit5TestAnnotation(ASTAnnotation annot) {
+        return JUNIT5_ALL_TEST_ANNOTS.stream().anyMatch(name -> TypeTestUtil.isA(name, annot));
+    }
+
+    public static boolean isJunit5ConfigAnnotation(ASTAnnotation annot) {
+        return JUNIT5_CONFIGURATION_ANNOTATIONS.stream().anyMatch(name -> TypeTestUtil.isA(name, annot));
+    }
+
+    public static boolean isTestNGTestAnnotation(ASTAnnotation annot) {
+        return TypeTestUtil.isA(TEST_NG_TEST_ANNOT, annot);
+    }
+
+    public static boolean isTestNGConfigAnnotation(ASTAnnotation annot) {
+        return TEST_NG_CONFIGURATION_ANNOTATIONS.stream().anyMatch(name -> TypeTestUtil.isA(name, annot));
     }
 
     /**

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3744,4 +3744,32 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="WrongTestAnnotation"
+          language="java"
+          since="7.26.0"
+          message="The annotation {0} is from {1}, your codebase is using {2}."
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.WrongTestAnnotationRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#wrongtestannotation">
+        <description>
+            When you use the @Test annotation from the wrong framework, your tests won't be executed.
+        </description>
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+// Example 1: GOOD if using JUnit Jupiter, BAD if using JUnit4/TestNG
+import org.junit.jupiter.api.Test;
+public class TestClass {
+    @Test
+    public void myTest() { }
+}
+
+// Example 2: GOOD if using TestNG, BAD if using JUnit
+import org.testng.annotations.Test;
+public class TestClass {
+    @Test
+    public void myTest() { }
+}
+]]>
+        </example>
+    </rule>
 </ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/WrongTestAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/WrongTestAnnotationTest.java
@@ -1,0 +1,10 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class WrongTestAnnotationTest extends PmdRuleTst {
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/WrongTestAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/WrongTestAnnotation.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_1_1.xsd">
+
+    <code-fragment id="jupiter"><![CDATA[
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.api.extension.*;
+
+import java.util.Collection;
+
+class SomeTest {
+    @BeforeAll
+    static void setupClass() {}
+
+    @BeforeEach
+    void setup() {}
+
+    @Test
+    void testFoo() {}
+
+    @RepeatedTest(10)
+    void testRepeated() {}
+
+    @TestFactory
+    Collection<DynamicTest> ruleTests() {}
+    
+    @TestTemplate
+    @ExtendWith(MyTestTemplateInvocationContextProvider.class)
+    void testTemplate(String param) {}
+    
+    @ParameterizedTest
+    @ValueSource(strings = { "abc", "def" })
+    void testParameterized(String param) {}
+
+    @AfterEach
+    void teardown() {}
+
+    @AfterAll
+    static void teardownClass() {}
+
+    private class MyTestTemplateInvocationContextProvider implements org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider {
+        @Override
+        public boolean supportsTestTemplate(ExtensionContext context) {
+            return true;
+        }
+
+        @Override
+        public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+            return Stream.of();
+        }
+    }
+}
+    ]]></code-fragment>
+
+    <code-fragment id="junit4"><![CDATA[
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.AfterClass;
+
+public class SomeTest {
+    @BeforeClass
+    public static void setupClass() {}
+
+    @Before
+    public void setup() {}
+
+    @Test
+    public void testFoo() {}
+
+    @After
+    public void teardown() {}
+
+    @AfterClass
+    public void teardownClass() {}
+}
+    ]]></code-fragment>
+
+    <code-fragment id="testNg"><![CDATA[
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.AfterSuite;
+
+public class TestNGCompleteTest {
+
+    @BeforeSuite
+    public void beforeSuite() {}
+
+    @BeforeTest
+    public void beforeTest() {}
+
+    @BeforeClass
+    public void beforeClass() {}
+
+    @BeforeGroups(groups = { "functional" })
+    public void beforeGroups() {}
+
+    @BeforeMethod
+    public void beforeMethod() {}
+
+    @Test
+    public void standardTest() {}
+
+    @AfterMethod
+    public void afterMethod() {}
+
+    @AfterGroups(groups = { "functional" })
+    public void afterGroups() {}
+
+    @AfterClass
+    public void afterClass() {}
+
+    @AfterTest
+    public void afterTest() {}
+
+    @AfterSuite
+    public void afterSuite() {}
+}
+    ]]></code-fragment>
+
+    <code-fragment id="simple"><![CDATA[
+import org.junit.Test;
+
+public class SomeTest {
+    @Test
+    public void testFoo() {}
+}
+    ]]></code-fragment>
+
+    <test-code>
+        <description>When using JUnit Jupiter, using a JUnit Jupiter annotation is OK</description>
+        <rule-property name="testFrameworks">jUnitJupiter</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="jupiter" />
+    </test-code>
+
+    <test-code>
+        <description>When using JUnit4, using a JUnit Jupiter annotation is NOT OK</description>
+        <rule-property name="testFrameworks">jUnit4</rule-property>
+        <expected-problems>9</expected-problems>
+        <code-ref id="jupiter" />
+    </test-code>
+
+    <test-code>
+        <description>When using TestNG, using a TestNG annotation is NOT OK</description>
+        <rule-property name="testFrameworks">testNG</rule-property>
+        <expected-problems>9</expected-problems>
+        <code-ref id="jupiter" />
+    </test-code>
+
+    <test-code>
+        <description>When using Jupiter, using a JUnit4 annotation is NOT OK</description>
+        <rule-property name="testFrameworks">jUnitJupiter</rule-property>
+        <expected-problems>5</expected-problems>
+        <code-ref id="junit4" />
+    </test-code>
+
+    <test-code>
+        <description>When using JUnit4, using a JUnit4 annotation is OK</description>
+        <rule-property name="testFrameworks">jUnit4</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="junit4" />
+    </test-code>
+
+    <test-code>
+        <description>When using TestNG, using a JUnit4 annotation is NOT OK</description>
+        <rule-property name="testFrameworks">testNG</rule-property>
+        <expected-problems>5</expected-problems>
+        <code-ref id="junit4" />
+    </test-code>
+
+    <test-code>
+        <description>When using Jupiter, using a TestNG annotation is NOT OK</description>
+        <rule-property name="testFrameworks">jUnitJupiter</rule-property>
+        <expected-problems>11</expected-problems>
+        <code-ref id="testNg" />
+    </test-code>
+
+    <test-code>
+        <description>When using JUnit4, using a TestNG annotation is NOT OK</description>
+        <rule-property name="testFrameworks">jUnit4</rule-property>
+        <expected-problems>11</expected-problems>
+        <code-ref id="testNg" />
+    </test-code>
+
+    <test-code>
+        <description>When using TestNG, using a TestNG annotation is OK</description>
+        <rule-property name="testFrameworks">testNG</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="testNg" />
+    </test-code>
+
+    <test-code>
+        <description>Verify location of violation</description>
+        <rule-property name="testFrameworks">jUnitJupiter</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4-4</expected-linenumbers>
+        <code-ref id="simple" />
+    </test-code>
+
+    <test-code>
+        <description>Verify violation message</description>
+        <rule-property name="testFrameworks">jUnitJupiter</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The annotation org.junit.Test is from JUnit 4, your codebase is using JUnit Jupiter.</message>
+        </expected-messages>
+        <code-ref id="simple" />
+    </test-code>
+
+    <test-code>
+        <description>Verify violation message (multiple)</description>
+        <rule-property name="testFrameworks">jUnitJupiter,testNG</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The annotation org.junit.Test is from JUnit 4, your codebase is using JUnit Jupiter, TestNG.</message>
+        </expected-messages>
+        <code-ref id="simple" />
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

The new Java rule WrongTestAnnotation detects when test annotations from the wrong testing framework (JUnit 4, JUnit Jupiter, or TestNG) are used in your code, preventing tests from being silently skipped due to framework mismatches. This helps avoid the silent failure where tests compile but don't execute because the test runner doesn't recognize the annotation.

## Related issues

- Fix #2846

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

