### PR TITLE
[chore] git-commit-id-maven-plugin: Use native git

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -45,6 +45,7 @@
                         <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
                         <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
                     </includeOnlyProperties>
+                    <useNativeGit>true</useNativeGit>  <!-- for worktree support. See https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 -->
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Describe the PR

Recently, I've been experimenting with [git worktree](https://dev.to/metal3d/git-worktree-like-a-boss-2j1b)s. Unfortunately, [git-commit-id-maven-plugin still uses jgit-6, worktrees are only supported in jgit-7](https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215). The workaround is to configure git-commit-id-maven-plugin to not use jgit, but the native implementation.

For every new worktree, I have to add this line. Would be nice if we could add this globally.

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

