### PR TITLE
[java] Fix #6743: CloseResource: False positive for closeable initialized with (T) null

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -27,6 +27,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛️ Fixed Issues
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
+* java-errorprone
+  * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -523,11 +523,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     }
 
     private boolean isNotNullInitialized(ASTVariableId var) {
-        return !hasNullInitializer(var);
-    }
-
-    private boolean hasNullInitializer(ASTVariableId var) {
-        return var.getInitializer() instanceof ASTNullLiteral;
+        return !(JavaAstUtils.peelCasts(var.getInitializer()) instanceof ASTNullLiteral);
     }
 
     private boolean areStatementsOfSameBlock(ASTStatement bs0, ASTStatement bs1) {
@@ -817,7 +813,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     private ASTExpressionStatement getFirstReassigningStatementBeforeBeingClosed(ASTVariableId variable, ASTExecutableDeclaration methodOrConstructor) {
         List<ASTExpressionStatement> statements = methodOrConstructor.descendants(ASTExpressionStatement.class).toList();
         boolean variableClosed = false;
-        boolean isInitialized = !hasNullInitializer(variable);
+        boolean isInitialized = isNotNullInitialized(variable);
         ASTExpression initializingExpression = initializerExpressionOf(variable);
         for (ASTExpressionStatement statement : statements) {
             if (isClosingVariableStatement(statement, variable)) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2304,4 +2304,31 @@ public abstract class Action implements AutoCloseable {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6743 [java] CloseResource: False positive for closeable initialized with (T) null</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class CastNullAfter {
+    public static void method() {
+        Connection connection = (Connection) null;
+        Statement statement = (Statement) null;
+        try {
+            connection = DriverManager.getConnection("blah");
+            statement = connection.createStatement();
+        } catch (SQLException e) {
+            System.err.println("Error: " + e);
+        } finally {
+            if (statement != null) try { statement.close(); } catch (SQLException e) {}
+            if (connection != null) try { connection.close(); } catch (SQLException e) {}
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6743 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

