### PR TITLE
[java] Fix examples in javadocs for InvocationMatcher

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
@@ -34,8 +34,8 @@ import net.sourceforge.pmd.util.StringUtil;
  *     _#toString()                  // match calls to toString on any receiver
  *     _#_()                         // match all calls to a method with no parameters
  *     _#toString(_*)                // match calls to a "toString" method with any number of parameters
- *     _#eq(_, _)                    // match calls to an "eq" method that has 2 parameters of unspecified type
- *     _#eq(java.lang.String, _)     // like the previous, but the first parameter must be String
+ *     _#eq(_,_)                     // match calls to an "eq" method that has 2 parameters of unspecified type
+ *     _#eq(java.lang.String,_)      // like the previous, but the first parameter must be String
  *     java.util.ArrayList#new(int)  // match constructor calls of this overload of the ArrayList constructor
  * </pre>
  *


### PR DESCRIPTION
## Describe the PR

The javadoc for InvocationMatcher says
> (no whitespace is tolerated anywhere)

This commit fixes the examples to conform to this.

## Related issues

- None

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

