### PR TITLE
[java] Fix #6736: Add JTypeMirror.streamClasses()

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -44,6 +44,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#6741](https://github.com/pmd/pmd/issues/6741): \[cli] Designer: Fix quotes in PMD_OPENJFX_MODULE_PATH setting
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
+  * [#6736](https://github.com/pmd/pmd/issues/6736): \[java] JUnitJupiterTestShouldBePackagePrivate: False negative when the only tests are in a @Nested class
   * [#6782](https://github.com/pmd/pmd/issues/6782): \[java] UseStandardCharsets: ArrayIndexOutOfBoundsException in line 81
 * java-codestyle
   * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -44,7 +44,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#6741](https://github.com/pmd/pmd/issues/6741): \[cli] Designer: Fix quotes in PMD_OPENJFX_MODULE_PATH setting
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
-  * [#6736](https://github.com/pmd/pmd/issues/6736): \[java] JUnitJupiterTestShouldBePackagePrivate: False negative when the only tests are in a @Nested class
+  * [#6736](https://github.com/pmd/pmd/issues/6736): \[java] JUnitJupiterTestShouldBePackagePrivate: False negative when the only tests are in a @<!-- -->Nested class
   * [#6782](https://github.com/pmd/pmd/issues/6782): \[java] UseStandardCharsets: ArrayIndexOutOfBoundsException in line 81
 * java-codestyle
   * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
@@ -217,8 +218,12 @@ public final class TestFrameworksUtil {
         JClassType typeMirror = node.getTypeMirror();
 
         return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
-                && typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
-                        .findAny().isPresent();
+                && (
+                        typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
+                                .findAny().isPresent()
+                        || typeMirror.streamClasses(TestFrameworksUtil::isJUnit5NestedClass)
+                                .findAny().isPresent()
+                );
     }
 
     public static boolean isTestNGClass(ASTClassDeclaration node) {
@@ -230,7 +235,14 @@ public final class TestFrameworksUtil {
     }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {
-        return innerClassDecl.isAnnotationPresent(JUNIT5_NESTED);
+        return isJUnit5NestedClass(innerClassDecl.getTypeMirror());
+    }
+
+    private static boolean isJUnit5NestedClass(JTypeMirror innerClassMirror) {
+        TypeSystem ts = innerClassMirror.getTypeSystem();
+
+        return innerClassMirror.getSymbol().getDeclaredAnnotations().stream().anyMatch(
+                it -> TypeTestUtil.isA(JUNIT5_NESTED, ts.typeOf(it.getAnnotationSymbol(), false)));
     }
 
     public static boolean isExpectExceptionCall(ASTMethodCall call) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -221,7 +221,8 @@ public final class TestFrameworksUtil {
                 && (
                         typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
                                 .findAny().isPresent()
-                        || typeMirror.streamClasses(TestFrameworksUtil::isJUnit5NestedClass)
+                        || typeMirror.streamClasses()
+                                .filter(c -> TestFrameworksUtil.isJUnit5NestedClass(c))
                                 .findAny().isPresent()
                 );
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
@@ -10,6 +10,7 @@ import static net.sourceforge.pmd.util.CollectionUtil.map;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -333,16 +334,14 @@ class ClassTypeImpl implements JClassType {
     }
 
     @Override
-    public Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+    public Stream<JTypeMirror> streamClasses() {
         return SuperTypesEnumerator.ALL_SUPERTYPES_INCLUDING_SELF.stream(this)
-                .flatMap(sup -> sup.streamDeclaredClasses(prefilter));
+                .flatMap(sup -> sup.streamDeclaredClasses());
     }
 
     @Override
-    public Stream<JTypeMirror> streamDeclaredClasses(Predicate<? super JTypeMirror> prefilter) {
-        return getDeclaredClasses().stream()
-                .filter(prefilter)
-                .map(c -> getDeclaredClass(c.getSymbol().getSimpleName()));
+    public Stream<JTypeMirror> streamDeclaredClasses() {
+        return getDeclaredClasses().stream().map(Function.identity());
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
@@ -10,7 +10,6 @@ import static net.sourceforge.pmd.util.CollectionUtil.map;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -336,12 +335,12 @@ class ClassTypeImpl implements JClassType {
     @Override
     public Stream<JTypeMirror> streamClasses() {
         return SuperTypesEnumerator.ALL_SUPERTYPES_INCLUDING_SELF.stream(this)
-                .flatMap(sup -> sup.streamDeclaredClasses());
+                .flatMap(JTypeMirror::streamDeclaredClasses);
     }
 
     @Override
     public Stream<JTypeMirror> streamDeclaredClasses() {
-        return getDeclaredClasses().stream().map(Function.identity());
+        return getDeclaredClasses().stream().map(JTypeMirror.class::cast);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
@@ -333,6 +333,19 @@ class ClassTypeImpl implements JClassType {
     }
 
     @Override
+    public Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+        return SuperTypesEnumerator.ALL_SUPERTYPES_INCLUDING_SELF.stream(this)
+                .flatMap(sup -> sup.streamDeclaredClasses(prefilter));
+    }
+
+    @Override
+    public Stream<JTypeMirror> streamDeclaredClasses(Predicate<? super JTypeMirror> prefilter) {
+        return getDeclaredClasses().stream()
+                .filter(prefilter)
+                .map(c -> getDeclaredClass(c.getSymbol().getSimpleName()));
+    }
+
+    @Override
     public @Nullable JClassType getDeclaredClass(String simpleName) {
         JClassSymbol declaredClass = symbol.getDeclaredClass(simpleName);
         if (declaredClass != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
@@ -142,8 +142,8 @@ public final class JIntersectionType implements JTypeMirror {
     }
 
     @Override
-    public Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
-        return getComponents().stream().flatMap(it -> it.streamClasses(prefilter));
+    public Stream<JTypeMirror> streamClasses() {
+        return getComponents().stream().flatMap(it -> it.streamClasses());
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
@@ -141,6 +141,10 @@ public final class JIntersectionType implements JTypeMirror {
         return getComponents().stream().flatMap(it -> it.streamMethods(prefilter));
     }
 
+    @Override
+    public Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+        return getComponents().stream().flatMap(it -> it.streamClasses(prefilter));
+    }
 
     @Override
     public JIntersectionType subst(Function<? super SubstVar, ? extends @NonNull JTypeMirror> subst) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
@@ -439,6 +439,30 @@ public interface JTypeMirror extends JTypeVisitable {
         return Stream.empty();
     }
 
+    /**
+     * Returns a stream of nested classes declared in and inherited
+     * by this type.
+     *
+     * @param prefilter Filter selecting symbols for which a class
+     *                  should be created and yielded by the stream
+     */
+    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+        return Stream.empty();
+    }
+
+    /**
+     * Like {@link #streamClasses(Predicate) streamNestedClasses}, but does
+     * not recurse into supertypes. Note that only class types
+     * declare nested classes themselves.
+     *
+     * <p>See also note in {@link #streamClasses(Predicate)}.
+     *
+     * @see #streamMethods(Predicate)
+     */
+    default Stream<JTypeMirror> streamDeclaredClasses(Predicate<? super JTypeMirror> prefilter) {
+        return Stream.empty();
+    }
+
 
     /**
      * Returns a list of all the declared constructors for this type.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
@@ -440,26 +440,19 @@ public interface JTypeMirror extends JTypeVisitable {
     }
 
     /**
-     * Returns a stream of nested classes declared in and inherited
-     * by this type.
-     *
-     * @param prefilter Filter selecting symbols for which a class
-     *                  should be created and yielded by the stream
+     * Returns a stream of nested classes declared in this type and its
+     * supertypes.
      */
-    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+    default Stream<JTypeMirror> streamClasses() {
         return Stream.empty();
     }
 
     /**
-     * Like {@link #streamClasses(Predicate) streamNestedClasses}, but does
+     * Like {@link #streamClasses() streamNestedClasses}, but does
      * not recurse into supertypes. Note that only class types
      * declare nested classes themselves.
-     *
-     * <p>See also note in {@link #streamClasses(Predicate)}.
-     *
-     * @see #streamMethods(Predicate)
      */
-    default Stream<JTypeMirror> streamDeclaredClasses(Predicate<? super JTypeMirror> prefilter) {
+    default Stream<JTypeMirror> streamDeclaredClasses() {
         return Stream.empty();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
@@ -153,5 +153,8 @@ public interface JTypeVar extends SubstVar {
         return getUpperBound().streamMethods(prefilter);
     }
 
-
+    @Override
+    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+        return getUpperBound().streamClasses(prefilter);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
@@ -154,7 +154,7 @@ public interface JTypeVar extends SubstVar {
     }
 
     @Override
-    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
-        return getUpperBound().streamClasses(prefilter);
+    default Stream<JTypeMirror> streamClasses() {
+        return getUpperBound().streamClasses();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
@@ -75,6 +75,11 @@ public interface JWildcardType extends JTypeMirror {
     }
 
     @Override
+    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
+        return asUpperBound().streamClasses(prefilter);
+    }
+
+    @Override
     JWildcardType subst(Function<? super SubstVar, ? extends @NonNull JTypeMirror> subst);
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
@@ -75,8 +75,8 @@ public interface JWildcardType extends JTypeMirror {
     }
 
     @Override
-    default Stream<JTypeMirror> streamClasses(Predicate<? super JTypeMirror> prefilter) {
-        return asUpperBound().streamClasses(prefilter);
+    default Stream<JTypeMirror> streamClasses() {
+        return asUpperBound().streamClasses();
     }
 
     @Override

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/JUnit5ParentWithNestedTestClass.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/rulesfortests/JUnit5ParentWithNestedTestClass.java
@@ -1,0 +1,13 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests;
+
+import org.junit.jupiter.api.Nested;
+
+public class JUnit5ParentWithNestedTestClass {
+    @Nested
+    class NestedClass {
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
@@ -162,6 +162,26 @@ class TestFrameworksUtilTest {
         }
 
         @Test
+        void aClassWithANestedTestClassIsAJUnit5Class() {
+            ASTCompilationUnit root = java.parse(
+                    "import org.junit.jupiter.api.Nested; class A { @Nested class B {}; }"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
+        void aClassWithANestedTestClassIsAJUnit5ClassEvenIfTheTestIsInAParentClass() {
+            ASTCompilationUnit root = java.parse(
+                    "import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.JUnit5ParentWithNestedTestClass; class A extends JUnit5ParentWithNestedTestClass {}"
+            );
+            ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
+
+            assertTrue(isJUnit5Class(classDecl));
+        }
+
+        @Test
         void anInterfaceWithATestIsANotJUnit5Class() {
             ASTCompilationUnit root = java.parse(
                     "import org.junit.jupiter.api.Test; interface A { @Test default void foo() {} }"

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ClassTypeImplTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ClassTypeImplTest.kt
@@ -6,18 +6,14 @@
 package net.sourceforge.pmd.lang.java.types
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.Matcher
-import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldHave
 import net.sourceforge.pmd.lang.java.JavaParsingHelper
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.test.ast.IntelliMarker
 import net.sourceforge.pmd.lang.test.ast.shouldBe
-import java.util.stream.Stream
 
 /**
  * @author Clément Fournier
@@ -51,7 +47,7 @@ class ClassTypeImplTest : IntelliMarker,FunSpec({
     }
 
     context("streamClasses()") {
-        val parser: JavaParsingHelper = JavaParsingHelper.DEFAULT.withResourceContext(javaClass);
+        val parser: JavaParsingHelper = JavaParsingHelper.DEFAULT.withResourceContext(javaClass)
 
         test("class with superclass") {
             val source = """

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ClassTypeImplTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ClassTypeImplTest.kt
@@ -6,10 +6,18 @@
 package net.sourceforge.pmd.lang.java.types
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldHave
+import net.sourceforge.pmd.lang.java.JavaParsingHelper
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit
+import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.test.ast.IntelliMarker
 import net.sourceforge.pmd.lang.test.ast.shouldBe
-import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
+import java.util.stream.Stream
 
 /**
  * @author Clément Fournier
@@ -42,5 +50,26 @@ class ClassTypeImplTest : IntelliMarker,FunSpec({
         }
     }
 
+    context("streamClasses()") {
+        val parser: JavaParsingHelper = JavaParsingHelper.DEFAULT.withResourceContext(javaClass);
+
+        test("class with superclass") {
+            val source = """
+                class Parent {
+                    class NestedInsideParent {}
+                }
+                class Child extends Parent {
+                    class NestedInsideChild {}
+                }
+            """.trimIndent()
+            val root: ASTCompilationUnit = parser.parse(source)
+            val classDecl: ASTClassDeclaration = root.children(ASTClassDeclaration::class.java).filter{it.canonicalName == "Child"}.first()!!
+            val typeMirror: JTypeMirror = classDecl.typeMirror
+
+            typeMirror.streamClasses().count() shouldBe 2
+            typeMirror.streamClasses().anyMatch { it.symbol?.simpleName == "NestedInsideParent" }.shouldBeTrue()
+            typeMirror.streamClasses().anyMatch { it.symbol?.simpleName == "NestedInsideChild" }.shouldBeTrue()
+        }
+    }
 
 })

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitJupiterTestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitJupiterTestShouldBePackagePrivate.xml
@@ -160,7 +160,7 @@ public class Child extends Junit5ParentWithTest {}
     </test-code>
 
     <test-code>
-        <description>test class should have default visibility, even if the test methods are in a nested class inside a parent class</description>
+        <description>test class should have default visibility, even if the test methods are in a nested class inside a parent class #6736</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3-3</expected-linenumbers>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitJupiterTestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitJupiterTestShouldBePackagePrivate.xml
@@ -158,4 +158,15 @@ import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.Junit5ParentW
 public class Child extends Junit5ParentWithTest {}
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>test class should have default visibility, even if the test methods are in a nested class inside a parent class</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3-3</expected-linenumbers>
+        <code><![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.JUnit5ParentWithNestedTestClass;
+
+public class FooTest extends JUnit5ParentWithNestedTestClass {}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR
* adds `JTypeMirror.streamClasses()` and `.streamDeclaredClasses()`,
* uses this to make `TestFrameworksUtil.isJunit5Class()` and `.isTestClass()` recognize classes with only @<!-- -->Nested classes as test classes
* which in turn fixes ClassNamingConventions, JUnitJupiterTestShouldBePackagePrivate, and JUnitJupiterTestNoPrivateModifier in this case.

## Related issues

- Fix #6736

## Review notes

I think this is my first time touching the `.types` package. I believe I've done the right thing here, but please double check.
I've used `.streamMethods()` and `.streamDeclaredMethods` as a template for my code. I didn't implement the two methods
in JArrayType, because I don't think arrays can have nested classes.

Are there existing tests for `JTypeMirror` and related classes where I need to add some tests? Currently, I only test my changes indirectly via
`TestFrameworksUtilTest`.

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

