### PR TITLE
[apex] New rule: InvocableClassNoArgConstructor

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -33,8 +33,13 @@ This is a {{ site.pmd.release_type }} release.
 * The new Kotlin rule {% rule kotlin/bestpractices/LocalVariableShadowsParameter %} detects local variable
   declarations that use the same name as a parameter of the enclosing function. This shadows the parameter
   and may lead to confusion about which value is used.
+* The new Apex rule {% rule apex/errorprone/InvocableClassNoArgConstructor %} detects classes that use
+  `@InvocableVariable` properties, but that don't provide a no-arg constructor. Without such a constructor,
+  runtime exception occur when Salesforce Flow tries to instantiate such classes.
 
 ### 🐛️ Fixed Issues
+* apex-errorprone
+  * [#6793](https://github.com/pmd/pmd/issues/6793): \[apex] New Rule: Invocable Classes require a no argument constructor
 * apex-security
   * [#2955](https://github.com/pmd/pmd/issues/2955): \[apex] ApexSOQLInjection: False positive when passing local var with concatenating strings
   * [#3877](https://github.com/pmd/pmd/issues/3877): \[apex] ApexCRUDViolation: False positive with Lists of Objects with getSObjectType().getDescribe()

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorRule.java
@@ -1,0 +1,122 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import java.util.List;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.apex.ast.ASTField;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+
+/**
+ * Flags Apex classes that declare {@code @InvocableVariable} fields or properties but define
+ * at least one explicit constructor without also providing an accessible no-argument constructor.
+ *
+ * <p>Salesforce Flow instantiates invocable-variable classes via a zero-argument constructor.
+ * When a developer adds any explicit constructor, Apex no longer synthesises a default
+ * one, so Flow cannot create an instance and throws a runtime error. Global classes additionally
+ * require the no-arg constructor to be {@code global} so that it is accessible from managed
+ * packages.
+ */
+public class InvocableClassNoArgConstructorRule extends AbstractApexRule {
+
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTUserClass.class);
+    }
+
+    /**
+     * Checks whether the visited class contains {@code @InvocableVariable} members and, if so,
+     * whether every explicit constructor is accompanied by an accessible no-argument constructor.
+     *
+     * @param node the class node being visited
+     * @param data the rule context data
+     * @return the (unchanged) rule context data
+     */
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+        if (!hasInvocableVariable(node)) {
+            return data;
+        }
+
+        List<ASTMethod> methods = node.descendants(ASTMethod.class).toList();
+        boolean hasCustomConstructors = false;
+        boolean hasValidNoArgConstructor = false;
+
+        boolean isClassGlobal = isGlobal(node.firstChild(ASTModifierNode.class));
+
+        for (ASTMethod method : methods) {
+            if (method.isConstructor()) {
+                hasCustomConstructors = true;
+
+                if (method.getArity() == 0) {
+                    ASTModifierNode constructorModifiers = method.firstChild(ASTModifierNode.class);
+
+                    if (isClassGlobal) {
+                        // Global classes require a global no-arg constructor for cross-package Flows
+                        if (isGlobal(constructorModifiers)) {
+                            hasValidNoArgConstructor = true;
+                            break;
+                        }
+                    } else {
+                        if (!isPrivate(constructorModifiers)) {
+                            hasValidNoArgConstructor = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (hasCustomConstructors && !hasValidNoArgConstructor) {
+            asCtx(data).addViolation(node, node.getImage());
+        }
+
+        return data;
+    }
+
+    private boolean hasInvocableVariable(ASTUserClass classNode) {
+        for (ASTField field : classNode.descendants(ASTField.class).toList()) {
+            if (hasInvocableAnnotation(field.getModifiers())) {
+                return true;
+            }
+        }
+
+        for (ASTProperty property : classNode.descendants(ASTProperty.class).toList()) {
+            if (hasInvocableAnnotation(property.getModifiers())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean hasInvocableAnnotation(ASTModifierNode modifiers) {
+        if (modifiers == null) {
+            return false;
+        }
+        for (ASTAnnotation annotation : modifiers.children(ASTAnnotation.class)) {
+            if ("InvocableVariable".equalsIgnoreCase(annotation.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isGlobal(ASTModifierNode modifiers) {
+        return modifiers != null && modifiers.isGlobal();
+    }
+
+    private boolean isPrivate(ASTModifierNode modifiers) {
+        return modifiers != null && modifiers.isPrivate();
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorRule.java
@@ -26,6 +26,8 @@ import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
  * one, so Flow cannot create an instance and throws a runtime error. Global classes additionally
  * require the no-arg constructor to be {@code global} so that it is accessible from managed
  * packages.
+ *
+ * @since 7.26.0
  */
 public class InvocableClassNoArgConstructorRule extends AbstractApexRule {
 
@@ -48,30 +50,28 @@ public class InvocableClassNoArgConstructorRule extends AbstractApexRule {
             return data;
         }
 
-        List<ASTMethod> methods = node.descendants(ASTMethod.class).toList();
-        boolean hasCustomConstructors = false;
+        List<ASTMethod> ctors = node.descendants(ASTMethod.class)
+                .filter(ASTMethod::isConstructor)
+                .toList();
+        boolean hasCustomConstructors = !ctors.isEmpty();
         boolean hasValidNoArgConstructor = false;
 
         boolean isClassGlobal = isGlobal(node.firstChild(ASTModifierNode.class));
 
-        for (ASTMethod method : methods) {
-            if (method.isConstructor()) {
-                hasCustomConstructors = true;
+        for (ASTMethod constructor : ctors) {
+            if (constructor.getArity() == 0) {
+                ASTModifierNode constructorModifiers = constructor.firstChild(ASTModifierNode.class);
 
-                if (method.getArity() == 0) {
-                    ASTModifierNode constructorModifiers = method.firstChild(ASTModifierNode.class);
-
-                    if (isClassGlobal) {
-                        // Global classes require a global no-arg constructor for cross-package Flows
-                        if (isGlobal(constructorModifiers)) {
-                            hasValidNoArgConstructor = true;
-                            break;
-                        }
-                    } else {
-                        if (!isPrivate(constructorModifiers)) {
-                            hasValidNoArgConstructor = true;
-                            break;
-                        }
+                if (isClassGlobal) {
+                    // Global classes require a global no-arg constructor for cross-package Flows
+                    if (isGlobal(constructorModifiers)) {
+                        hasValidNoArgConstructor = true;
+                        break;
+                    }
+                } else {
+                    if (!isPrivate(constructorModifiers)) {
+                        hasValidNoArgConstructor = true;
+                        break;
                     }
                 }
             }
@@ -85,13 +85,13 @@ public class InvocableClassNoArgConstructorRule extends AbstractApexRule {
     }
 
     private boolean hasInvocableVariable(ASTUserClass classNode) {
-        for (ASTField field : classNode.descendants(ASTField.class).toList()) {
+        for (ASTField field : classNode.descendants(ASTField.class)) {
             if (hasInvocableAnnotation(field.getModifiers())) {
                 return true;
             }
         }
 
-        for (ASTProperty property : classNode.descendants(ASTProperty.class).toList()) {
+        for (ASTProperty property : classNode.descendants(ASTProperty.class)) {
             if (hasInvocableAnnotation(property.getModifiers())) {
                 return true;
             }

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -539,7 +539,36 @@ public class Foo {
 ]]>
     </example>
   </rule>
-  
+
+    <rule name="InvocableClassNoArgConstructor"
+          language="apex"
+          since="7.26.0"
+          message="Class ''{0}'' defines @InvocableVariable fields but has no accessible no-argument constructor."
+          class="net.sourceforge.pmd.lang.apex.rule.errorprone.InvocableClassNoArgConstructorRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#invocableclassnoargconstructor">
+        <description>
+            Apex classes containing @InvocableVariable properties used for flow parameters must expose a visible, zero-argument constructor
+            to prevent runtime instantiation errors under modern Salesforce API versions.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+// BAD: Explicit constructor eliminates default constructor, leaving no zero-arg constructor
+public class FlowInput {
+    @InvocableVariable public String recordId;
+    public FlowInput(String recordId) { this.recordId = recordId; }
+}
+
+// GOOD: Explicit zero-arg constructor alongside customized signature
+public class FlowInput {
+    @InvocableVariable public String recordId;
+    public FlowInput() {}
+    public FlowInput(String recordId) { this.recordId = recordId; }
+}
+]]>
+        </example>
+    </rule>
+
   <rule name="MethodWithSameNameAsEnclosingClass"
         language="apex"
         since="5.5.0"
@@ -693,35 +722,6 @@ public class Database {
     public static String query() {
         return 'Hello World';
     }
-}
-]]>
-        </example>
-    </rule>
-
-    <rule name="InvocableClassNoArgConstructor"
-          language="apex"
-          since="7.26.0"
-          message="Class ''{0}'' defines @InvocableVariable fields but has no accessible no-argument constructor."
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.InvocableClassNoArgConstructorRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#invocableclassnoargconstructor">
-        <description>
-            Apex classes containing @InvocableVariable properties used for flow parameters must expose a visible, zero-argument constructor
-            to prevent runtime instantiation errors under modern Salesforce API versions.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
-// BAD: Explicit constructor eliminates default constructor, leaving no zero-arg constructor
-public class FlowInput {
-    @InvocableVariable public String recordId;
-    public FlowInput(String recordId) { this.recordId = recordId; }
-}
-
-// GOOD: Explicit zero-arg constructor alongside customized signature
-public class FlowInput {
-    @InvocableVariable public String recordId;
-    public FlowInput() {}
-    public FlowInput(String recordId) { this.recordId = recordId; }
 }
 ]]>
         </example>

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -697,4 +697,34 @@ public class Database {
 ]]>
         </example>
     </rule>
+
+    <rule name="InvocableClassNoArgConstructor"
+          language="apex"
+          since="7.26.0"
+          message="Class ''{0}'' defines @InvocableVariable fields but has no accessible no-argument constructor."
+          class="net.sourceforge.pmd.lang.apex.rule.errorprone.InvocableClassNoArgConstructorRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#invocableclassnoargconstructor">
+        <description>
+            Apex classes containing @InvocableVariable properties used for flow parameters must expose a visible, zero-argument constructor
+            to prevent runtime instantiation errors under modern Salesforce API versions.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+// BAD: Explicit constructor eliminates default constructor, leaving no zero-arg constructor
+public class FlowInput {
+    @InvocableVariable public String recordId;
+    public FlowInput(String recordId) { this.recordId = recordId; }
+}
+
+// GOOD: Explicit zero-arg constructor alongside customized signature
+public class FlowInput {
+    @InvocableVariable public String recordId;
+    public FlowInput() {}
+    public FlowInput(String recordId) { this.recordId = recordId; }
+}
+]]>
+        </example>
+    </rule>
+
 </ruleset>

--- a/pmd-apex/src/main/resources/rulesets/apex/quickstart.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/quickstart.xml
@@ -197,5 +197,6 @@
    <!-- <rule ref="category/apex/errorprone.xml/AvoidStatefulDatabaseResult" /> -->
    <!-- <rule ref="category/apex/errorprone.xml/TypeShadowsBuiltInNamespace" /> -->
    <!-- <rule ref="category/apex/errorprone.xml/AvoidInterfaceAsMapKey" /> -->
+   <!-- <rule ref="category/apex/errorprone.xml/InvocableClassNoArgConstructor"/> -->
 
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InvocableClassNoArgConstructorTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class InvocableClassNoArgConstructorTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InvocableClassNoArgConstructor.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InvocableClassNoArgConstructor.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.github.io/schema/rule-tests_1_1_0.xsd">
+
+    <test-code>
+        <description>Failure: Class with @InvocableVariable and only a parameterized constructor</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        public class FlowInput {
+            @InvocableVariable
+            public String recordId;
+
+            public FlowInput(String recordId) {
+                this.recordId = recordId;
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Pass: Class with @InvocableVariable using implicit default constructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        public class FlowInput {
+            @InvocableVariable
+            public String recordId;
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Pass: Class with @InvocableVariable and explicit no-arg constructor alongside parameterized constructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        public class FlowInput {
+            @InvocableVariable
+            public String recordId;
+
+            public FlowInput() {}
+
+            public FlowInput(String recordId) {
+                this.recordId = recordId;
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Failure: Class with global @InvocableVariable but private no-arg constructor</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        global class FlowInput {
+            @InvocableVariable
+            global String recordId;
+
+            private FlowInput() {}
+
+            public FlowInput(String recordId) {
+                this.recordId = recordId;
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Pass: Normal class with a parameterized constructor but no @InvocableVariable annotations</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        public class RegularClass {
+            public String name;
+            public RegularClass(String name) {
+                this.name = name;
+            }
+        }
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
Detects Apex classes that declare @InvocableVariable fields or properties but define at least one explicit constructor without also providing an accessible no-argument constructor. Salesforce Flow instantiates these classes via a zero-arg constructor; without one, Flow throws a runtime error. Global classes additionally require the no-arg constructor to be global for cross-package Flow access.

Summer '26 Release Note: [Provide Visible No-Argument Constructors for Custom Apex Classes Used as Invocable Action Parameters](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_constructor_visibility_invocable_custom_classes_v66.htm&release=262&type=5)

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

Adds a new Apex rule `InvocableClassNoArgConstructor` in the `errorprone` category.

Detects Apex classes that declare `@InvocableVariable` fields or properties but define at least one explicit constructor without also providing an accessible no-argument constructor. Salesforce Flow instantiates these classes via a zero-arg constructor; without one, Flow throws a runtime error. Global classes additionally require the no-arg constructor to be `global` for cross-package Flow access.


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6793

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

