### PR TITLE
Bump build-tools from 38 to 39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>38</pmd.build-tools.version>
+        <pmd.build-tools.version>39</pmd.build-tools.version>
 
         <pmd-designer.version>7.19.2</pmd-designer.version>
 


### PR DESCRIPTION
## Describe the PR

- Enable new rules (https://github.com/pmd/build-tools/pull/165)
- Supports surefire 3.5.6 (https://github.com/pmd/build-tools/pull/164):  
  In build-tools, we implemented a surefire extension to properly report test results (especially from the kotest tests): https://github.com/pmd/pmd/blob/980ae5c84d790236dfbed907aabc89fe010e40df/pom.xml#L349-L363

  With the latest update of surefire from 3.5.5 to 3.5.6, some parts are broken, resulting currently in the following errors during test execution:

  ```
  'void org.apache.maven.plugin.surefire.report.WrappedReportEntry.<init>(org.apache.maven.surefire.api.report.ReportEntry, org.apache.maven.plugin.surefire.report.ReportEntryType, java.lang.Integer, org.apache.maven.plugin.surefire.report.Utf8RecodingDeferredFileOutputStream, org.apache.maven.plugin.surefire.report.Utf8RecodingDeferredFileOutputStream)'. See the dump file /home/andreas/PMD/source/pmd/pmd-cli/target/surefire-reports/2026-06-04T17-34-01_485-jvmRun1.dumpstream
  ```
  
  The new build tools is updated to fix those.

- Avoid using deprecated rule JUnit5TestShouldBePackagePrivate to get rid of the following build warnings (https://github.com/pmd/build-tools/pull/161):

  ```
  [WARNING] Warning at /home/andreas/PMD/source/pmd/pmd-cli/target/pmd/rulesets/001-pmd-test-dogfood-config.xml:11:5
    9|         <priority>1</priority>
   10|     </rule>
   11|     <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate">
           ^^^^^ Use Rule name category/java/bestpractices.xml/JUnitJupiterTestShouldBePackagePrivate instead of the deprecated Rule name category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate. PMD 8.0.0 will remove support for this deprecated Rule name usage.
  ```

## Related issues

- It requires that #6761 is merged before

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

