### PR TITLE
[java] Fix #4623: CloseResource: False positive with resource being closed in method

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -75,6 +75,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
 * java-errorprone
+    * [#4623](https://github.com/pmd/pmd/issues/4623): \[java] CloseResource: False positive with resource being closed in method
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -732,8 +732,22 @@ public class CloseResourceRule extends AbstractJavaRule {
             if (isMethodCallClosingResourceVariable(call, variableToClose)) {
                 return true;
             }
+
+            if (variableIsPassedToMethod(variableToClose, call)) {
+                ASTBlock methodBody = call.getRoot().descendants(ASTMethodDeclaration.class)
+                        .filter(m -> m.getSymbol().equals(call.getMethodType().getSymbol()))
+                        .map(ASTMethodDeclaration::getBody)
+                        .first();
+                if (methodBody != null && methodBodyContainsClosingCall(methodBody)) {
+                    return true;
+                }
+            }
         }
         return false;
+    }
+
+    private boolean methodBodyContainsClosingCall(ASTBlock methodBody) {
+        return methodBody.descendants(ASTMethodCall.class).any(this::isCloseTargetMethodCall);
     }
 
     private boolean isMethodCallClosingResourceVariable(ASTExpression expr, ASTVariableId variableToClose) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -12,11 +12,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
@@ -32,6 +34,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -729,25 +733,41 @@ public class CloseResourceRule extends AbstractJavaRule {
     private boolean hasMethodCallClosingResourceVariable(ASTBlock block, ASTVariableId variableToClose) {
         List<ASTMethodCall> methodCalls = block.descendants(ASTMethodCall.class).crossFindBoundaries().toList();
         for (ASTMethodCall call : methodCalls) {
-            if (isMethodCallClosingResourceVariable(call, variableToClose)) {
+            if (isMethodCallClosingResourceVariable(call, variableToClose)
+                    || isClosedByCallee(call, variableToClose)) {
                 return true;
-            }
-
-            if (variableIsPassedToMethod(variableToClose, call)) {
-                ASTBlock methodBody = call.getRoot().descendants(ASTMethodDeclaration.class)
-                        .filter(m -> m.getSymbol().equals(call.getMethodType().getSymbol()))
-                        .map(ASTMethodDeclaration::getBody)
-                        .first();
-                if (methodBody != null && methodBodyContainsClosingCall(methodBody)) {
-                    return true;
-                }
             }
         }
         return false;
     }
 
-    private boolean methodBodyContainsClosingCall(ASTBlock methodBody) {
-        return methodBody.descendants(ASTMethodCall.class).any(this::isCloseTargetMethodCall);
+    private boolean isClosedByCallee(ASTMethodCall call, ASTVariableId variableToClose) {
+        ASTExpression argument = call.getArguments().toStream()
+                .filter(arg -> JavaAstUtils.isReferenceToVar(arg, variableToClose.getSymbol()))
+                .first();
+        // the resource is only closed if the callee closes the exact parameter it was passed as
+        ASTVariableId param = argument == null ? null : calleeParameters(call).get(argument.getIndexInParent());
+        return param != null && param.getLocalUsages().stream()
+                .anyMatch(usage -> usage.getParent() instanceof ASTMethodCall
+                        && isCloseTargetMethodCall((ASTMethodCall) usage.getParent()));
+    }
+
+    private NodeStream<ASTVariableId> calleeParameters(ASTMethodCall call) {
+        JavaNode method = call.getMethodType().getSymbol().tryGetNode();
+        if (method instanceof ASTMethodDeclaration) {
+            return ((ASTMethodDeclaration) method).getFormalParameters().toStream().map(ASTFormalParameter::getVarId);
+        }
+
+        Optional<JVariableSymbol> lambdaCallCandidate = Optional.ofNullable(call.getQualifier() instanceof ASTVariableAccess
+                ? ((ASTVariableAccess) call.getQualifier()).getReferencedSym() : null);
+
+        return lambdaCallCandidate.map(JVariableSymbol::tryGetNode)
+                .map(this::initializerOrFirstAssignedValueOf)
+                .filter(ASTLambdaExpression.class::isInstance)
+                .map(ASTLambdaExpression.class::cast)
+                .map(ASTLambdaExpression::getParameters)
+                .map(params -> params.toStream().map(ASTLambdaParameter::getVarId))
+                .orElse(NodeStream.empty());
     }
 
     private boolean isMethodCallClosingResourceVariable(ASTExpression expr, ASTVariableId variableToClose) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2331,6 +2331,31 @@ public class CastNullAfter {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#4623 [java] CloseResource: False positive with resource being closed in method</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+
+    void closeConnection(Connection c) {
+        c.close();
+    }
+
+    void bar(Pool pool) {
+        Connection c = pool.getConnection();
+        try {
+        } catch (Exception e) {
+        } finally {
+            // a lambda has the same effect
+            closeConnection(c);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 
 
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2349,8 +2349,81 @@ public class Foo {
         try {
         } catch (Exception e) {
         } finally {
-            // a lambda has the same effect
             closeConnection(c);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#4623 [java] CloseResource: the called method closes another resource, not the one passed to it</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>11</expected-linenumbers>
+        <code><![CDATA[
+import java.sql.Connection;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+
+    void closeSecondArg(Connection c, Connection other) {
+        other.close();
+    }
+
+    void bar(Pool pool, Connection other) {
+        Connection c = pool.getConnection();
+        try {
+        } catch (Exception e) {
+        } finally {
+            closeSecondArg(c, other);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#4623 [java] CloseResource: False positive with resource being closed in a method of a nested class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+
+    static class Helper {
+        void closeConnection(Connection c) {
+            c.close();
+        }
+    }
+
+    void bar(Pool pool) {
+        Connection c = pool.getConnection();
+        Helper helper = new Helper();
+        try {
+        } catch (Exception e) {
+        } finally {
+            helper.closeConnection(c);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#4623 [java] CloseResource: False positive with resource being closed in a lambda</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import java.util.function.Consumer;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+
+    void bar(Pool pool) {
+        Connection c = pool.getConnection();
+        Consumer<Connection> closeConnection = conn -> conn.close();
+        try {
+        } catch (Exception e) {
+        } finally {
+            closeConnection.accept(c);
         }
     }
 }


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4623

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

