### PR TITLE
[java] #4730: Add a test for FinalFieldCouldBeStatic that shows that #4730 was already fixed

### DIFF
--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -345,5 +345,11 @@
             <version>6.1.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.46</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -144,6 +144,27 @@ public class ExampleClass {
     </test-code>
 
     <test-code>
+        <description>#2708/#4730 - False positive with lombok @Builder.Default fields</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package com.example;
+
+import lombok.Builder;
+import lombok.Data;
+
+import static lombok.Builder.Default;
+
+@Data
+@Builder
+public class ExampleClass {
+
+    @Default
+    private final long exampleField = 0L;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Should trigger multiple times for fields declared on one line</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>5,5</expected-linenumbers>


### PR DESCRIPTION
## Describe the PR

* Adds a regression test for #4730. As far as I can tell, this was fixed sometime between 6.55.0 and 7.0.0. I added the issue to the 7.0.0 milestone.
* Added lombok as a test-dependency, so that lombok annotation can be resolved in tests.

## Related issues

- Closes #4730

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

