### PR TITLE
[java] Fix #6460: Fix false negative for overridden methods in PublicMemberInNonPublicType

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,8 @@ This is a {{ site.pmd.release_type }} release.
 * java-codestyle
   * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral
   * [#6775](https://github.com/pmd/pmd/issues/6775): \[java] UselessParentheses: False negative when on the right-hand side of an assignment statement
+* java-design
+  * [#6460](https://github.com/pmd/pmd/issues/6460): \[java] PublicMemberInNonPublicType: False negative for overridden methods
 * java-errorprone
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
   * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PublicMemberInNonPublicTypeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PublicMemberInNonPublicTypeRule.java
@@ -1,0 +1,126 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design;
+
+import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PUBLIC;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTCompactConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * @since 7.21.0 (as XPath) / 7.26.0 (as Java)
+ */
+public class PublicMemberInNonPublicTypeRule extends AbstractJavaRulechainRule {
+
+    public PublicMemberInNonPublicTypeRule() {
+        super(ASTMethodDeclaration.class,
+                ASTConstructorDeclaration.class,
+                ASTCompactConstructorDeclaration.class,
+                ASTFieldDeclaration.class,
+                ASTClassDeclaration.class,
+                ASTEnumDeclaration.class,
+                ASTAnnotationTypeDeclaration.class
+        );
+    }
+
+    @Override
+    public Object visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getName());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTConstructorDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getName());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTCompactConstructorDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getEnclosingType().getSimpleName());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTFieldDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            for (ASTVariableId varId : node.getVarIds()) {
+                ctx.addViolation(varId, varId.getName());
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTClassDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getSimpleName());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTEnumDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getSimpleName());
+        }
+
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (isViolation(node)) {
+            ctx.addViolation(node, node.getSimpleName());
+        }
+
+        return null;
+    }
+
+    private boolean isViolation(ASTMethodDeclaration node) {
+        return isViolation((ModifierOwner) node)
+                && !node.isOverridden();
+    }
+
+    private boolean isViolation(ModifierOwner node) {
+        return node.getEffectiveVisibility() != V_PUBLIC && node.getVisibility() == V_PUBLIC
+                && !(node.ancestors(ASTTypeDeclaration.class).first().isInterface());
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PublicMemberInNonPublicTypeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PublicMemberInNonPublicTypeRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static java.lang.reflect.Modifier.isPublic;
 import static net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility.V_PUBLIC;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
@@ -116,11 +117,13 @@ public class PublicMemberInNonPublicTypeRule extends AbstractJavaRulechainRule {
 
     private boolean isViolation(ASTMethodDeclaration node) {
         return isViolation((ModifierOwner) node)
-                && !node.isOverridden();
+                // special case: if a method is overriding another method we only report
+                // if we're allowed to reduce the visibility.
+                && (!node.isOverridden() || !isPublic(node.getOverriddenMethod().getModifiers()));
     }
 
     private boolean isViolation(ModifierOwner node) {
         return node.getEffectiveVisibility() != V_PUBLIC && node.getVisibility() == V_PUBLIC
-                && !(node.ancestors(ASTTypeDeclaration.class).first().isInterface());
+                && !node.ancestors(ASTTypeDeclaration.class).first().isInterface();
     }
 }

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1062,7 +1062,7 @@ public class Foo {
           language="java"
           since="7.21.0"
           message="Public member ''{0}'' declared in a non-public type"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.design.PublicMemberInNonPublicTypeRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#publicmemberinnonpublictype">
         <description>
 A non-public type should not declare its own members as public, as their visibility is effectively limited
@@ -1079,21 +1079,6 @@ methods of the supertype. Converting these methods to private removes them from 
 can inadvertently change the subtype's public API.
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value><![CDATA[
-//(MethodDeclaration|ConstructorDeclaration|CompactConstructorDeclaration|
-   FieldDeclaration|
-   ClassDeclaration|EnumDeclaration|AnnotationTypeDeclaration)
-  [@EffectiveVisibility != 'public']
-  [@Visibility = 'public']
-  [@Overridden = false() or not(@Overridden)]
-  [not(ancestor::ClassDeclaration[@Interface = true()] or ancestor::AnnotationTypeDeclaration)]
-(: Make sure, we return nodes that implement getName() for {0} in the rule message :)
-!(if (self::FieldDeclaration) then VariableDeclarator else .)
-]]></value>
-            </property>
-        </properties>
         <example><![CDATA[
 class Wrong {
     public void method() {} // violation

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
@@ -81,7 +81,7 @@ class Wrong {
 
     public int
     field // <--violation: line 7
-    ;
+    = 0;
 
     public int
     iField1, // <--violation: line 11

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
@@ -189,7 +189,7 @@ class Child extends Parent {
     </test-code>
 
     <test-code>
-        <description>Methods in interfaces are implicitely public, so methods implementing an interface need to be public, too</description>
+        <description>Methods in interfaces are implicitly public, so methods implementing an interface need to be public, too</description>
         <expected-problems>0</expected-problems>
         <code>
 public interface I {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
@@ -167,4 +167,43 @@ class Wrong {
 }
         </code>
     </test-code>
+
+    <test-code>
+        <description>Overriding a method from another class should only prevent a violation if the method from the parent class is public #6460</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>11-11</expected-linenumbers>
+        <code>
+public class Parent {
+    public void foo() { }
+    void bar() { }
+}
+
+class Child extends Parent {
+    @Override
+    public void foo() { }  // this has to be public, because an overriding method has to be at least as visible as the overridden one
+
+    @Override
+    public void bar() { }  // violation, because this can be default visibility
+}
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Methods in interfaces are implicitely public, so methods implementing an interface need to be public, too</description>
+        <expected-problems>0</expected-problems>
+        <code>
+public interface I {
+    public void foo() { }
+    void bar() { }
+}
+
+class Child extends Parent {
+    @Override
+    public void foo() { }  // this has to be public
+
+    @Override
+    public void bar() { }  // this has to be public, too
+}
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR...
* rewrites the XPath rule PublicMemberInNonPublicType in Java
* Changes how the rule treats methods overriding other methods
  * Old behavior: Overrides never trigger a violation
  * New behavior: Overrides only trigger a violation if the visibility can be reduced. If the overridden method is public, the overriding methods needs to be public too, so no violation is triggered.

## Related issues

- Fix #6460

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

