### PR TITLE
[java] Fix #6627: UnusedPrivateMethod: add javax to ignored annotations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -62,6 +62,7 @@ For the changes, see [PMD Designer Changelog (7.19.3)](https://github.com/pmd/pm
 * cli
   * [#6741](https://github.com/pmd/pmd/issues/6741): \[cli] Designer: Fix quotes in PMD_OPENJFX_MODULE_PATH setting
 * java-bestpractices
+  * [#6627](https://github.com/pmd/pmd/issues/6627): \[java] UnusedPrivateMethod: could not handle javax.annotation 
   * [#6692](https://github.com/pmd/pmd/issues/6692): \[java] ForLoopCanBeForeach: inconsistent detection between i += 1 and i = i + 1 update forms
   * [#6736](https://github.com/pmd/pmd/issues/6736): \[java] JUnitJupiterTestShouldBePackagePrivate: False negative when the only tests are in a @<!-- -->Nested class
   * [#6782](https://github.com/pmd/pmd/issues/6782): \[java] UseStandardCharsets: ArrayIndexOutOfBoundsException in line 81

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -42,6 +42,8 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             "java.lang.Deprecated",
             "jakarta.annotation.PostConstruct",
             "jakarta.annotation.PreDestroy",
+            "javax.annotation.PostConstruct",
+            "javax.annotation.PreDestroy",
             "lombok.EqualsAndHashCode.Include"
         );
     }
@@ -82,7 +84,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
     }
 
     private static void handleUnresolvedCall(MethodUsage ref, OverloadSelectionResult selectionInfo, Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
-        // If the type is may be an instance of this class, then the method may be
+        // If the type may be an instance of this class, then the method may be
         // a call to a private method here. In that case we whitelist all methods
         // with that name.
         JTypeMirror receive = selectionInfo.getTypeToSearch();

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -2799,4 +2799,18 @@ class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#6627 Ignore methods with javax.annotation.PostConstruct/PreDestroy</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+public class Foo {
+    @PostConstruct
+    private void bar() {}
+    @PreDestroy
+    private void baz() {}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Add `javax.annotations.PostConstruct` and `javax.annotations.PreDestroy` to the default list of annotations in `UnusedPrivateMethodRule` that cause a method to be ignored. The list already contains their newer versions in `jakarta.annotations`, there is no reason not to include the older version.

## Related issues

- Fix #6627

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

