### PR TITLE
[apex] Fix #3877: ApexCRUDViolation false positive on Lists of Objects with getSObjectType().getDescribe()

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -82,6 +82,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private static final String ANY = "ANY";
     private static final String S_OBJECT_TYPE = "sObjectType";
     private static final String GET_DESCRIBE = "getDescribe";
+    private static final String GET_S_OBJECT_TYPE = "getSObjectType";
 
     private static final String ACCESS_LEVEL = "AccessLevel";
 
@@ -461,6 +462,31 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
                     String resolvedType = getType(nestedMethodCall);
                     if (!typeToDMLOperationMapping.get(resolvedType).contains(method)) {
                         typeToDMLOperationMapping.put(resolvedType, method);
+                    }
+                } else if (GET_DESCRIBE.equalsIgnoreCase(nestedMethodCall.getMethodName())) {
+                    // CustomObject__c.getSObjectType().getDescribe().isXxx() pattern
+                    // getDescribe()'s reference has no names (the receiver is
+                    // also a method call), and getSObjectType() is a child of
+                    // that reference, not of getDescribe() directly
+                    ASTReferenceExpression refOfGetDescribe = nestedMethodCall
+                            .firstChild(ASTReferenceExpression.class);
+                    if (refOfGetDescribe != null) {
+                        ASTMethodCallExpression getSObjectTypeCall = refOfGetDescribe
+                                .firstChild(ASTMethodCallExpression.class);
+                        if (getSObjectTypeCall != null
+                                && GET_S_OBJECT_TYPE.equalsIgnoreCase(getSObjectTypeCall.getMethodName())) {
+                            ASTReferenceExpression objectRef = getSObjectTypeCall
+                                    .firstChild(ASTReferenceExpression.class);
+                            if (objectRef != null && !objectRef.getNames().isEmpty()) {
+                                String objectType = objectRef.getNames().get(0);
+                                String resolvedType = new StringBuilder()
+                                        .append(getSObjectTypeCall.getDefiningType())
+                                        .append(":").append(objectType).toString();
+                                if (!typeToDMLOperationMapping.get(resolvedType).contains(method)) {
+                                    typeToDMLOperationMapping.put(resolvedType, method);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -1899,4 +1899,53 @@ public with sharing class Dummy {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3877 Proper CRUD check via getSObjectType().getDescribe() for single object DML</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static CustomObject__c updateCustomObject(CustomObject__c customObject) {
+        if (CustomObject__c.getSObjectType().getDescribe().isUpdateable() == false) {
+            throw new DmlException('No permissions to update.');
+        }
+        update customObject;
+        return customObject;
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3877 Proper CRUD check via getSObjectType().getDescribe() for List DML</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static List<CustomObject__c> updateCustomObjects(List<CustomObject__c> customObjects) {
+        if (CustomObject__c.getSObjectType().getDescribe().isUpdateable() == false) {
+            throw new DmlException('No permissions to update.');
+        }
+        update customObjects;
+        return customObjects;
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3877 Missing CRUD check via getSObjectType().getDescribe() for List DML - violation expected</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public static List<CustomObject__c> updateCustomObjects(List<CustomObject__c> customObjects) {
+        if (CustomObject__c.getSObjectType().getDescribe().isCreateable() == false) {
+            throw new DmlException('No permissions to create.');
+        }
+        update customObjects;
+        return customObjects;
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix false positive in ApexCRUDViolation rule when using `getSObjectType().getDescribe()` CRUD check pattern on custom objects.

## Related issue

* Fixes #3877

## How to review

The issue is that the existing `getDescribe()` handler in `collectCRUDMethodLevelChecks` expects the method call's reference expression to have names ending with `sObjectType` (e.g., `Contact.sObjectType.getDescribe()`). However, for `CustomObject__c.getSObjectType().getDescribe()`, `getSObjectType()` is a method call — so the reference of `getDescribe()` has no names, and `getSObjectType()` is a child of that reference expression rather than a direct child of `getDescribe()`.

The fix adds a new `else if` branch that checks for this pattern by traversing the reference expression of `getDescribe()` to find the `getSObjectType()` call and extract the SObject type name.

## Test cases added

1. `getSObjectType().getDescribe()` with single object DML — expects 0 violations
2. `getSObjectType().getDescribe()` with List DML — expects 0 violations
3. `getSObjectType().getDescribe()` with wrong CRUD check — expects 1 violation

All 911 existing tests pass (0 failures).