### PR TITLE
[java] Fix #6781: False positive in UselessPureMethodCall with unresolved types

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -61,6 +61,7 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
@@ -458,7 +459,11 @@ public final class JavaRuleUtil {
     public static boolean isKnownPure(ASTMethodCall call) {
         return isGetterCall(call)
                     && isPureGetter(call)
-            || KNOWN_PURE_METHODS.anyMatch(call) && !call.getMethodType().getReturnType().isVoid();
+            || KNOWN_PURE_METHODS.anyMatch(call) && isNotVoid(call.getMethodType().getReturnType());
+    }
+
+    private static boolean isNotVoid(JTypeMirror returnType) {
+        return !returnType.isVoid() && returnType != returnType.getTypeSystem().UNKNOWN;
     }
 
     private static boolean isPureGetter(ASTMethodCall call) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
@@ -482,4 +482,22 @@ public class a {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UselessPureMethodCall false negative for unresolved type #6781</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Tester {
+    void triggersUselessPureMethodCall(List<Object> source) {
+        var varResult = source.stream()
+            .collect(Collectors.toCollection(ArrayList::new));
+        source.stream().forEach(varResult::add);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR adds defensive code to the pure method call rule so that cases where argument type cannot be resolved are not reported.

## Related issues

- Fix #6781

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

