### PR TITLE
[java] Fix #3741: Deprecate UseObjectForClearerApi

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -34,6 +34,10 @@ This is a {{ site.pmd.release_type }} release.
   declarations that use the same name as a parameter of the enclosing function. This shadows the parameter
   and may lead to confusion about which value is used.
 
+#### Deprecated Rules
+* The rule {% rule java/design/UseObjectForClearerAPI %} was deprecated. Use {% rule java/design/ExcessiveParameterList %}
+  instead. The old rule name still works.
+
 ### 🐛️ Fixed Issues
 * apex-security
   * [#2955](https://github.com/pmd/pmd/issues/2955): \[apex] ApexSOQLInjection: False positive when passing local var with concatenating strings

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -694,7 +694,7 @@ public void sendEmail(String to, String subject, String body, String[] cc) {
     // With cc recipients
 }
 
-public void sendEmail(String to, String subject, String body, String[] cc, String[] bcc, String from, boolean html) {
+public void sendEmail(String to, String subject, String body, String[] cc, String[] bcc, String from, boolean html) {  //NOPMD
     // Full featured
 }
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1541,7 +1541,8 @@ public Long getId() {
           since="4.2.6"
           message="Rather than using a lot of String arguments, consider using a container object for those values."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#useobjectforclearerapi">
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#useobjectforclearerapi"
+          deprecated="true">
         <description>
 When you write a public method, you should be thinking in terms of an API. If your method is public, it means other class
 will use it, therefore, you want (or need) to offer a comprehensive and evolutive API. If you pass a lot of information
@@ -1549,6 +1550,9 @@ as a simple series of Strings, you may think of using an Object to represent all
 API (such as doWork(Workload workload), rather than a tedious series of Strings) and more importantly, if you need at some
 point to pass extra data, you'll be able to do so by simply modifying or extending Workload without any modification to
 your API.
+
+**Deprecated:** This rule is deprecated since PMD 7.26.0 and will be removed with PMD 8.0.0.
+Use ExcessiveParameterList instead.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1552,7 +1552,7 @@ point to pass extra data, you'll be able to do so by simply modifying or extendi
 your API.
 
 **Deprecated:** This rule is deprecated since PMD 7.26.0 and will be removed with PMD 8.0.0.
-Use ExcessiveParameterList instead.
+Use {% rule ExcessiveParameterList %} instead.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -610,24 +610,116 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveParameterListRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessiveparameterlist">
         <description>
-Methods with numerous parameters are a challenge to maintain, especially if most of them share the
-same datatype. These situations usually denote the need for new objects to wrap the numerous parameters.
+            Methods with numerous parameters are a challenge to maintain and increase the risk of bugs.
+            When parameters share similar datatypes, they become prone to mix-ups during refactoring or
+            when calling the method with positional arguments. Additionally, long parameter lists violate
+            the Single Responsibility Principle — they suggest the method is trying to do too much or that
+            conceptually related data hasn't been properly grouped. As methods evolve, maintaining consistent
+            parameter ordering across overloads and similar methods becomes increasingly difficult.
+
+            Long parameter lists also make code harder to read and understand. Callers must carefully match
+            arguments to parameters, and the parameter list itself becomes a visual barrier. This complexity
+            increases the cognitive load for maintainers and leads to higher defect rates. The more parameters
+            a method has, the less intuitive it becomes and the harder it is to test comprehensively,
+            since the number of possible input combinations grows exponentially.
+
+            There are several well-established alternatives to long parameter lists, each suited to different scenarios:
+            the Builder Pattern (constructing objects fluently with named parameters),
+            Multiple Parameter Objects (grouping related parameters into dedicated classes),
+            Method Overloading (providing convenient signatures for common use cases),
+            and Method Decomposition (splitting a single method into multiple, more focused methods that each take fewer parameters).
+
+            Builder Pattern — Use when you want to replace a method call with many positional arguments
+            with a fluent, named-parameter style. Each parameter is named at the call site, eliminating confusion
+            about argument order and making the code self-documenting.
+
+            Multiple Parameter Objects — Use when parameters naturally group into distinct semantic units.
+            This is lighter than a full builder and works well when the parameter objects are stable
+            and reused across multiple methods.
+
+            Method Overloading — Use to provide convenient signatures for common cases without forcing callers
+            to provide all possible parameters. Effective for APIs where there are genuinely frequent
+            "common use case" patterns. Be cautious of overloading too many variants.
+
+            Method Decomposition — Use when a single method is trying to do too much. Split it into focused methods,
+            each with a clear responsibility and fewer parameters. Often combined with builder-style fluent APIs
+            for controlled sequencing and initialization.
         </description>
         <priority>3</priority>
         <example>
-<![CDATA[
-public void addPerson(      // too many arguments liable to be mixed up
-    int birthYear, int birthMonth, int birthDate, int height, int weight, int ssn) {
+            <![CDATA[
+// ============ PROBLEM ============
+public void createDatabaseConnection(String host, int port, String username, String password, int timeout, boolean ssl) { }
 
-    . . . .
+// Usage - hard to understand what each argument means
+createDatabaseConnection("localhost", 5432, "admin", "secret", 30, true);
+
+
+// ============ SOLUTION 1: Builder Pattern ============
+public class ConnectionBuilder { [...] }
+
+// Usage - clear and self-documenting
+createDatabaseConnection(new ConnectionBuilder()
+    .withHost("localhost")
+    .withPort(5432)
+    .withCredentials("admin", "secret")
+    .withTimeout(30)
+    .withSSL(true)
+    .build());
+
+
+// ============ SOLUTION 2: Multiple Parameter Objects ============
+public class ServerAddress { [...] }
+
+public class DatabaseCredentials { [...] }
+
+public class ConnectionOptions { [...] }
+
+public void createDatabaseConnection(ServerAddress address, DatabaseCredentials credentials, ConnectionOptions options) { }
+
+// Usage - semantic grouping makes intent clear
+createDatabaseConnection(
+    new ServerAddress("localhost", 5432),
+    new DatabaseCredentials("admin", "secret"),
+    new ConnectionOptions(30, true)
+);
+
+
+// ============ example for Method Overloading ============
+public void sendEmail(String to, String subject, String body) {
+    // Basic email with defaults
 }
 
-public void addPerson(      // preferred approach
-    Date birthdate, BodyMeasurements measurements, int ssn) {
-
-    . . . .
+public void sendEmail(String to, String subject, String body, String[] cc) {
+    // With cc recipients
 }
-]]>
+
+public void sendEmail(String to, String subject, String body, String[] cc, String[] bcc, String from, boolean html) {
+    // Full featured
+}
+
+// Usage - call with only needed parameters
+sendEmail("user@example.com", "Welcome", "Hello there");
+sendEmail("user@example.com", "Welcome", "Hello there", new String[]{"manager@example.com"});
+sendEmail("user@example.com", "Welcome", "<b>Hello</b>",
+          new String[]{"manager@example.com"},
+          new String[]{"admin@example.com"},
+          "noreply@company.com",
+          true);
+
+
+// ============ Example for Method Decomposition ============
+// Problem: ReportGenerator is called like this:
+Report report = ReportGenerator.generate("Sales Report", "PDF", "Company Report", 16, true, "Page {n} of {total}", 1, "center", "John Smith", LocalDate.now(), "1.0"
+
+// Solution: Allow your code to be called like this:
+ReportGenerator generator = new ReportGenerator();
+generator.startReport("Sales Report", "PDF");
+generator.addHeader("Company Report", 16, true);
+generator.addFooter("Page {n} of {total}", 1, "center");
+generator.addMetadata("John Smith", LocalDate.now(), "1.0");
+Report report = generator.generate();
+            ]]>
         </example>
     </rule>
 

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -179,7 +179,6 @@
     <!-- <rule ref="category/java/design.xml/TooManyFields" /> -->
     <!-- <rule ref="category/java/design.xml/TooManyMethods" /> -->
     <rule ref="category/java/design.xml/UselessOverridingMethod"/>
-    <!-- <rule ref="category/java/design.xml/UseObjectForClearerAPI" /> -->
     <rule ref="category/java/design.xml/UseUtilityClass"/>
 
 


### PR DESCRIPTION
## Describe the PR

Enhance description of ExcessiveParameterList and deprecate UseObjectForClearerAPI

## Related issues

- Fix #3741 

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

