### PR TITLE
[java] Fix #6239: UseDiamondOperator: Implement heuristic for Super Type Token Pattern

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -34,6 +34,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛️ Fixed Issues
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
+* java-codestyle
+  * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral
 * java-errorprone
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAnonymousClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTClassType;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
@@ -80,6 +81,10 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
             return null;
         }
 
+        if (isSuperTypeTokenPattern(ctorCall)) {
+            return null;
+        }
+
         if (inferenceSucceedsWithoutTypeArgs(ctorCall)) {
             // report it
             JavaNode reportNode = targs == null ? newTypeNode : targs;
@@ -94,6 +99,24 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
         return ctorCall.getLanguageVersion().compareToVersion("9") >= 0;
     }
 
+    /**
+     * Heuristic to detect the
+     * <a href="https://gafter.blogspot.com/2006/12/super-type-tokens.html">Super Type Token</a>
+     * Pattern
+     */
+    // visible for testing
+    /* private */ static boolean isSuperTypeTokenPattern(ASTConstructorCall ctorCall) {
+        if (!ctorCall.isAnonymousClass()) {
+            return false;
+        }
+
+        ASTAnonymousClassDeclaration anonymousClassDeclaration = ctorCall.getAnonymousClassDeclaration();
+        ASTClassType superClass = anonymousClassDeclaration.getSuperClassTypeNode();
+
+        return superClass != null
+                && superClass.getTypeArguments() != null
+                && anonymousClassDeclaration.getBody().isEmpty();
+    }
 
     /** Redo inference as described in the javadoc of this class. */
     private static boolean inferenceSucceedsWithoutTypeArgs(ASTConstructorCall call) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -167,7 +167,7 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
         produceSameTypeWithDiamond(ctor.getTypeNode(), sb, true);
         ASTArgumentList arguments = ctor.getArguments();
         String argsString;
-        if (arguments.size() == 0) {
+        if (arguments.isEmpty()) {
             argsString = "()";
         } else {
             CharSequence text = arguments.getText();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -25,6 +25,8 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.JVariableSig.FieldSig;
+import net.sourceforge.pmd.lang.java.types.Substitution;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypingContext;
 import net.sourceforge.pmd.lang.java.types.ast.ExprContext;
@@ -115,7 +117,14 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
 
         return superClass != null
                 && superClass.getTypeArguments() != null
-                && anonymousClassDeclaration.getBody().isEmpty();
+                && anonymousClassDeclaration.getBody().isEmpty()
+                && ((JClassType) superClass.getTypeMirror()).getDeclaredFields().stream().anyMatch(UseDiamondOperatorRule::isTypeField);
+    }
+
+    private static boolean isTypeField(FieldSig fieldSig) {
+        JTypeMirror fieldType = fieldSig.getSymbol().getTypeMirror(Substitution.EMPTY);
+        return fieldType instanceof JClassType
+                && "java.lang.reflect.Type".equals(((JClassType) fieldType).getSymbol().getCanonicalName());
     }
 
     /** Redo inference as described in the javadoc of this class. */

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
@@ -26,7 +26,7 @@ class UseDiamondOperatorTest extends PmdRuleTst {
         @Test
         @DisplayName("Creating an object of an anonymous class without a class body, where the parent class is generic - looks like the super type pattern")
         void testPositive() {
-            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() {}; } }");
+            ASTCompilationUnit root = java.parse("class TypeReference<T> { private java.lang.reflect.Type type; } public class A { { new TypeReference<java.util.List<String>>() {}; } }");
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertTrue(isSuperTypeTokenPattern(ctorCall));
@@ -35,7 +35,7 @@ class UseDiamondOperatorTest extends PmdRuleTst {
         @Test
         @DisplayName("Needs to create an anonymous class")
         void testNoAnonymousClass() {
-            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>(); } }");
+            ASTCompilationUnit root = java.parse("class TypeReference<T> { private java.lang.reflect.Type type; } public class A { { new TypeReference<java.util.List<String>>(); } }");
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertFalse(isSuperTypeTokenPattern(ctorCall));
@@ -44,7 +44,7 @@ class UseDiamondOperatorTest extends PmdRuleTst {
         @Test
         @DisplayName("Anonymous class body needs to be empty")
         void testAnonymousClassBodyIsntEmpty() {
-            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() { void foo() {} }; } }");
+            ASTCompilationUnit root = java.parse("class TypeReference<T> { private java.lang.reflect.Type type; } public class A { { new TypeReference<java.util.List<String>>() { void foo() {} }; } }");
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertFalse(isSuperTypeTokenPattern(ctorCall));
@@ -53,7 +53,7 @@ class UseDiamondOperatorTest extends PmdRuleTst {
         @Test
         @DisplayName("Superclass must be generic")
         void testSuperclassNotGeneric() {
-            ASTCompilationUnit root = java.parse("class TypeReference {} public class A { { new TypeReference() {}; } }");
+            ASTCompilationUnit root = java.parse("class TypeReference { private java.lang.reflect.Type type; } public class A { { new TypeReference() {}; } }");
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertFalse(isSuperTypeTokenPattern(ctorCall));
@@ -62,7 +62,7 @@ class UseDiamondOperatorTest extends PmdRuleTst {
         @Test
         @DisplayName("Missing type arguments")
         void testMissingTypeArguments() {
-            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference() {}; } }");
+            ASTCompilationUnit root = java.parse("class TypeReference<T> { private java.lang.reflect.Type type; } public class A { { new TypeReference() {}; } }");
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertFalse(isSuperTypeTokenPattern(ctorCall));
@@ -75,6 +75,24 @@ class UseDiamondOperatorTest extends PmdRuleTst {
             ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
 
             assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Missing member of type java.lang.reflect.Type")
+        void testTypeMember() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Type token has additional array member")
+        void testArrayMember() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> { private Object[] o; private java.lang.reflect.Type type; } public class A { { new TypeReference<java.util.List<String>>() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertTrue(isSuperTypeTokenPattern(ctorCall));
         }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorTest.java
@@ -4,8 +4,77 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.lang.java.rule.codestyle.UseDiamondOperatorRule.isSuperTypeTokenPattern;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.java.JavaParsingHelper;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class UseDiamondOperatorTest extends PmdRuleTst {
-    // no additional unit tests
+
+    private final JavaParsingHelper java = JavaParsingHelper.DEFAULT.withResourceContext(getClass());
+
+    @Nested
+    class IsSuperTypeTokenPattern {
+        @Test
+        @DisplayName("Creating an object of an anonymous class without a class body, where the parent class is generic - looks like the super type pattern")
+        void testPositive() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertTrue(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Needs to create an anonymous class")
+        void testNoAnonymousClass() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>(); } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Anonymous class body needs to be empty")
+        void testAnonymousClassBodyIsntEmpty() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() { void foo() {} }; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Superclass must be generic")
+        void testSuperclassNotGeneric() {
+            ASTCompilationUnit root = java.parse("class TypeReference {} public class A { { new TypeReference() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Missing type arguments")
+        void testMissingTypeArguments() {
+            ASTCompilationUnit root = java.parse("class TypeReference<T> {} public class A { { new TypeReference() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+
+        @Test
+        @DisplayName("Interfaces can't be type references")
+        void testInterface() {
+            ASTCompilationUnit root = java.parse("interface TypeReference<T> {} public class A { { new TypeReference<java.util.List<String>>() {}; } }");
+            ASTConstructorCall ctorCall = root.descendants(ASTConstructorCall.class).first();
+
+            assertFalse(isSuperTypeTokenPattern(ctorCall));
+        }
+    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -574,4 +574,30 @@ public class Foo {
         </code>
     </test-code>
 
+    <test-code>
+        <description>#6239 False positive with Typeliterals / super type tokens pattern</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+
+public class A {
+
+    public List<String> bar(String json) {
+        return foo(new TypeReference<List<String>>() {});
+    }
+
+    public static <T> List<String> foo(TypeReference<T> t) {
+        return null;
+    }
+}
+
+// stand in for
+// com.google.inject.TypeLiteral
+// javax.enterprise.util.TypeLiteral
+// org.apache.commons.lang3.reflect.TypeLiteral
+// com.fasterxml.jackson.core.type.TypeReference
+// etc.
+class TypeReference<T> {}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -579,6 +579,7 @@ public class Foo {
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.List;
+import java.lang.reflect.Type;
 
 public class A {
 
@@ -597,7 +598,9 @@ public class A {
 // org.apache.commons.lang3.reflect.TypeLiteral
 // com.fasterxml.jackson.core.type.TypeReference
 // etc.
-class TypeReference<T> {}
+class TypeReference<T> {
+    private Type type;
+}
         ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The way I see it, there are two ways to tackle #6239:

The first: create a list of classes which are exempt from the UseDiamondOperator rule. The issue already mentions four of them. This list could be either hard-coded or user-configurable. In either case, someone has to edit the list when another framework creates their one version of the TypeToken. I don't like this.

The second: attempt to find uses of the [super type token pattern](https://gafter.blogspot.com/2006/12/super-type-tokens.html) programmatically. This is what this PR does.

## Related issues

- Fix #6239

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

