### PR TITLE
[doc] Update "Merging pull requests"

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,3 +6,4 @@ _pdf
 vendor/
 .bundle/
 assets/*.zip
+.ruby-version

--- a/docs/_includes/note.html
+++ b/docs/_includes/note.html
@@ -1,5 +1,5 @@
-<div markdown="block" class="alert alert-info" role="alert">
+<span markdown="block" class="alert alert-info" role="alert">
 <i class="fas fa-info-circle"></i>
 **Note:**
 {{include.content}}
-</div>
+</span>

--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -973,6 +973,7 @@ h4 code {
 .alert {
     margin-bottom: 10px;
     margin-top: 10px;
+    display: block;
 }
 
 a.accordion-toggle {

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -110,7 +110,7 @@ PMD version 7.26.0, so that we can create a bugfix release 7.26.1.
     git pull
     ```
 
-2.  Fetch the PR and rebase it onto the maintenance branch:
+2.  Cherrypick the already merged PR from main branch into the maintenance branch:
 
     ```
     git checkout backport-pr-124-to-7.26.x             # creates a new temporary branch

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -67,7 +67,7 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
 6.  On the PR page, wait until the "Squash and Merge" button turns green, then press it.
 
 
-## Example 2: Merging PR #124 into a maintenance branch
+## Example 2: Backporting changes into a maintenance branch
 
 Every change should go into main first.
 But in the rare case a fix needs to be made in an older version as well, we need to backport it.

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -69,93 +69,79 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
 
 ## Example 2: Merging PR #124 into a maintenance branch
 
-We ask, to create every pull request against main, to make it easier to contribute.
-But if a pull request is intended to fix a bug in an older version of PMD, then we need to backport this pull request.
+Every change should go into main first.
+But in the rare case a fix needs to be made in an older version as well, we need to backport it.
 
 ### Creating a maintenance branch
 
-For older versions, we use maintenance branches, like `pmd/5.8.x`. If there is no maintenance branch for
+For older versions, we use maintenance branches, like `pmd/7.26.x`. If there is no maintenance branch for
 the specific version, then we'll have to create it first. Let's say, we want a maintenance branch for
-PMD version 5.8.0, so that we can create a bugfix release 5.8.1.
+PMD version 7.26.0, so that we can create a bugfix release 7.26.1.
 
-1.  We'll simply create a new branch off of the release tag:
-
-    ```
-    git branch pmd/5.8.x pmd_releases/5.8.0 && git checkout pmd/5.8.x
-    ```
-
-2.  Now we'll need to adjust the version, since it's currently the same as the release version.
-    We'll change the version to the next patch version: "5.8.1-SNAPSHOT".
+1.  Make sure your checkout is in a clean state, that is, the output of
 
     ```
-    ./mvnw versions:set -DnewVersion=5.8.1-SNAPSHOT
+    git status
+    ```
+   
+    ends with `nothing to commit, working tree clean`.
+
+2.  Create a new branch off of the release tag:
+
+    ```
+    git branch pmd/7.26.x pmd_releases/7.26.0 && git checkout pmd/7.26.x
+    ```
+
+3.  Now we'll need to adjust the version, since it's currently the same as the release version.
+    We'll change the version to the next patch version: "7.26.1-SNAPSHOT".
+
+    ```
+    ./mvnw versions:set -DnewVersion=7.26.1-SNAPSHOT
     git add pom.xml \*/pom.xml pmd-scala-modules/\*/pom.xml
-    git commit -m "Prepare next version 5.8.1-SNAPSHOT"
+    git commit -m "Prepare next version 7.26.1-SNAPSHOT"
+    git push
     ```
 
-### Merging the PR
+### Backporting the changes from the PR
 
-1.  As above: Review the PR
+1.  Switch to the branch we created above, fetch recent changes:
+
+    ```
+    git checkout pmd/7.26.x
+    git pull
+    ```
 
 2.  Fetch the PR and rebase it onto the maintenance branch:
 
     ```
-    git fetch origin pull/124/head:pr-124 && git checkout pr-124     # creates a new temporary branch
-    git rebase main --onto pmd/5.8.x
-    ./mvnw clean verify                                # make sure, everything works after the rebase
+    git checkout backport-pr-124-to-7.26.x             # creates a new temporary branch
+    git cherrypick commit-hash-you-want-to-packport
     ```
 
-    {%include note.html content="You might need to fix conflicts / backport the commits for the older
-    PMD version." %}
+    {%include note.html content="At this point, that you will need to fix conflicts / backport the changes for the older
+    PMD version. At least in the release notes (see above for details), maybe also in the code." %}
 
-3.  Update the release notes. See above for details.
-
-4.  Now merge the pull request into the maintenance branch:
+3.  Run the complete build, then push:
 
     ```
-    git checkout pmd/5.8.x
-    git merge --no-ff pr-124 -m "Merge pull request #124 from xyz:branch
-    
-    Full-title-of-the-pr #124" --log
+    ./mvnw clean verify -Pgenerate-rule-docs
+    git push
     ```
 
-5.  Just to be sure, run the complete build again: `./mvnw clean verify -Pgenerate-rule-docs`.
+4.  Create a PR on GitHub:
 
-6.  If the build was successful, you are ready to push:
+    * Make sure that you merge *from* backport-pr-124-to-7.26.x *to* pmd/7.26.x.
+    * Make sure that you mention #124 in the description.
 
-    ```
-    git push origin pmd/5.8.x
-    ```
+5.  Merge the PR (ideally by a second person)
 
-7.  Since we have rebased the pull request, it won't appear as merged on github.
-    You need to manually close the pull request. Leave a comment, that it has been
-    rebased onto the maintenance branch.
+    Press the big green button if everything looks as expected.
 
-### Merging into main
-
-Now the PR has been merged into the maintenance branch, but it is missing in any later version of PMD.
-Therefore, we merge first into the next minor version maintenance branch (if existing):
-
-    git checkout pmd/5.9.x
-    git merge pmd/5.8.x
-
-After that, we merge the changes into the main branch:
-
-    git checkout main
-    git merge pmd/5.9.x
-
-{%include note.html content="This ensures, that every change on the maintenance branch eventually ends
-up in the main branch and therefore in any future version of PMD.<br>
-The downside is however, that there are inevitable merge conflicts for the maven `pom.xml` files, since
-every branch changed the version number differently.<br>
-We could avoid this by merging only the temporary branch \"pr-124\" into each maintenance branch and
-eventually into main, with the risk of missing single commits in a maintenance branch, that have been
-done outside the temporary branch." %}
+6.  Repeat for every version the fix needs to be backported to.
 
 ### Merging vs. Cherry-Picking
 
-We are not using cherry-picking, so that each fix is represented by a single commit.
-Cherry-picking would duplicate the commit and you can't see in the log, on which branches the fix has been
-integrated (e.g. gitk and github show the branches, from which the specific commit is reachable).
-
-The downside is a more complex history - the maintenance branches and main branch are "connected" and not separate.
+Since we are squashing, we are also using cherry-picking. This means that if the same fix is applied to multiple versions,
+it appears as several, seemingly unrelated commits. This is fine, since the commit message of the backported fix will
+reference the original PR.
+This leads to a linear history for each branch - the maintenance branches and main branch are separate and not "connected".

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -97,8 +97,7 @@ PMD version 7.26.0, so that we can create a bugfix release 7.26.1.
 
     ```
     ./mvnw versions:set -DnewVersion=7.26.1-SNAPSHOT
-    git add pom.xml \*/pom.xml pmd-scala-modules/\*/pom.xml
-    git commit -m "Prepare next version 7.26.1-SNAPSHOT"
+    git commit -a -m "Prepare next version 7.26.1-SNAPSHOT"
     git push
     ```
 

--- a/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
+++ b/docs/pages/pmd/projectdocs/committers/merging_pull_requests.md
@@ -1,7 +1,7 @@
 ---
 title: Merging pull requests
 permalink: pmd_projectdocs_committers_merging_pull_requests.html
-last_updated: January 2026 (7.21.0)
+last_updated: June 2026 (7.27.0)
 author: Andreas Dangel <andreas.dangel@adangel.org>
 ---
 
@@ -9,26 +9,35 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
 
 1.  Review the pull request
 
-    *   Compilation and checkstyle is verified already by github actions build:
+    *   Compilation and checkstyle is verified already by GitHub actions build:
         PRs are automatically checked.
     *   If it is a bug fix, a new unit test, that reproduces the bug, is mandatory.
         Without such a test, we might accidentally reintroduce the bug again.
-    *   Add the appropriate labels on the github issue: If the PR fixes a bug, the label "a:bug"
+    *   Make sure the PR contains only the commits related to the bugfix/feature.
+    *   Add the appropriate labels on the GitHub issue: If the PR fixes a bug, the label "a:bug"
         should be used.
-    *   Make sure, the PR is added to the appropriate milestone.
+    *   Add the PR to the appropriate milestone:
         If the PR fixes a bug, make sure, that the bug issue is added to the same milestone.
+    *   Make sure the target branch is set to `main`
 
-2.  The actual merge commands:
+2.  Checkout the branch locally:
 
-    We assume, that the PR has been created from the main branch. If this is not the case,
-    then we'll either need to rebase or ask for rebasing before merging.
+    Use the [GitHub CLI tool](https://cli.github.com/) to check out the branch:
 
     ```
     git checkout main && git pull origin main                        # make sure, you have the latest code
-    git fetch origin pull/123/head:pr-123 && git checkout pr-123     # creates a new temporary branch "pr-123"
+    gh pr checkout https://github.com/pmd/pmd/pull/123 -b pr-123     # creates a new temporary branch "pr-123"
     ```
 
-3.  Update the [release notes](https://github.com/pmd/pmd/blob/main/docs/pages/release_notes.md):
+3.  Now merge the main branch into the pull request branch:
+
+    ```
+    git merge main
+    ```
+
+    {%include note.html content="If there are merge conflicts, you'll need to deal with them here." %}
+
+4.  Update the [release notes](https://github.com/pmd/pmd/blob/main/docs/pages/release_notes.md):
     
     *   Are there any API changes, that need to be documented? (Section "API Changes")
     *   Are there any significant changes to existing rules, that should be mentioned?
@@ -37,10 +46,8 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
         Changes for modified rules are e.g. new properties or changed default values for properties.
         
     *   If the PR fixes a bug, make sure, it is listed under the section "Fixed Issues".
-        Also make sure, that the PR description mentions this (e.g. "- fixes #issue-number") and
-        the this PR is linked with the issue. Merging this PR will then automatically close the issue.
-    *   In any case, add the PR to the section "Merged pull requests". You can add it by calling
-        `.ci/tools/release-notes-add-pr.sh prnumber`.
+        Also make sure, that the PR description mentions this (e.g. "- Fixes #issue-number") and
+        that the PR is linked with the issue. Merging this PR will then automatically close the issue.
     *   Commit these changes with the message:
         
         ```
@@ -48,45 +55,16 @@ author: Andreas Dangel <andreas.dangel@adangel.org>
         git commit -m "[doc] Update release notes (#123)"
         ```
     
-    {% include note.html content="If the PR fixes a bug, verify, that we have a commit with the message
-    \"Fixes #issue-number\". If this doesn't exist, you can add it to the commit message when
-    updating the release notes: `[doc] Update release notes (#123, fixes #issue-number)`.
-    This will automatically close the github issue." %}
-
-4.  Add the contributor to `.all-contributorsrc`:
-    
-    ```
-    npx all-contributors add <username> code
-    ```
-    
-    This will modify the files `.all-contributorsrc` and `docs/pages/pmd/projectdocs/credits.md`.
-    Commit them with `git commit -am "Add @<username> as a contributor` into the current branch (pr-123).
-
-5.  Now merge the pull request into the main branch:
+5.  Push the PR back to GitHub
 
     ```
-    git checkout main
-    git merge --no-ff pr-123 -m "Full-title-of-the-pr (#123)"
-    ```
-
-    {%include note.html content="If there are merge conflicts, you'll need to deal with them here." %}
-
-6.  Run the complete build: `./mvnw clean verify -Pgenerate-rule-docs`
-
-    {% include note.html content="This will execute all the unit tests and the checkstyle tests. It ensures,
-    that the complete project can be build and is functioning on top of the current main." %}
-    
-    {% include note.html content="The profile `generate-rule-docs` will run the doc checks, that would
-    otherwise only run on github actions and fail the build, if e.g. a jdoc or rule reference is wrong." %}
-
-7.  If the build was successful, you are ready to push:
-
-    ```
-    git push origin main
+    git push
     ```
 
     Since the temporary branch is now not needed anymore, you can delete it:
     `git branch -d pr-123`.
+
+6.  On the PR page, wait until the "Squash and Merge" button turns green, then press it.
 
 
 ## Example 2: Merging PR #124 into a maintenance branch


### PR DESCRIPTION
## Describe the PR

Update the "Merging Pull Requests" docs page.

Changes to "Example 1: Merging PR #123 into main"
* Change the preferred merge strategy to "Squash and merge"
* Remove parts that have since become automated

Changes to "Example 2: Merging PR #124 into a maintenance branch
* Since every PR becomes a single commit after "Squash and merge", cherrypicking becomes trivial. That's why I rewrote the example to use cherrypicking instead of merging.

Changes to note.html/stylesheet
* Using a `<div>` inside a markdown list breaks the list (See all the spurious `</div>`s on the [current version of the page](https://docs.pmd-code.org/latest/pmd_projectdocs_committers_merging_pull_requests.html)).
I fixed it by using a `<span>` which is rendered as a `<div>` would be.

## Related issues

- See #https://github.com/pmd/pmd/discussions/6673