### PR TITLE
[java] Fix #6459: special case main in PublicMemberInNonPublicType

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -53,6 +53,8 @@ This is a {{ site.pmd.release_type }} release.
 * java-codestyle
   * [#6239](https://github.com/pmd/pmd/issues/6239): \[java] UseDiamondOperator: False positive with Guice TypeLiteral
   * [#6775](https://github.com/pmd/pmd/issues/6775): \[java] UselessParentheses: False negative when on the right-hand side of an assignment statement
+* java-design
+  * [#6459](https://github.com/pmd/pmd/issues/6459): \[java] PublicMemberInNonPublicType: False positive for main(...) methods
 * java-errorprone
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
   * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1088,6 +1088,7 @@ can inadvertently change the subtype's public API.
   [@EffectiveVisibility != 'public']
   [@Visibility = 'public']
   [@Overridden = false() or not(@Overridden)]
+  [@MainMethod = false() or not(@MainMethod)]
   [not(ancestor::ClassDeclaration[@Interface = true()] or ancestor::AnnotationTypeDeclaration)]
 (: Make sure, we return nodes that implement getName() for {0} in the rule message :)
 !(if (self::FieldDeclaration) then VariableDeclarator else .)

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PublicMemberInNonPublicType.xml
@@ -167,4 +167,16 @@ class Wrong {
 }
         </code>
     </test-code>
+
+    <test-code>
+        <description>Special case main() (#6459)</description>
+        <expected-problems>0</expected-problems>
+        <code>
+class MyTest {
+    public static void main(final String... args)  {
+        // main method that is invoked in IntelliJ
+    }
+}
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR removes the violation for main().

For simplicity, I didn't add version logic. Strictly speaking, this should be a violation in Java >= 25. But main() is special in any case, so I can see why people would want to keep main public, even in Java >= 25.

## Related issues

- Fix #6459

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

