### PR TITLE
[apex] Fix #6806: Upgrade vf-parser to 2.0.0-beta.1

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,6 +38,8 @@ This is a {{ site.pmd.release_type }} release.
   and may lead to confusion about which value is used.
 
 ### 🐛️ Fixed Issues
+* apex
+  * [#6806](https://github.com/pmd/pmd/issues/6806): \[apex] ANTLR runtime mismatch 4.9.1 used for code generation does not match the current runtime version 4.13.2
 * apex-security
   * [#2955](https://github.com/pmd/pmd/issues/2955): \[apex] ApexSOQLInjection: False positive when passing local var with concatenating strings
   * [#3877](https://github.com/pmd/pmd/issues/3877): \[apex] ApexCRUDViolation: False positive with Lists of Objects with getSObjectType().getDescribe()

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>apex-ls_2.13</artifactId>
             <version>6.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.apex-dev-tools</groupId>
+            <artifactId>vf-parser</artifactId>
+            <version>2.0.0-beta.1</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/SomePage.page
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/SomePage.page
@@ -1,0 +1,5 @@
+<apex:page>
+The contents of this page aren't relevant to the test, but the test requires the file to be present.
+This causes apex-link to parse this file via vf-parser. This detects issues like https://github.com/pmd/pmd/issues/6806
+when the ANTLR runtime doesn't match the compile-time version of vf-parser.
+</apex:page>


### PR DESCRIPTION
## Describe the PR

Also adds a simple test, so that we see such dependency issues earlier. There just has to exist some Visualforce Page in the project, then apex-link tries to parse it...


## Related issues

- Fix #6806 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

