### PR TITLE
[java] Fix #5011: Fix FP in TestClassWithoutTestCases when the only tests are in a superclass

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -69,7 +69,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#6460](https://github.com/pmd/pmd/issues/6460): \[java] PublicMemberInNonPublicType: False negative for overridden methods
 * java-errorprone
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
-  * [#5011](https://github.com/pmd/pmd/issues/5011): \[java] TestClassWithoutTestCases - false-positive for test classes extending a class with tests (in nested classes)
+  * [#5011](https://github.com/pmd/pmd/issues/5011): \[java] TestClassWithoutTestCases: False positive for test classes extending a class with tests (in nested classes)
   * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null
   * [#6781](https://github.com/pmd/pmd/issues/6781): \[java] UselessPureMethodCall: False positive for Stream.forEach
 * kotlin

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -69,6 +69,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#6460](https://github.com/pmd/pmd/issues/6460): \[java] PublicMemberInNonPublicType: False negative for overridden methods
 * java-errorprone
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
+  * [#5011](https://github.com/pmd/pmd/issues/5011): \[java] TestClassWithoutTestCases - false-positive for test classes extending a class with tests (in nested classes)
   * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null
   * [#6781](https://github.com/pmd/pmd/issues/6781): \[java] UselessPureMethodCall: False positive for Stream.forEach
 * kotlin

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -4,18 +4,20 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.hasJUnit3Tests;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.hasJUnit4Tests;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.hasJUnit5Tests;
+import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.hasTestNGTests;
 import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit3Class;
 import static net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil.isJUnit5NestedClass;
 
 import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
-import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class TestClassWithoutTestCasesRule extends AbstractJavaRulechainRule {
 
@@ -32,17 +34,22 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTClassDeclaration node, Object data) {
-        if (isJUnit3Class(node) || isJUnit5NestedClass(node) || isTestClassByPattern(node)) {
-            boolean hasTests =
-                node.getDeclarations(ASTMethodDeclaration.class)
-                    .any(TestFrameworksUtil::isTestMethod);
-            boolean hasNestedTestClasses = node.getDeclarations(ASTTypeDeclaration.class)
-                    .any(TestFrameworksUtil::isJUnit5NestedClass);
+        RuleContext ctx = (RuleContext) data;
 
-            if (!hasTests && !hasNestedTestClasses) {
-                asCtx(data).addViolation(node, node.getSimpleName());
+        if (isJUnit3Class(node)) {
+            if (!hasJUnit3Tests(node)) {
+                ctx.addViolation(node, node.getSimpleName());
+            }
+        } else if (isJUnit5NestedClass(node)) {
+            if (!hasJUnit5Tests(node)) {
+                ctx.addViolation(node, node.getSimpleName());
+            }
+        } else if (isTestClassByPattern(node)) {
+            if (!(hasJUnit4Tests(node) || hasJUnit5Tests(node) || hasTestNGTests(node))) {
+                ctx.addViolation(node, node.getSimpleName());
             }
         }
+
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -240,6 +240,10 @@ public final class TestFrameworksUtil {
             && TypeTestUtil.isA(JUNIT3_CLASS_NAME, node);
     }
 
+    public static boolean hasJUnit3Tests(ASTTypeDeclaration node) {
+        return node.getDeclarations(ASTMethodDeclaration.class).any(TestFrameworksUtil::isJunit3MethodSignature);
+    }
+
     public static boolean isTestClass(ASTClassDeclaration node) {
         return isJUnit3Class(node) || isJUnit4Class(node) || isJUnit5Class(node) || isTestNGClass(node);
     }
@@ -247,30 +251,53 @@ public final class TestFrameworksUtil {
     public static boolean isJUnit4Class(ASTClassDeclaration node) {
         JClassType typeMirror = node.getTypeMirror();
 
-        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
-                && typeMirror.streamMethods(TestFrameworksUtil::isJUnit4Method)
-                        .findAny().isPresent();
+        return isConcreteToplevelClass(typeMirror) && hasJUnit4Tests(typeMirror);
+    }
+
+    public static boolean hasJUnit4Tests(ASTTypeDeclaration node) {
+        return hasJUnit4Tests(node.getTypeMirror());
+    }
+
+    private static boolean hasJUnit4Tests(JClassType typeMirror) {
+        return typeMirror.streamMethods(TestFrameworksUtil::isJUnit4Method)
+                .findAny().isPresent();
     }
 
     public static boolean isJUnit5Class(ASTClassDeclaration node) {
         JClassType typeMirror = node.getTypeMirror();
 
-        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
-                && (
-                        typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
-                                .findAny().isPresent()
-                        || typeMirror.streamClasses()
-                                .filter(c -> TestFrameworksUtil.isJUnit5NestedClass(c))
-                                .findAny().isPresent()
-                );
+        return isConcreteToplevelClass(typeMirror) && hasJUnit5Tests(typeMirror);
+    }
+
+    public static boolean hasJUnit5Tests(ASTTypeDeclaration node) {
+        return hasJUnit5Tests(node.getTypeMirror());
+    }
+
+    private static boolean hasJUnit5Tests(JClassType typeMirror) {
+        return typeMirror.streamMethods(TestFrameworksUtil::isJUnit5Method)
+                        .findAny().isPresent()
+                || typeMirror.streamClasses()
+                        .filter(TestFrameworksUtil::isJUnit5NestedClass)
+                        .findAny().isPresent();
     }
 
     public static boolean isTestNGClass(ASTClassDeclaration node) {
         JClassType typeMirror = node.getTypeMirror();
 
-        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null
-                && typeMirror.streamMethods(TestFrameworksUtil::isTestNgMethod)
-                        .findAny().isPresent();
+        return isConcreteToplevelClass(typeMirror) && hasTestNGTests(typeMirror);
+    }
+
+    public static boolean hasTestNGTests(ASTClassDeclaration node) {
+        return hasTestNGTests(node.getTypeMirror());
+    }
+
+    private static boolean hasTestNGTests(JClassType typeMirror) {
+        return typeMirror.streamMethods(TestFrameworksUtil::isTestNgMethod)
+                .findAny().isPresent();
+    }
+
+    private static boolean isConcreteToplevelClass(JClassType typeMirror) {
+        return !typeMirror.isInterface() && !typeMirror.getSymbol().isAbstract() && typeMirror.getEnclosingType() == null;
     }
 
     public static boolean isJUnit5NestedClass(ASTTypeDeclaration innerClassDecl) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -19,6 +19,17 @@ public class FooTest extends TestCase {
     </test-code>
 
     <test-code>
+        <description>JUnit3: valid case</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class FooTest extends TestCase {
+    public void testX(){}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>JUnit3: test method should be public</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
@@ -197,7 +208,7 @@ final class SampleTest extends Object {
         Assertions.assertTrue(num > 0);
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -211,7 +222,7 @@ final class SampleTest {
     void doesTest() {
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -220,7 +231,7 @@ final class SampleTest {
         <expected-linenumbers>1</expected-linenumbers>
         <code><![CDATA[
 class SampleTest { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -231,7 +242,7 @@ class SampleTest { }
         <code><![CDATA[
 package my.pkg;
 class MyEmptyCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -249,7 +260,7 @@ class MyEmptyCase {
     class MyNestedCase { }
     class OtherNestedClass { }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -259,7 +270,7 @@ class MyEmptyCase {
         <code><![CDATA[
 package my.other.pkg;
 class MyEmptyCase { }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -270,7 +281,7 @@ public class SampleTest {
     @org.testng.annotations.Test
     public void runAssertions() {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -282,7 +293,7 @@ public class SampleTest {
     @Test
     public void runAssertions() {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -302,7 +313,7 @@ class DemoNestedTests {
         }
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -324,7 +335,7 @@ class DemoNestedTests {
         // missing tests
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -341,7 +352,7 @@ class SampleTest {
 
     private static class Other {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -360,7 +371,7 @@ public final class TestInputConfiguration {
     public static final class InnerTest {
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -374,7 +385,7 @@ public class MyTests {
 
     static class Config {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -388,7 +399,7 @@ public class MyTests {
 
     static class Config {}
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -399,7 +410,7 @@ public class MyTests {
 class
 FooTest // <--violation: line 2
 {}
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -415,7 +426,7 @@ class FooTest extends net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortest
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class FooTest extends net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.JUnit4ParentWithTest {}
-]]></code>
+        ]]></code>
     </test-code>
     
     <test-code>
@@ -437,7 +448,7 @@ class TimeProfilerTests {
         void testFoo() {}
     }
 }
-]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -401,4 +401,52 @@ FooTest // <--violation: line 2
 {}
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>JUnit5: Tests are in superclass</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class FooTest extends net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.Junit5ParentWithTest {}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit4: Tests are in superclass</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class FooTest extends net.sourceforge.pmd.lang.java.rule.errorprone.rulesfortests.JUnit4ParentWithTest {}
+]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>#5011: FP in nested classes (superclass has tests)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.*;
+
+public class SpeedProfilerTests extends TimeProfilerTests {
+	@Nested
+	class operations extends TimeProfilerTests.operations {}
+}
+
+class TimeProfilerTests {
+    @Test
+    void testBar() {}
+    class operations {
+        @Test
+        void testFoo() {}
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Just because a methods name starts with "test", doesn't mean it is a test (in all frameworks but JUnit 3)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class FooTest {
+    public void testX(){}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

* Split TestFrameworksUtil.isXXXClass into hasXXXTests and isConcreteToplevelClass
* These methods automatically supports superclasses because of the work done in previous PRs (https://github.com/pmd/pmd/pull/6604, https://github.com/pmd/pmd/pull/6680, https://github.com/pmd/pmd/pull/6689, https://github.com/pmd/pmd/pull/6735, https://github.com/pmd/pmd/pull/6738)
* Use these methods in TestClassWithoutTestCasesRule

## Related issues

- Fix #5011

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

