### PR TITLE
chore: Remove maven-shade-plugin from <pluginManagement>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,11 +335,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.6.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
                     <configuration>


### PR DESCRIPTION
## Describe the PR

Remove maven-shade-plugin from `<pluginManagement>`

It was used in the past for some stuff in pmd-apex, but hasn't been used since 2017.

## Related issues

- Follow-Up for #605 

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

