### PR TITLE
[cli] Designer: Fix quotes in PMD_OPENJFX_MODULE_PATH setting

### DIFF
--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -154,7 +154,7 @@ IF [%APPNAME%] == [designer] (
       EXIT /B 2
     )
 
-    SET "PMD_OPENJFX_MODULE_PATH=--module-path %JAVAFX_HOME%/lib --add-modules javafx.controls,javafx.fxml"
+    SET "PMD_OPENJFX_MODULE_PATH=--module-path "%JAVAFX_HOME%/lib" --add-modules javafx.controls,javafx.fxml"
   )
 )
 EXIT /B


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

If JAVAFX_HOME contains a path with spaces, e.g. `C:\Program Files\Java\javafx-sdk-21.0.2`, the command `.\pmd.bat designer` would fail to start the designer with the error message `java.lang.ClassNotFoundException: Files\Java\javafx-sdk-21.0.2.lib`.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

