### PR TITLE
[java] Fix #5670, #5514: ExhaustiveSwitchHasDefault when default is necessary

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,9 @@ This is a {{ site.pmd.release_type }} release.
   * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
   * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+* java-bestpractices
+  * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
+  * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
 * java-codestyle
   * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
 * java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
@@ -46,6 +46,7 @@ public interface ASTSwitchLike extends JavaNode, Iterable<ASTSwitchBranch> {
 
     /**
      * Returns the default branch if this switch has a {@code default} case, {@code null} if not.
+     * @since 7.27.0
      */
     default ASTSwitchBranch getDefaultCase() {
         return getBranches().first(it -> it.getLabel().isDefault());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLike.java
@@ -44,6 +44,13 @@ public interface ASTSwitchLike extends JavaNode, Iterable<ASTSwitchBranch> {
         return getBranches().any(it -> it.getLabel().isDefault());
     }
 
+    /**
+     * Returns the default branch if this switch has a {@code default} case, {@code null} if not.
+     */
+    default ASTSwitchBranch getDefaultCase() {
+        return getBranches().first(it -> it.getLabel().isDefault());
+    }
+
 
     /**
      * Returns a stream of all branches of this switch.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -42,14 +42,17 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
         if (node.isExhaustive() && node.hasDefaultCase()) {
             if (!defaultBranchIsNecessary(node)) {
                 ctx.addViolation(node);
-            } else if (!defaultBranchJustThrows(node.getDefaultCase())) {
+            } else if (!branchJustThrows(node.getDefaultCase())) {
                 ctx.addViolationWithMessage(node, "The switch block is exhaustive. The default case should only throw, nothing else.");
             }
         }
     }
 
+    /**
+     * returns true iff the only thing this branch does is throw an exception
+     */
     // visible for testing
-    /* private */ static boolean defaultBranchJustThrows(ASTSwitchBranch branch) {
+    /* private */ static boolean branchJustThrows(ASTSwitchBranch branch) {
         if (branch instanceof ASTSwitchFallthroughBranch) {
             ASTSwitchFallthroughBranch fallthroughBranch = (ASTSwitchFallthroughBranch) branch;
             return fallthroughBranch.getStatements().count() == 1
@@ -66,6 +69,10 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
         return false;
     }
 
+    /**
+     * returns true iff the default branch of this switch is necessary to make the code compile.
+     * This happens, if you initialize a final variable in your other branches.
+     */
     // visible for testing
     /* private */ static boolean defaultBranchIsNecessary(ASTSwitchLike switchLike) {
         return switchLike.descendants(ASTAssignableExpr.ASTNamedReferenceExpr.class)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
-import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
@@ -23,7 +22,7 @@ import net.sourceforge.pmd.reporting.RuleContext;
  */
 public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
     public ExhaustiveSwitchHasDefaultRule() {
-        super(ASTSwitchExpression.class, ASTStatement.class);
+        super(ASTSwitchExpression.class, ASTSwitchStatement.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -4,10 +4,15 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLike;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -33,7 +38,27 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
 
     private void visitSwitchLike(ASTSwitchLike node, RuleContext ctx) {
         if (node.isExhaustive() && node.hasDefaultCase()) {
-            ctx.addViolation(node);
+            if (!defaultBranchJustThrows(node.getDefaultCase())) {
+                ctx.addViolation(node);
+            }
         }
+    }
+
+    // visible for testing
+    /* private */ static boolean defaultBranchJustThrows(ASTSwitchBranch branch) {
+        if (branch instanceof ASTSwitchFallthroughBranch) {
+            ASTSwitchFallthroughBranch fallthroughBranch = (ASTSwitchFallthroughBranch) branch;
+            return fallthroughBranch.getStatements().count() == 1
+                    && fallthroughBranch.getStatements().first() instanceof ASTThrowStatement;
+        }
+        ASTSwitchArrowBranch arrowBranch = (ASTSwitchArrowBranch) branch;
+        if (arrowBranch.getRightHandSide() instanceof ASTThrowStatement) {
+            return true;
+        }
+        if (arrowBranch.getRightHandSide() instanceof ASTBlock) {
+            ASTBlock block = (ASTBlock) arrowBranch.getRightHandSide();
+            return block.size() == 1 && block.get(0) instanceof ASTThrowStatement;
+        }
+        return false;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -1,0 +1,39 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.java.ast.ASTStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLike;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * @since 7.10.0 (as XPath) / 7.27.0 (as Java)
+ */
+public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
+    public ExhaustiveSwitchHasDefaultRule() {
+        super(ASTSwitchExpression.class, ASTStatement.class);
+    }
+
+    @Override
+    public Object visit(ASTSwitchExpression node, Object data) {
+        visitSwitchLike(node, (RuleContext) data);
+        return null;
+    }
+
+    @Override
+    public Object visit(ASTSwitchStatement node, Object data) {
+        visitSwitchLike(node, (RuleContext) data);
+        return null;
+    }
+
+    private void visitSwitchLike(ASTSwitchLike node, RuleContext ctx) {
+        if (node.isExhaustive() && node.hasDefaultCase()) {
+            ctx.addViolation(node);
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
@@ -13,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLike;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -38,8 +40,10 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
 
     private void visitSwitchLike(ASTSwitchLike node, RuleContext ctx) {
         if (node.isExhaustive() && node.hasDefaultCase()) {
-            if (!defaultBranchJustThrows(node.getDefaultCase())) {
+            if (!defaultBranchIsNecessary(node)) {
                 ctx.addViolation(node);
+            } else if (!defaultBranchJustThrows(node.getDefaultCase())) {
+                ctx.addViolationWithMessage(node, "The switch block is exhaustive. The default case should only throw, nothing else.");
             }
         }
     }
@@ -60,5 +64,13 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
             return block.size() == 1 && block.get(0) instanceof ASTThrowStatement;
         }
         return false;
+    }
+
+    // visible for testing
+    /* private */ static boolean defaultBranchIsNecessary(ASTSwitchLike switchLike) {
+        return switchLike.descendants(ASTAssignableExpr.ASTNamedReferenceExpr.class)
+                .filter(expr -> expr.getReferencedSym() != null)
+                .filter(expr -> expr.getReferencedSym().isFinal())
+                .any(JavaAstUtils::isVarAccessStrictlyWrite);
     }
 }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -615,7 +615,7 @@ class ColorTester {
           language="java"
           since="7.10.0"
           message="The switch block is exhaustive even without the default case"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#exhaustiveswitchhasdefault">
         <description>
 When switching over an enum or sealed class, the compiler will ensure that all possible cases are covered.
@@ -634,15 +634,6 @@ notified, if someone adds a new enum constant and that new constant is not cover
 that previously was exhaustive but now is not anymore.
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-                    //(SwitchStatement | SwitchExpression)
-                      [@Exhaustive = true()]
-                      [@DefaultCase = true()]
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 class Foo {

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -627,6 +627,11 @@ new subclass to the sealed class hierarchy is added. We will discover this probl
 rather than at runtime (if at all).
 
 Note: The fix it not necessarily just removing the default case. Maybe a case is missing which needs to be implemented.
+
+Note 2: The compiler doesn't create a compilation error for a switch *statement* over an enum that is non-exhaustive.
+When enabling this rule, you should consider also enabling the rule {% rule NonExhaustiveSwitch %}, so that you are still
+notified, if someone adds a new enum constant and that new constant is not covered in an existing switch statement
+that previously was exhaustive but now is not anymore.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLikeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLikeTest.java
@@ -98,6 +98,67 @@ class ASTSwitchLikeTest extends BaseParserTest {
                 () -> assertSwitch(switchStatements.get("notExhaustiveEnum"), true, false, false),
                 () -> assertSwitch(switchStatements.get("notExhaustiveEnumWithDefault"), true, false, true)
         );
+
+        assertAll(
+                () -> assertDefaultCase(switchStatements.get("exhaustiveSealedWithDefault"), "unnecessary default"),
+                () -> assertDefaultCase(switchStatements.get("notExhaustiveSealedWithDefault"), "anything else"),
+                () -> assertDefaultCase(switchStatements.get("exhaustiveEnumWithDefault"), "unnecessary default"),
+                () -> assertDefaultCase(switchStatements.get("notExhaustiveEnumWithDefault"), "unnecessary default")
+        );
+    }
+
+    @Test
+    void exhaustiveClassicalSwitchSealedClassesAST() {
+        Map<String, ASTSwitchLike> switchStatements =
+                java.parse(
+                                "import net.sourceforge.pmd.lang.java.rule.bestpractices.switchstmtsshouldhavedefault.SimpleEnum;\n"
+                                        + "public sealed class Foo {\n"
+                                        + "    void exhaustiveEnum(SimpleEnum x) {\n"
+                                        + "        switch (x) {\n"
+                                        + "            case FOO: System.out.println(\"x is foo\"); break;\n"
+                                        + "            case BAR: System.out.println(\"x is bar\"); break;\n"
+                                        + "            case BZAZ: System.out.println(\" x is bzaz\"); break;\n"
+                                        + "        }\n"
+                                        + "    }\n"
+                                        + "    void exhaustiveEnumWithDefault(SimpleEnum x) {\n"
+                                        + "        switch (x) {\n"
+                                        + "            case FOO: System.out.println(\"x is foo\"); break;\n"
+                                        + "            case BAR: System.out.println(\"x is bar\"); break;\n"
+                                        + "            case BZAZ: System.out.println(\" x is bzaz\"); break;\n"
+                                        + "            default: System.out.println(\"unnecessary default\"); break;\n"
+                                        + "        }\n"
+                                        + "    }\n"
+                                        + "    void notExhaustiveEnum(SimpleEnum x) {\n"
+                                        + "        switch (x) {\n"
+                                        + "            case FOO: System.out.println(\"x is foo\"); break;\n"
+                                        + "            // missing: case BAR: System.out.println(\"x is bar\"); break;\n"
+                                        + "            case BZAZ: System.out.println(\" x is bzaz\"); break;\n"
+                                        + "        }\n"
+                                        + "    }\n"
+                                        + "    void notExhaustiveEnumWithDefault(SimpleEnum x) {\n"
+                                        + "        switch (x) {\n"
+                                        + "            case FOO: System.out.println(\"x is foo\"); break;\n"
+                                        + "            //missing: case BAR: System.out.println(\"x is bar\"); break;\n"
+                                        + "            case BZAZ: System.out.println(\" x is bzaz\"); break;\n"
+                                        + "            default: System.out.println(\"unnecessary default\"); break;\n"
+                                        + "        }\n"
+                                        + "    }\n"
+                                        + "}")
+                        .descendants(ASTSwitchLike.class)
+                        .collect(Collectors.toMap(s -> s.ancestors(ASTMethodDeclaration.class).firstOrThrow().getName(),
+                                Function.identity()));
+
+        assertAll(
+                () -> assertSwitch(switchStatements.get("exhaustiveEnum"), true, true, false),
+                () -> assertSwitch(switchStatements.get("exhaustiveEnumWithDefault"), true, true, true),
+                () -> assertSwitch(switchStatements.get("notExhaustiveEnum"), true, false, false),
+                () -> assertSwitch(switchStatements.get("notExhaustiveEnumWithDefault"), true, false, true)
+        );
+
+        assertAll(
+                () -> assertDefaultCase(switchStatements.get("exhaustiveEnumWithDefault"), "unnecessary default"),
+                () -> assertDefaultCase(switchStatements.get("notExhaustiveEnumWithDefault"), "unnecessary default")
+        );
     }
 
     @Test
@@ -136,6 +197,11 @@ class ASTSwitchLikeTest extends BaseParserTest {
                 () -> assertSwitch(switchExpressions.get("exhaustiveSealed"), false, true, false),
                 () -> assertSwitch(switchExpressions.get("exhaustiveSealedWithDefault"), false, true, true),
                 () -> assertSwitch(switchExpressions.get("notExhaustiveSealedWithDefault"), false, false, true)
+        );
+
+        assertAll(
+                () -> assertDefaultCase(switchExpressions.get("exhaustiveSealedWithDefault"), "unnecessary default"),
+                () -> assertDefaultCase(switchExpressions.get("notExhaustiveSealedWithDefault"), "anything else")
         );
     }
 
@@ -181,5 +247,10 @@ class ASTSwitchLikeTest extends BaseParserTest {
         assertEquals(isEnum & isExhaustive, switchLike.isExhaustiveEnumSwitch(), "wrong isExhaustiveEnumSwitch");
         assertEquals(isExhaustive, switchLike.isExhaustive(), "wrong isExhaustive");
         assertEquals(hasDefault, switchLike.hasDefaultCase(), "wrong hasDefaultCase");
+        assertEquals(hasDefault, switchLike.getDefaultCase() != null);
+    }
+
+    private static void assertDefaultCase(ASTSwitchLike switchLike, String expected) {
+        assertEquals(expected, switchLike.getDefaultCase().descendants(ASTStringLiteral.class).first().getConstValue());
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.branchJustThrows;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchIsNecessary;
-import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchJustThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,14 +25,14 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
     private final JavaParsingHelper java = JavaParsingHelper.DEFAULT.withResourceContext(getClass());
 
     @Nested
-    class DefaultBranchJustThrows {
+    class BranchJustThrows {
         @Test
         @DisplayName("Classical switch with default that just throws => true")
         void testClassicalSwitchDefaultJustThrows() {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: throw new IllegalStateException(); } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertTrue(defaultBranchJustThrows(defaultBranch));
+            assertTrue(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -41,7 +41,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: i++; throw new IllegalStateException(); } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertFalse(defaultBranchJustThrows(defaultBranch));
+            assertFalse(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -50,7 +50,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: break; } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertFalse(defaultBranchJustThrows(defaultBranch));
+            assertFalse(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -59,7 +59,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> throw new IllegalStateException(); } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertTrue(defaultBranchJustThrows(defaultBranch));
+            assertTrue(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -68,7 +68,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { throw new IllegalStateException(); } } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertTrue(defaultBranchJustThrows(defaultBranch));
+            assertTrue(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -77,7 +77,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { i++; throw new IllegalStateException(); } } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertFalse(defaultBranchJustThrows(defaultBranch));
+            assertFalse(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -86,7 +86,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { i++; } } } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertFalse(defaultBranchJustThrows(defaultBranch));
+            assertFalse(branchJustThrows(defaultBranch));
         }
 
         @Test
@@ -95,7 +95,7 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTCompilationUnit root = java.parse("public class Foo { public int foo(int i) { return switch (i) { default -> 42; }; } }");
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
-            assertFalse(defaultBranchJustThrows(defaultBranch));
+            assertFalse(branchJustThrows(defaultBranch));
         }
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchIsNecessary;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchJustThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import net.sourceforge.pmd.lang.java.JavaParsingHelper;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchBranch;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLike;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
@@ -93,6 +96,45 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
 
             assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+    }
+
+    @Nested
+    class DefaultBranchIsNecessary {
+        @Test
+        @DisplayName("Default branch is necessary, because without it, the compiler will complaint that foo might not have been initialized.")
+        void testPositive() {
+            ASTCompilationUnit root = java.parse("public class Foo { private final int foo; public Foo(int i) { switch(i) { case 1: foo = 1; break; default: throw new IllegalArgumentException(); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
+
+            assertTrue(defaultBranchIsNecessary(switchLike));
+        }
+
+        @Test
+        @DisplayName("Variable isn't final, doesn't have to be initialized")
+        void testVarIsntFinal() {
+            ASTCompilationUnit root = java.parse("public class Foo { private int foo; public Foo(int i) { switch(i) { case 1: foo = 1; break; default: throw new IllegalArgumentException(); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
+
+            assertFalse(defaultBranchIsNecessary(switchLike));
+        }
+
+        @Test
+        @DisplayName("Final var is only read")
+        void testReadFinalVar() {
+            ASTCompilationUnit root = java.parse("public class Foo { private int foo; private final int bar = 42; public Foo(int i) { switch(i) { case 1: foo = bar; break; default: throw new IllegalArgumentException(); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
+
+            assertFalse(defaultBranchIsNecessary(switchLike));
+        }
+
+        @Test
+        @DisplayName("No referenced variable")
+        void testNoVarReferenced() {
+            ASTCompilationUnit root = java.parse("public class Foo { private int foo; public Foo(int i) { switch(i) { default: throw new IllegalArgumentException(); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
+
+            assertFalse(defaultBranchIsNecessary(switchLike));
         }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -4,8 +4,95 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchJustThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.java.JavaParsingHelper;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchBranch;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
-    // no additional unit tests
+
+    private final JavaParsingHelper java = JavaParsingHelper.DEFAULT.withResourceContext(getClass());
+
+    @Nested
+    class DefaultBranchJustThrows {
+        @Test
+        @DisplayName("Classical switch with default that just throws => true")
+        void testClassicalSwitchDefaultJustThrows() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: throw new IllegalStateException(); } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertTrue(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Classical switch with default that does more than just throwing => false")
+        void testClassicalSwitchDefaultMoreThanJustThrows() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: i++; throw new IllegalStateException(); } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Classical switch with default that does not throw => false")
+        void testClassicalSwitchDefaultDoesNotThrow() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch(i) { default: break; } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Arrow style switch with default that just throws => true")
+        void testArrowSwitchDefaultJustThrows() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> throw new IllegalStateException(); } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertTrue(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Arrow style switch with default that just throws (in braces) => true")
+        void testArrowSwitchDefaultJustThrowsInBraces() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { throw new IllegalStateException(); } } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertTrue(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Arrow style switch with default that does more than just throwing => false")
+        void testArrowSwitchDefaultMoreThanJustThrows() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { i++; throw new IllegalStateException(); } } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Arrow style switch with default that does not throw => false")
+        void testArrowSwitchDefaultDoesNotThrow() {
+            ASTCompilationUnit root = java.parse("public class Foo { public void foo(int i) { switch (i) { default -> { i++; } } } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+
+        @Test
+        @DisplayName("Arrow style switch with default that returns a value => false")
+        void testArrowSwitchDefaultReturns() {
+            ASTCompilationUnit root = java.parse("public class Foo { public int foo(int i) { return switch (i) { default -> 42; }; } }");
+            ASTSwitchBranch defaultBranch = root.descendants(ASTSwitchBranch.class).first();
+
+            assertFalse(defaultBranchJustThrows(defaultBranch));
+        }
+    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
@@ -22,6 +22,22 @@ class Foo {
     </test-code>
 
     <test-code>
+        <description>Non-exhaustive Enum Switch - no default: ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+    enum MyEnum { A, B };
+
+    void doSomething(MyEnum e) {
+        switch(e) {
+            case A -> System.out.println("a");
+        };
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
         <description>Exhaustive Enum Switch - with default: nok</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
@@ -25,6 +25,9 @@ class Foo {
         <description>Exhaustive Enum Switch - with default: nok</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The switch block is exhaustive even without the default case</message>
+        </expected-messages>
         <code><![CDATA[
 class Foo {
     enum MyEnum { A, B };
@@ -134,6 +137,41 @@ public class Test {
         // The blank final field out may not have been initialized.
         // Note that a problem regarding missing 'default:' on 'switch' has been suppressed,
         // which is perhaps related to this problem
+        throw new IllegalStateException();
+    }
+  }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>But when the default is doing too much, we still get a violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <expected-messages>
+            <message>The switch block is exhaustive. The default case should only throw, nothing else.</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.io.PrintStream;
+
+public class Test {
+  private final PrintStream out;
+
+  public enum ProcessStream {
+    STDOUT,
+    STDERR
+  }
+
+  public Test(ProcessStream stream) {
+    switch (stream) {
+      case STDOUT:
+        this.out = System.out;
+        break;
+      case STDERR:
+        this.out = System.err;
+        break;
+      default:
+        this.out = null;
         throw new IllegalStateException();
     }
   }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
@@ -106,4 +106,38 @@ class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor #5670</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.PrintStream;
+
+public class Test {
+  private final PrintStream out;
+
+  public enum ProcessStream {
+    STDOUT,
+    STDERR
+  }
+
+  public Test(ProcessStream stream) {
+    switch (stream) {
+      case STDOUT:
+        this.out = System.out;
+        break;
+      case STDERR:
+        this.out = System.err;
+        break;
+      default:
+        // Without this "default" section, Eclipse complains with:
+        // The blank final field out may not have been initialized.
+        // Note that a problem regarding missing 'default:' on 'switch' has been suppressed,
+        // which is perhaps related to this problem
+        throw new IllegalStateException();
+    }
+  }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

* Add @adangel's [note](https://github.com/pmd/pmd/issues/5514#issuecomment-2687365412) to the rule description of ExhaustiveSwitchHasDefault
* Convert the rule from XPath to Java
* Change the rule's behavior for default branches that are necessary because of final-variable-initialization (#5670). In this case, we only demand that the default branch only consists of a single throws statement.

## What this PR *doesn't* do

* This PR doesn't address any of the concerns in [this comment](https://github.com/pmd/pmd/issues/5514#issuecomment-3580193601).

## Related issues

- Fix #5670
- Fix #5514

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

