### PR TITLE
[java] Fix #6709: Fix false positive: LambdaCanBeMethodReference should not flag lambda…

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
   * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+* java-codestyle
+  * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
 * java-errorprone
   * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LambdaCanBeMethodReferenceRule.java
@@ -181,7 +181,7 @@ public class LambdaCanBeMethodReferenceRule extends AbstractJavaRulechainRule {
             // err on the side of FNs
             return false;
         }
-        if (qualifier instanceof ASTConstructorCall) {
+        if (qualifier != null && qualifier.descendantsOrSelf().filterIs(ASTConstructorCall.class).nonEmpty()) {
             // ctors may not be transformed because that would change semantics,
             // with only one instance being created
             return false;
@@ -198,7 +198,7 @@ public class LambdaCanBeMethodReferenceRule extends AbstractJavaRulechainRule {
         boolean isIgnoredBecauseOfMethodCall =
             qualifier instanceof ASTMethodCall && getProperty(IGNORE_IF_RECEIVER_IS_METHOD);
 
-        // if call uses first lambda parm as receiver, then the mref may not npe at creation time 
+        // if call uses first lambda parm as receiver, then the mref may not npe at creation time
         boolean mayNPE = lambda.getParameters().size() == call.getArguments().size();
         boolean isIgnoredBecauseOfNPE = mayNPE && getProperty(IGNORE_IF_MAY_NPE);
         return !isIgnoredBecauseOfNPE && !isIgnoredBecauseOfMethodCall;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
@@ -126,7 +126,7 @@
             }
             ]]>
     </code-fragment>
-    
+
     <test-code>
         <description>Ignore methods by default</description>
         <expected-problems>0</expected-problems>
@@ -415,6 +415,21 @@
             ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#new FN: constructor hidden inside array receiver should not be suggested as method reference</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.util.function.IntPredicate;
+            public class Test {
+                IntPredicate p() {
+                    return x -> new Holder[] { new Holder() }[0].test(x);
+                }
+            }
 
+            class Holder {
+                boolean test(int x) { return x > 0; }
+            }
+        ]]></code>
+    </test-code>
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
@@ -416,7 +416,7 @@
     </test-code>
 
     <test-code>
-        <description>#new FN: constructor hidden inside array receiver should not be suggested as method reference</description>
+        <description>#6709 FN: constructor hidden inside array receiver should not be suggested as method reference</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             import java.util.function.IntPredicate;


### PR DESCRIPTION
## Describe the PR
This PR fixes a false positive in the `LambdaCanBeMethodReference` rule where lambda expressions were incorrectly flagged when the method-call receiver contains an array creation expression with a nested constructor call (e.g., `x -> new Holder[] { new Holder() }[0].test(x)`). Converting such a lambda to a method reference changes its semantics — the array and object would only be instantiated once at reference creation time rather than on every invocation.

### Root Cause
The rule did not account for cases where the receiver of the method call is an array access expression backed by an array creation with a nested constructor call. As a result, it treated these lambdas as safe to convert, producing a false positive.

### Solution
Added an explicit check to detect when the method-call receiver involves an array creation expression containing a nested constructor call. Lambdas matching this pattern are now skipped by the rule.

## Related issues
- Fix #6709

## Ready?
- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)