### PR TITLE
[java] #4960: Add regression test for UnusedAssignment

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -4044,4 +4044,34 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] Regression with UnusedAssignment #4960</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TreeNode {
+    private Map<String, TreeNode> childrenMap = new HashMap<>();
+
+    public Map<String, TreeNode> getChildrenMap() {
+        return childrenMap;
+    }
+
+    public List<TreeNode> getChildren() {
+        return new ArrayList<>(childrenMap.values());
+    }
+
+    public void collapsePackage() {
+        while (getChildren().size() == 1) {
+            TreeNode singleChild = getChildrenMap().values().iterator().next();
+            childrenMap = singleChild.getChildrenMap();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

#4960 was fixed with #4435. This PR adds a regression test for that.

## Related issues

- Closes #4960

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

