### PR TITLE
chore: Keep versions of byte-buddy and byte-buddy-agent in sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <antlr.version>4.13.2</antlr.version>
         <slf4j.version>1.7.36</slf4j.version>
         <saxon.version>12.9</saxon.version>
+        <byte.buddy.version>1.18.10</byte.buddy.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1044,13 +1045,13 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.18.10</version>
+                <version>${byte.buddy.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
-                <version>1.18.10</version>
+                <version>${byte.buddy.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
## Describe the PR

This PR introduces a new variable `byte.buddy.version` to keep the versions of byte-buddy and byte-buddy-agent in sync.
They are always released from the same repository at the same time. This way, there is only one depend-a-bot PR instead of two.

## Related issues

- None

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

