### PR TITLE
[java] Fix #6826: AssertEqualsArgumentOrder false positive for double/float delta

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* java-errorprone
+  * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -115,10 +115,17 @@ public final class TestFrameworksUtil {
         new EqualMethod("org.junit.jupiter.api.Assertions#assertEquals(_,_,_)", 1, 0),
         // JUnit 3 and 4, Spring: [message], expected, actual
         new EqualMethod("org.junit.Assert#assertEquals(_,_)", 1, 0),
-        new EqualMethod("org.junit.Assert#assertEquals(_,_,_)", 2, 1),
+        new EqualMethod("org.junit.Assert#assertEquals(java.lang.String,_,_)", 2, 1),
         new EqualMethod("junit.framework.TestCase#assertEquals(_,_)", 1, 0),
-        new EqualMethod("junit.framework.TestCase#assertEquals(_,_,_)", 2, 1),
+        new EqualMethod("junit.framework.TestCase#assertEquals(java.lang.String,_,_)", 2, 1),
         new EqualMethod("org.springframework.test.util.AssertionErrors#assertEquals(_,_,_)", 2, 1),
+        // JUnit 3 and 4 delta overloads: [message], expected, actual, delta
+        new EqualMethod("org.junit.Assert#assertEquals(double,double,double)", 1, 0),
+        new EqualMethod("org.junit.Assert#assertEquals(float,float,float)", 1, 0),
+        new EqualMethod("org.junit.Assert#assertEquals(java.lang.String,_,_,_)", 2, 1),
+        new EqualMethod("junit.framework.TestCase#assertEquals(double,double,double)", 1, 0),
+        new EqualMethod("junit.framework.TestCase#assertEquals(float,float,float)", 1, 0),
+        new EqualMethod("junit.framework.TestCase#assertEquals(java.lang.String,_,_,_)", 2, 1),
         // TestNG: actual, expected, [message]
         new EqualMethod("org.testng.Assert#assertEquals(_*)", 0, 1),
         // JSONAssert: [message], expected, actual, compare mode

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssertEqualsArgumentOrder.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssertEqualsArgumentOrder.xml
@@ -102,4 +102,52 @@ public class SimpleTest {
 ]]>
         </code>
     </test-code>
+    <test-code>
+        <description>[java] assertEquals double delta overloads, 3-arg and 4-arg #6826</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>8,9</expected-linenumbers>
+        <code>
+            <![CDATA[
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+public class SimpleTest {
+    @Test
+    public void testX() {
+        assertEquals(100.0, computePercentage(), 0.01); // (expected, actual, delta), correctly ordered
+        assertEquals("pct", 100.0, computePercentage(), 0.01); // (message, expected, actual, delta), correctly ordered
+        assertEquals(computePercentage(), 100.0, 0.01); // expected and actual swapped
+        assertEquals("pct", computePercentage(), 100.0, 0.01); // expected and actual swapped
+    }
+
+    private double computePercentage() {
+        return 99.9;
+    }
+}
+]]>
+        </code>
+    </test-code>
+    <test-code>
+        <description>[java] assertEquals float delta overloads, 3-arg and 4-arg #6826</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>8,9</expected-linenumbers>
+        <code>
+            <![CDATA[
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+public class SimpleTest {
+    @Test
+    public void testX() {
+        assertEquals(100.0f, computePercentage(), 0.01f); // (expected, actual, delta), correctly ordered
+        assertEquals("pct", 100.0f, computePercentage(), 0.01f); // (message, expected, actual, delta), correctly ordered
+        assertEquals(computePercentage(), 100.0f, 0.01f); // expected and actual swapped
+        assertEquals("pct", computePercentage(), 100.0f, 0.01f); // expected and actual swapped
+    }
+
+    private float computePercentage() {
+        return 99.9f;
+    }
+}
+]]>
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The wildcard `assertEquals(_,_,_)` matchers for `org.junit.Assert` and `junit.framework.TestCase` modeled the 3-arg form as `(message?, expected, actual)`, so for the delta overload `assertEquals(double expected, double actual, double delta)` they read the delta as "actual" and flagged correctly-ordered calls.

Replace the wildcards with the forms actually in use: `(String,_,_)` and `(String,_,_,_)` for the message variants, `(double,double,double)` and `(float,float,float)` for the deltas. The message + delta form was not matched at all before, so a swap there went undetected.

Added a release-note entry under `java-errorprone`.

## Related issues

- Fix #6826

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
