### PR TITLE
[java] Fix #6782: Add missing check for varargs

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -42,6 +42,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#6641](https://github.com/pmd/pmd/issues/6641): \[cpp]: IndexOutOfBoundsException in CPD when a duplication is at end of file with UTF8-BOM
 * java-bestpractices
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
+  * [#6782](https://github.com/pmd/pmd/issues/6782): \[java] UseStandardCharsets: ArrayIndexOutOfBoundsException in line 81
 * java-codestyle
   * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral
   * [#6775](https://github.com/pmd/pmd/issues/6775): \[java] UselessParentheses: False negative when on the right-hand side of an assignment statement

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -69,6 +69,10 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
     }
 
     private void checkIthArgument(RuleContext ctx, InvocationNode call, int index) {
+        if (index >= call.getMethodType().getArity()) {  // this can happen if we're looking at varargs!
+            return;
+        }
+
         Object callArgument = call.getArguments().get(index).getConstValue();
         if (callArgument instanceof String) {
             String stringArgument = (String) callArgument;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsRule.java
@@ -69,25 +69,28 @@ public class UseStandardCharsetsRule extends AbstractJavaRulechainRule {
     }
 
     private void checkIthArgument(RuleContext ctx, InvocationNode call, int index) {
-        if (index >= call.getMethodType().getArity()) {  // this can happen if we're looking at varargs!
+        JMethodSig callSignature = call.getMethodType();
+        if (index >= callSignature.getArity()) {  // this can happen if we're looking at varargs!
             return;
         }
 
         Object callArgument = call.getArguments().get(index).getConstValue();
-        if (callArgument instanceof String) {
-            String stringArgument = (String) callArgument;
-            if (standardCharsetExists(call.getLanguageVersion(), stringArgument)) {
-                JMethodSig callSignature = call.getMethodType();
-                Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
-                long count = otherSignatures
-                        .filter(sig -> Modifier.isPublic(sig.getModifiers()))
-                        .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
-                        .filter(sig -> CHARSET.equals(sig.getFormalParameters().get(index).toString()))
-                        .count();
-                if (count > 0) {
-                    ctx.addViolation(call);
-                }
-            }
+        if (!(callArgument instanceof String)) {
+            return;
+        }
+        String stringArgument = (String) callArgument;
+        if (!standardCharsetExists(call.getLanguageVersion(), stringArgument)) {
+            return;
+        }
+
+        Stream<JMethodSig> otherSignatures = streamMethodSignatures(call);
+        long count = otherSignatures
+                .filter(sig -> Modifier.isPublic(sig.getModifiers()))
+                .filter(sig -> isSameSignatureExcept(callSignature, sig, index))
+                .filter(sig -> CHARSET.equals(sig.getFormalParameters().get(index).toString()))
+                .count();
+        if (count > 0) {
+            ctx.addViolation(call);
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -457,4 +457,42 @@ public class Foo {
         ]]></code>
         <source-type>java 21</source-type>
     </test-code>
+
+    <test-code>
+        <description>varargs</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        bar("UTF-8", "ISO-8859-1");
+    }
+
+    public void bar(String... x) { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ArrayIndexOutOfBoundsException in rule UseStandardCharsetsRule.java:81 #6782</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package edu.hm.hafner.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ValidationUtilitiesTest {
+    @Test
+    void shouldContainDefaultCharsets() {
+        var allCharsets = getAllCharsets();
+        assertThat(allCharsets).isNotEmpty().contains("UTF-8", "ISO-8859-1");
+    }
+
+    private String getAllCharsets() {
+        return "UTF-8";
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The current code doesn't account for varargs when looking for methods with an almost-same signature. This PR fixes this.

## Related issues

- Fix #6782 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

