### PR TITLE
[java] Fix #6740: Fix FP in OptimizableToArrayCall

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -71,6 +71,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#2846](https://github.com/pmd/pmd/issues/2846): \[java] New Rule: WrongTestAnnotation
   * [#6743](https://github.com/pmd/pmd/issues/6743): \[java] CloseResource: False positive for closeable initialized with (T) null
   * [#6781](https://github.com/pmd/pmd/issues/6781): \[java] UselessPureMethodCall: False positive for Stream.forEach
+* java-performance
+  * [#6740](https://github.com/pmd/pmd/issues/6740): \[java] OptimizableToArrayCall: False positive when new T\[0x0] is used instead of new T\[0]
 * kotlin
   * [#6677](https://github.com/pmd/pmd/issues/6677): \[kotlin] Add auxClasspath language property
 * kotlin-bestpractices

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -505,7 +505,7 @@ is faster, but returns only an array of type `Object[]`.
                 <value>
 <![CDATA[
 //MethodCall[pmd-java:matchesSig("java.util.Collection#toArray(_)")]
-    [ArgumentList/ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr[not(NumericLiteral[@Image="0"])]]
+    [ArgumentList/ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr[not(NumericLiteral[@ValueAsInt=0])]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -68,7 +68,7 @@ If you want to copy/move elements inside the _same_ array (e.g. shift the elemen
             <property name="xpath">
                 <value>
 <![CDATA[
-//(ForStatement[ForUpdate//(UnaryExpression[@Operator=('++','--')] | AssignmentExpression[@Operator = ('+=', '-=')][NumericLiteral[@Image = '1']])]
+//(ForStatement[ForUpdate//(UnaryExpression[@Operator=('++','--')] | AssignmentExpression[@Operator = ('+=', '-=')][NumericLiteral[@ValueAsInt = 1]])]
  | WhileStatement | DoStatement)
     [not(.//ContinueStatement)]
     [not(.//BreakStatement[not(parent::SwitchFallthroughBranch)])]
@@ -711,14 +711,14 @@ You must use `new ArrayList<>(Arrays.asList(...))` if that is inconvenient for y
   [ForInit
     [LocalVariableDeclaration
       [PrimitiveType[@Kind = 'int']]
-      [VariableDeclarator[NumericLiteral[@IntLiteral][@Image = '0']]]
+      [VariableDeclarator[NumericLiteral[@IntLiteral][@ValueAsInt = 0]]]
     ]
   ]
   [*[2]//FieldAccess[@Name = 'length']/VariableAccess[pmd-java:typeIs("java.lang.Object[]")]]
   [ForUpdate
     [StatementExpressionList
       [UnaryExpression[@Operator = '++']
-       | AssignmentExpression[@Operator = '+='][NumericLiteral[@IntLiteral][@Image = '1']]]
+       | AssignmentExpression[@Operator = '+='][NumericLiteral[@IntLiteral][@ValueAsInt = 1]]]
     ]
   ]
   /*[last()][not(IfStatement)]/ExpressionStatement/

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/OptimizableToArrayCall.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/OptimizableToArrayCall.xml
@@ -89,4 +89,21 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>FP: Alternative spellings of 0 (#6740)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+public class Foo {
+    {
+        List<Foo> x = new ArrayList<>();
+        x.toArray(new Foo[0x0]);
+        x.toArray(new Foo[00]);
+        x.toArray(new Foo[0_0]);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Use @<!-- -->ValueAsInt instead of @<!-- -->Image to get the value of the ASTNumericLiteral instead of the String representation.

## Related issues

- Fix #6740
- See #4787

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

