### PR TITLE
[core] Fix #4953: Deprecate PMDConfiguration#getClassLoader

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,27 +26,27 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 * chore
-    * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
+  * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
-    * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
-    * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
-    * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
+  * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+  * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
+  * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
 * java-codestyle
-    * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
+  * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
 * java-errorprone
-    * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
+  * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 
 ### 🚨️ API Changes
 
 #### Deprecations
-*   core
-    *   {%jdoc !!core::PMDConfiguration#getClassLoader() %} and {%jdoc !!core::PMDConfiguration#setClassLoader(java.lang.ClassLoader) %} are deprecated.
-        Use {%jdoc core::PMDConfiguration#prependAuxClasspath(String) %} or {%jdoc core::PMDConfiguration#setAuxClasspath(String) %} to
-        configure the auxClasspath for analyzing Java code.  
-        Note: In order to read back the currently configured auxClasspath, use {%jdoc core::PMDConfiguration#getAuxClasspath() %} and not the
-        deprecated `getClassLoader()` anymore.  
-        Using ClassLoaders directly is discouraged, as it is unclear, if and when the ClassLoaders should be closed to release their resources.
-        By just configuring the auxClasspath, PMD internally can deal with that.
+* core
+  * {%jdoc !!core::PMDConfiguration#getClassLoader() %} and {%jdoc !!core::PMDConfiguration#setClassLoader(java.lang.ClassLoader) %} are deprecated.
+    Use {%jdoc core::PMDConfiguration#prependAuxClasspath(String) %} or {%jdoc core::PMDConfiguration#setAuxClasspath(String) %} to
+    configure the auxClasspath for analyzing Java code.  
+    Note: In order to read back the currently configured auxClasspath, use {%jdoc core::PMDConfiguration#getAuxClasspath() %} and not the
+    deprecated `getClassLoader()` anymore.  
+    Using ClassLoaders directly is discouraged, as it is unclear, if and when the ClassLoaders should be closed to release their resources.
+    By just configuring the auxClasspath, PMD internally can deal with that.
 
 ### ✨️ Merged pull requests
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,15 +26,26 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 * chore
-  * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
+    * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
-  * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+    * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+    * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
 * java-codestyle
-  * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
+    * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
 * java-errorprone
-  * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
+    * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 
 ### 🚨️ API Changes
+
+#### Deprecations
+*   core
+    *   {%jdoc !!core::PMDConfiguration#getClassLoader() %} and {%jdoc !!core::PMDConfiguration#setClassLoader(java.lang.ClassLoader) %} are deprecated.
+        Use {%jdoc core::PMDConfiguration#prependAuxClasspath(String) %} or {%jdoc core::PMDConfiguration#setAuxClasspath(String) %} to
+        configure the auxClasspath for analyzing Java code.  
+        Note: In order to read back the currently configured auxClasspath, use {%jdoc core::PMDConfiguration#getAuxClasspath() %} and not the
+        deprecated `getClassLoader()` anymore.  
+        Using ClassLoaders directly is discouraged, as it is unclear, if and when the ClassLoaders should be closed to release their resources.
+        By just configuring the auxClasspath, PMD internally can deal with that.
 
 ### ✨️ Merged pull requests
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
     * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+    * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
 * java-codestyle
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.cache.internal.AnalysisCache;
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
-import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.cache.internal.AnalysisCache;
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
+import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -290,13 +291,13 @@ public class PMDConfiguration extends AbstractConfiguration {
         List<Path> notExistingFiles = new ArrayList<>();
         if (classpath.startsWith("file:")) {
             try {
-                URI uri = new URI(classpath);
-                String uriPath = uri.getPath();
-                if (uriPath == null) {
-                    // to support relative paths, only the scheme specific part is available
-                    uriPath = uri.getSchemeSpecificPart();
+                Path path;
+                if (classpath.length() > 5 && classpath.charAt(5) == '/') {
+                    path = Paths.get(new URI(classpath));
+                } else {
+                    // support relative paths
+                    path = Paths.get(classpath.substring(5));
                 }
-                Path path = Paths.get(uriPath);
 
                 try (Stream<String> lines = Files.lines(path, Charset.defaultCharset())) {
                     notExistingFiles.addAll(lines

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLClassLoader;
@@ -15,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -218,8 +220,8 @@ public class PMDConfiguration extends AbstractConfiguration {
             throw new IllegalStateException("Can't mix setClassLoader with setAuxClasspath or prependAuxClasspath!");
         }
         if (classLoader != null && !(classLoader instanceof URLClassLoader)) {
-            getReporter().warn("Unsupported classloader for auxClasspath detected: " + classLoader.getClass() + ". "
-                    + "Only " + URLClassLoader.class.getName() + " is supported.");
+            getReporter().warn("Unsupported classloader for auxClasspath detected: {0}. "
+                    + "Only {1} is supported.", classLoader.getClass().getName(), URLClassLoader.class.getName());
         }
         this.classLoader = classLoader;
     }
@@ -263,11 +265,14 @@ public class PMDConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Checks whether any referenced file on the classpath exists.
+     * Checks whether any referenced file on the classpath exists. File URLs are replaced by their
+     * content and each referenced file in the classpath-file must exist. If the classpath entry
+     * references a directory (an entry not ending with .jar) and the directory does not exist, it is
+     * ignored - only files must exist.
      *
      * <p>Valid classpath formats (under Unix):
      * <ul>
-     *     <li>/absolute/file.jar:relative/file.jar</li>
+     *     <li>/absolute/file.jar:relative/file.jar:/absolute/directory/with/classes</li>
      *     <li>file:relative/classpath.txt</li>
      *     <li>file:/absolute/classpath.txt</li>
      * </ul>
@@ -310,8 +315,24 @@ public class PMDConfiguration extends AbstractConfiguration {
             while (toker.hasMoreTokens()) {
                 String token = toker.nextToken();
                 Path path = Paths.get(token);
-                if (!Files.exists(path)) {
+                boolean isJarFile = path.getNameCount() > 0 && path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".jar");
+                if (isJarFile && !Files.isRegularFile(path)) {
                     notExistingFiles.add(path);
+                } else if (!isJarFile) {
+                    // might be a directory
+                    if (!Files.exists(path)) {
+                        getReporter().warn("Suspicious auxClasspath entry: {0} does not exist",
+                                path.toString());
+                    } else if (Files.isDirectory(path)) {
+                        try (Stream<Path> dir = Files.list(path)) {
+                            if (!dir.findAny().isPresent()) {
+                                getReporter().warn("Suspicious auxClasspath entry: directory {0} is empty",
+                                        path.toString());
+                            }
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
                 }
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -176,6 +177,8 @@ public class PMDConfiguration extends AbstractConfiguration {
      * set explicitly via {@link #setClassLoader(ClassLoader)}. Instead of setting a classloader,
      * the auxClasspath should be configured via {@link #setAuxClasspath(String)} or {@link #prependAuxClasspath(String)}.</p>
      *
+     * <p>See also the notes on {@link #setClassLoader(ClassLoader)} regarding closing and supported types.</p>
+     *
      * @return The ClassLoader being used
      * @deprecated Since 7.27.0. Use {@link #getAuxClasspath()} instead.
      */
@@ -194,8 +197,16 @@ public class PMDConfiguration extends AbstractConfiguration {
      *
      * <p>Since 7.27.0, a classloader should not be set anymore. Instead, the auxClasspath should be configured
      * via {@link #setAuxClasspath(String)} or {@link #prependAuxClasspath(String)}. For
-     * backwards compatibility, if setting a classloader here, it will still be used, and it will be
-     * closed, when PMD is called via {@link PmdAnalysis}.</p>
+     * backwards compatibility, if setting a classloader here, it will still be used.</p>
+     *
+     * <p>Note 1: The classloader might keep open file references to jar files if it is not closed.
+     * A {@link java.net.URLClassLoader} is closeable and any given classloader that is {@link java.io.Closeable}
+     * will be closed, when PMD is called via {@link PmdAnalysis}. In other cases, e.g. not using PmdAnalysis,
+     * you need to close the classloader yourself.</p>
+     *
+     * <p>Note 2: Only subtypes of {@link java.net.URLClassLoader} are compatible with PMD, as for the
+     * <a href="https://docs.pmd-code.org/latest/pmd_userdocs_incremental_analysis.html">incremental analysis</a>
+     * we need to figure out the actual URLs of the classpath to check the validity of our cache.</p>
      *
      * @param classLoader
      *            The ClassLoader to use
@@ -205,6 +216,10 @@ public class PMDConfiguration extends AbstractConfiguration {
     public void setClassLoader(ClassLoader classLoader) {
         if (auxClasspath != null) {
             throw new IllegalStateException("Can't mix setClassLoader with setAuxClasspath or prependAuxClasspath!");
+        }
+        if (classLoader != null && !(classLoader instanceof URLClassLoader)) {
+            getReporter().warn("Unsupported classloader for auxClasspath detected: " + classLoader.getClass() + ". "
+                    + "Only " + URLClassLoader.class.getName() + " is supported.");
         }
         this.classLoader = classLoader;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -7,12 +7,18 @@ package net.sourceforge.pmd;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.LoggerFactory;
@@ -20,7 +26,6 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.cache.internal.AnalysisCache;
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
-import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -97,7 +102,12 @@ public class PMDConfiguration extends AbstractConfiguration {
     // General behavior options
     private String suppressMarker = DEFAULT_SUPPRESS_MARKER;
     private int threads = Runtime.getRuntime().availableProcessors();
-    private ClassLoader classLoader = getClass().getClassLoader();
+    /**
+     * @deprecated Since 7.27.0. This field is only used for fallback behavior.
+     */
+    @Deprecated
+    private ClassLoader classLoader = null;
+    private String auxClasspath = null;
 
     // Rule and source file options
     private List<String> ruleSets = new ArrayList<>();
@@ -160,34 +170,54 @@ public class PMDConfiguration extends AbstractConfiguration {
     }
 
     /**
-     * Get the ClassLoader being used by PMD when processing Rules.
+     * Get the ClassLoader being used by PMD when analyzing code, e.g. Java.
+     *
+     * <p>Since 7.27.0, this method will only return the classloader, that has been
+     * set explicitly via {@link #setClassLoader(ClassLoader)}. Instead of setting a classloader,
+     * the auxClasspath should be configured via {@link #setAuxClasspath(String)} or {@link #prependAuxClasspath(String)}.</p>
      *
      * @return The ClassLoader being used
+     * @deprecated Since 7.27.0. Use {@link #getAuxClasspath()} instead.
      */
+    @Deprecated
     public ClassLoader getClassLoader() {
+        if (classLoader == null && auxClasspath == null) {
+            // preserve old behavior for default classloader
+            return PMDConfiguration.class.getClassLoader();
+        }
         return classLoader;
     }
 
     /**
-     * Set the ClassLoader being used by PMD when processing Rules. Setting a
+     * Set the ClassLoader being used by PMD when analyzing code, e.g. Java. Setting a
      * value of <code>null</code> will cause the default ClassLoader to be used.
+     *
+     * <p>Since 7.27.0, a classloader should not be set anymore. Instead, the auxClasspath should be configured
+     * via {@link #setAuxClasspath(String)} or {@link #prependAuxClasspath(String)}. For
+     * backwards compatibility, if setting a classloader here, it will still be used, and it will be
+     * closed, when PMD is called via {@link PmdAnalysis}.</p>
      *
      * @param classLoader
      *            The ClassLoader to use
+     * @deprecated Since 7.27.0. Use {@link #prependAuxClasspath(String)} or {@link #setAuxClasspath(String)} instead.
      */
+    @Deprecated
     public void setClassLoader(ClassLoader classLoader) {
-        if (classLoader == null) {
-            this.classLoader = getClass().getClassLoader();
-        } else {
-            this.classLoader = classLoader;
+        if (auxClasspath != null) {
+            throw new IllegalStateException("Can't mix setClassLoader with setAuxClasspath or prependAuxClasspath!");
         }
+        this.classLoader = classLoader;
     }
 
     /**
-     * Prepend the specified classpath like string to the current ClassLoader of
-     * the configuration. If no ClassLoader is currently configured, the
-     * ClassLoader used to load the {@link PMDConfiguration} class will be used
-     * as the parent ClassLoader of the created ClassLoader.
+     * Prepend the specified classpath like string to the currently set auxClasspath of
+     * the configuration.
+     *
+     * <p>Use {@link #setAuxClasspath(String)} if you don't want any fallbacks (neither to PMD's runtime
+     * classpath nor to the current JVM runtime) and only access classes on the given auxClasspath.</p>
+     *
+     * <p>Specify the JVM's platform classpath yourself explicitly (e.g. adding {@code jrt-fs.jar})
+     * in order to not fall back to the current JVM runtime.</p>
      *
      * <p>If the classpath String looks like a URL to a file (i.e. starts with
      * <code>file://</code>) the file will be read with each line representing
@@ -196,24 +226,121 @@ public class PMDConfiguration extends AbstractConfiguration {
      * <p>You can specify multiple class paths separated by `:` on Unix-systems or `;` under Windows.
      * See {@link File#pathSeparator}.
      *
-     * @param classpath The prepended classpath.
+     * @param classpath The additional classpath entries to be prepended.
      *
      * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist)
-     * @see PMDConfiguration#setClassLoader(ClassLoader)
+     * @see PMDConfiguration#setAuxClasspath(String)
      */
     public void prependAuxClasspath(String classpath) {
-        try {
-            if (classLoader == null) {
-                classLoader = PMDConfiguration.class.getClassLoader();
-            }
-            if (classpath != null) {
-                classLoader = new ClasspathClassLoader(classpath, classLoader);
-            }
-        } catch (IOException e) {
-            // Note: IOExceptions shouldn't appear anymore, they should already be converted
-            // to IllegalArgumentException in ClasspathClassLoader.
-            throw new IllegalArgumentException(e);
+        if (classpath == null) {
+            return;
         }
+        if (classLoader != null) {
+            throw new IllegalStateException("Can't mix setClasspath with prependAuxClasspath!");
+        }
+        verifyAuxClasspath(classpath); // throws IllegalArgumentException...
+
+        if (auxClasspath == null) {
+            auxClasspath = classpath;
+        } else {
+            auxClasspath = classpath + File.pathSeparator + auxClasspath;
+        }
+    }
+
+    /**
+     * Checks whether any referenced file on the classpath exists.
+     *
+     * <p>Valid classpath formats (under Unix):
+     * <ul>
+     *     <li>/absolute/file.jar:relative/file.jar</li>
+     *     <li>file:relative/classpath.txt</li>
+     *     <li>file:/absolute/classpath.txt</li>
+     * </ul>
+     * </p>
+     *
+     * @param classpath
+     * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist).
+     */
+    private void verifyAuxClasspath(String classpath) {
+        if (classpath == null) {
+            return;
+        }
+
+        List<Path> notExistingFiles = new ArrayList<>();
+        if (classpath.startsWith("file:")) {
+            try {
+                URI uri = new URI(classpath);
+                String uriPath = uri.getPath();
+                if (uriPath == null) {
+                    // to support relative paths, only the scheme specific part is available
+                    uriPath = uri.getSchemeSpecificPart();
+                }
+                Path path = Paths.get(uriPath);
+
+                try (Stream<String> lines = Files.lines(path, Charset.defaultCharset())) {
+                    notExistingFiles.addAll(lines
+                            .map(String::trim)
+                            .filter(s -> !s.startsWith("#"))
+                            .map(Paths::get)
+                            .filter(p -> !Files.exists(p))
+                            .collect(Collectors.toList()));
+                }
+            } catch (IOException | URISyntaxException e) {
+                throw new IllegalArgumentException(e);
+            }
+        } else {
+            StringTokenizer toker = new StringTokenizer(classpath, File.pathSeparator);
+            while (toker.hasMoreTokens()) {
+                String token = toker.nextToken();
+                Path path = Paths.get(token);
+                if (!Files.exists(path)) {
+                    notExistingFiles.add(path);
+                }
+            }
+        }
+        if (!notExistingFiles.isEmpty()) {
+            throw new IllegalArgumentException("Invalid classpath - not existing files: " + notExistingFiles);
+        }
+    }
+
+    /**
+     * Uses the specified classpath like string as the auxClasspath of
+     * the configuration.
+     *
+     * <p>If the classpath String looks like a URL to a file (i.e. starts with
+     * <code>file://</code>) the file will be read with each line representing
+     * an entry on the classpath.</p>
+     *
+     * <p>You can specify multiple class paths separated by `:` on Unix-systems or `;` under Windows.
+     * See {@link File#pathSeparator}.
+     *
+     * @param classpath The classpath entries to be used.
+     *
+     * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist)
+     * @see PMDConfiguration#prependAuxClasspath(String)
+     * @since 7.27.0
+     */
+    public void setAuxClasspath(String classpath) {
+        if (classLoader != null) {
+            throw new IllegalStateException("Can't mix setClasspath with setAuxClasspath!");
+        }
+        verifyAuxClasspath(classpath);
+        auxClasspath = classpath;
+    }
+
+    /**
+     * Gets the currently set auxClasspath.
+     *
+     * @return the configured auxClasspath. Might be {@code null}.
+     * @see #setAuxClasspath(String)
+     * @see #prependAuxClasspath(String)
+     * @since 7.27.0
+     */
+    public String getAuxClasspath() {
+        if (classLoader != null) {
+            throw new IllegalStateException("Can't mix setClasspath with getAuxClasspath!");
+        }
+        return auxClasspath;
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -277,6 +277,7 @@ public class PMDConfiguration extends AbstractConfiguration {
      * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist).
      */
     private void verifyAuxClasspath(String classpath) {
+        // TODO: Once #6841 is merged, use AnalysisClasspathUtil#expandAnalysisClasspath + check each entry for existence
         if (classpath == null) {
             return;
         }
@@ -295,6 +296,7 @@ public class PMDConfiguration extends AbstractConfiguration {
                 try (Stream<String> lines = Files.lines(path, Charset.defaultCharset())) {
                     notExistingFiles.addAll(lines
                             .map(String::trim)
+                            .filter(s -> !s.isEmpty())
                             .filter(s -> !s.startsWith("#"))
                             .map(Paths::get)
                             .filter(p -> !Files.exists(p))

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -8,18 +8,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.cache.internal.AnalysisCache;
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
+import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -38,6 +35,7 @@ import net.sourceforge.pmd.lang.rule.RuleSetLoader;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.renderers.RendererFactory;
 import net.sourceforge.pmd.util.AssertionUtil;
+import net.sourceforge.pmd.util.internal.AuxClasspathUtil;
 import net.sourceforge.pmd.util.log.internal.SimpleMessageReporter;
 
 /**
@@ -282,60 +280,36 @@ public class PMDConfiguration extends AbstractConfiguration {
      * @throws IllegalArgumentException if the given classpath is invalid (e.g. does not exist).
      */
     private void verifyAuxClasspath(String classpath) {
-        // TODO: Once #6841 is merged, use AnalysisClasspathUtil#expandAnalysisClasspath + check each entry for existence
         if (classpath == null) {
             return;
         }
 
-        List<Path> notExistingFiles = new ArrayList<>();
-        if (classpath.startsWith("file:")) {
-            try {
-                Path path;
-                if (classpath.length() > 5 && classpath.charAt(5) == '/') {
-                    path = Paths.get(new URI(classpath));
-                } else {
-                    // support relative paths
-                    path = Paths.get(classpath.substring(5));
-                }
-
-                try (Stream<String> lines = Files.lines(path, Charset.defaultCharset())) {
-                    notExistingFiles.addAll(lines
-                            .map(String::trim)
-                            .filter(s -> !s.isEmpty())
-                            .filter(s -> !s.startsWith("#"))
-                            .map(Paths::get)
-                            .filter(p -> !Files.exists(p))
-                            .collect(Collectors.toList()));
-                }
-            } catch (IOException | URISyntaxException e) {
-                throw new IllegalArgumentException(e);
-            }
-        } else {
-            StringTokenizer toker = new StringTokenizer(classpath, File.pathSeparator);
-            while (toker.hasMoreTokens()) {
-                String token = toker.nextToken();
-                Path path = Paths.get(token);
-                boolean isJarFile = path.getNameCount() > 0 && path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".jar");
-                if (isJarFile && !Files.isRegularFile(path)) {
-                    notExistingFiles.add(path);
-                } else if (!isJarFile) {
-                    // might be a directory
-                    if (!Files.exists(path)) {
-                        getReporter().warn("Suspicious auxClasspath entry: {0} does not exist",
-                                path.toString());
-                    } else if (Files.isDirectory(path)) {
-                        try (Stream<Path> dir = Files.list(path)) {
-                            if (!dir.findAny().isPresent()) {
-                                getReporter().warn("Suspicious auxClasspath entry: directory {0} is empty",
-                                        path.toString());
+        List<Path> expandedClasspath = AuxClasspathUtil.expandClasspath(classpath);
+        List<Path> notExistingFiles = expandedClasspath.stream()
+                .filter(path -> {
+                    boolean isJarFile = "jar".equalsIgnoreCase(IOUtil.getFilenameExtension(path.toString()));
+                    if (isJarFile && !Files.exists(path)) {
+                        return true;
+                    } else if (!isJarFile) {
+                        // might be a directory
+                        if (!Files.exists(path)) {
+                            getReporter().warn("Suspicious auxClasspath entry: {0} does not exist",
+                                    path.toString());
+                        } else if (Files.isDirectory(path)) {
+                            try (Stream<Path> dir = Files.list(path)) {
+                                if (!dir.findAny().isPresent()) {
+                                    getReporter().warn("Suspicious auxClasspath entry: directory {0} is empty",
+                                            path.toString());
+                                }
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
                             }
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
                         }
                     }
-                }
-            }
-        }
+                    return false;
+                })
+                .collect(Collectors.toList());
+
         if (!notExistingFiles.isEmpty()) {
             throw new IllegalArgumentException("Invalid classpath - not existing files: " + notExistingFiles);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -217,7 +217,12 @@ public final class PmdAnalysis implements AutoCloseable {
             //  CLI syntax is implemented. #2947
             props.setProperty(LanguagePropertyBundle.SUPPRESS_MARKER, config.getSuppressMarker());
             if (props instanceof JvmLanguagePropertyBundle) {
-                ((JvmLanguagePropertyBundle) props).setClassLoader(config.getClassLoader());
+                ClassLoader externallyConfiguredClassLoader = config.getClassLoader();
+                if (externallyConfiguredClassLoader != null) {
+                    ((JvmLanguagePropertyBundle) props).setClassLoader(externallyConfiguredClassLoader);
+                } else {
+                    props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAuxClasspath());
+                }
             }
         }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -6,7 +6,9 @@ package net.sourceforge.pmd;
 
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -89,8 +93,9 @@ class PmdConfigurationTest {
         assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Default ClassLoader");
         assertNull(configuration.getAuxClasspath(), "Default AuxClasspath should be null");
 
-        configuration.setClassLoader(PmdConfigurationTest.class.getClassLoader());
-        assertSame(PmdConfigurationTest.class.getClassLoader(), configuration.getClassLoader(), "Not anymore the default ClassLoader");
+        URLClassLoader customClassLoader = new URLClassLoader(new URL[0], PMDConfiguration.class.getClassLoader());
+        configuration.setClassLoader(customClassLoader);
+        assertSame(customClassLoader, configuration.getClassLoader(), "Not anymore the default ClassLoader");
 
         // reset
         configuration.setClassLoader(null);
@@ -169,6 +174,52 @@ class PmdConfigurationTest {
         } finally {
             TempDirDeletionStrategy.Standard.INSTANCE.delete(targetTempDir, null, null);
         }
+    }
+
+    @Test
+    void verifyAuxClasspathFiles() throws IOException {
+        PMDConfiguration configuration = new PMDConfiguration();
+
+        Path doesNotExistJar = tempDir.resolve("doesNotExist.jar");
+        assertFalse(Files.exists(doesNotExistJar), "Test setup failure: the file "
+                + doesNotExistJar + " must not exist for the test");
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> configuration.prependAuxClasspath(doesNotExistJar.toString()));
+        assertThat(exception.getMessage(), containsString(doesNotExistJar.toString()));
+
+        Path doesNotExistJar2 = tempDir.resolve("doesNotExist.JAR");
+        assertFalse(Files.exists(doesNotExistJar2), "Test setup failure: the file "
+                + doesNotExistJar2 + " must not exist for the test");
+        exception = assertThrows(IllegalArgumentException.class, () -> configuration.prependAuxClasspath(doesNotExistJar2.toString()));
+        assertThat(exception.getMessage(), containsString(doesNotExistJar2.toString()));
+
+        Path existingJar = Files.createFile(tempDir.resolve("existing.jar"));
+        exception = assertThrows(IllegalArgumentException.class, () -> configuration.prependAuxClasspath(existingJar + File.pathSeparator + doesNotExistJar2));
+        assertThat(exception.getMessage(), containsString(doesNotExistJar2.toString()));
+        assertThat(exception.getMessage(), not(containsString(existingJar.toString())));
+
+        configuration.prependAuxClasspath(existingJar.toString());
+        assertEquals(existingJar.toString(), configuration.getAuxClasspath());
+    }
+
+    @Test
+    void verifyAuxClasspathDirectories() throws IOException {
+        PMDConfiguration configuration = new PMDConfiguration();
+
+        Path notExistingDirectory = tempDir.resolve("doesNotExist");
+        assertFalse(Files.exists(notExistingDirectory), "Test setup failure: the directory "
+            + notExistingDirectory + " must not exist for the test");
+        configuration.prependAuxClasspath(notExistingDirectory.toString()); // no exception
+        assertEquals(notExistingDirectory.toString(), configuration.getAuxClasspath());
+
+        Path existingJar = Files.createFile(tempDir.resolve("existing.jar"));
+        String classpathWithNotExistingDir = existingJar + File.pathSeparator + notExistingDirectory;
+        configuration.setAuxClasspath(classpathWithNotExistingDir);
+        assertEquals(classpathWithNotExistingDir, configuration.getAuxClasspath());
+
+        Path existingDirectory = Files.createDirectory(tempDir.resolve("existingDirectory"));
+        String classpath = existingJar + File.pathSeparator + existingDirectory;
+        configuration.setAuxClasspath(classpath);
+        assertEquals(classpath, configuration.getAuxClasspath());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -7,21 +7,20 @@ package net.sourceforge.pmd;
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -30,14 +29,16 @@ import org.junit.jupiter.api.io.TempDir;
 
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
-import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
 import net.sourceforge.pmd.lang.CpdOnlyDummyLanguage;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.RulePriority;
 import net.sourceforge.pmd.renderers.CSVRenderer;
 import net.sourceforge.pmd.renderers.Renderer;
+import net.sourceforge.pmd.util.CollectionUtil;
 
 class PmdConfigurationTest {
+    @TempDir
+    private Path tempDir;
 
     @Test
     void testSuppressMarker() {
@@ -56,64 +57,104 @@ class PmdConfigurationTest {
     }
 
     @Test
-    void testClassLoader() {
+    void testClassLoader() throws IOException {
         PMDConfiguration configuration = new PMDConfiguration();
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Default ClassLoader");
-        configuration.prependAuxClasspath("some.jar");
-        assertEquals(ClasspathClassLoader.class, configuration.getClassLoader().getClass(),
-                "Prepended ClassLoader class");
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(1, urls.length, "urls length");
-        assertTrue(urls[0].toString().endsWith("/some.jar"), "url[0]");
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader().getParent(),
-                "parent classLoader");
+        assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Default ClassLoader");
+        assertNull(configuration.getAuxClasspath(), "Default AuxClasspath should be null");
+
+        String someJar = Files.createFile(tempDir.resolve("some.jar")).toString();
+        configuration.prependAuxClasspath(someJar);
+        assertEquals(someJar, configuration.getAuxClasspath(), "auxClasspath is missing some.jar");
+        // new since 7.27.0 - no classloader is created eagerly anymore
+        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
+
+        // reset auxClasspath
+        configuration.setAuxClasspath(null);
+        assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Revert to default ClassLoader");
+        assertNull(configuration.getAuxClasspath(), "Default AuxClasspath should be null");
+
+        // reset classLoader
         configuration.setClassLoader(null);
-        assertEquals(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(),
-                "Revert to default ClassLoader");
+        assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Revert to default ClassLoader");
+    }
+
+    /**
+     * @deprecated Since 7.27.0. Only tests a deprecated API
+     */
+    @Test
+    @Deprecated
+    void testExternallySetClassLoader() {
+        PMDConfiguration configuration = new PMDConfiguration();
+        assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Default ClassLoader");
+        assertNull(configuration.getAuxClasspath(), "Default AuxClasspath should be null");
+
+        configuration.setClassLoader(PmdConfigurationTest.class.getClassLoader());
+        assertSame(PmdConfigurationTest.class.getClassLoader(), configuration.getClassLoader(), "Not anymore the default ClassLoader");
+
+        // reset
+        configuration.setClassLoader(null);
+        assertSame(PMDConfiguration.class.getClassLoader(), configuration.getClassLoader(), "Revert to default ClassLoader");
     }
 
     @Test
     void auxClasspathWithRelativeFileEmpty() {
         String relativeFilePath = "src/test/resources/net/sourceforge/pmd/auxclasspath-empty.cp";
         PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(0, urls.length);
+        String auxClasspath = "file:" + relativeFilePath;
+        configuration.prependAuxClasspath(auxClasspath);
+        assertEquals(auxClasspath, configuration.getAuxClasspath());
+
+        // new since 7.27.0 - no classloader is created eagerly anymore
+        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
     }
 
     @Test
     void auxClasspathWithRelativeFileEmpty2() {
         String relativeFilePath = "./src/test/resources/net/sourceforge/pmd/auxclasspath-empty.cp";
         PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        assertEquals(0, urls.length);
+        String auxClasspath = "file:" + relativeFilePath;
+        configuration.prependAuxClasspath(auxClasspath);
+        assertEquals(auxClasspath, configuration.getAuxClasspath());
+
+        // new since 7.27.0 - no classloader is created eagerly anymore
+        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
     }
 
     @Test
-    void auxClasspathWithRelativeFile() throws URISyntaxException {
-        final String FILE_SCHEME = "file";
+    void auxClasspathWithRelativeFile() throws IOException {
+        // Prepare auxclasspath.cp file and jar files
+        Path currentWorkdirDir = Paths.get(".").toAbsolutePath();
+        Path lib1Jar = Files.createFile(tempDir.resolve("lib1.jar")).toAbsolutePath();
+        Path lib2Jar = Files.createFile(Files.createDirectories(tempDir.resolve("other/directory")).resolve("lib2.jar")).toAbsolutePath();
+        Path lib3Jar = Files.createFile(tempDir.resolve("lib3.jar")).toAbsolutePath();
+        Path classes = Files.createDirectory(tempDir.resolve("classes")).toAbsolutePath();
+        Path classes2 = Files.createDirectory(tempDir.resolve("classes2")).toAbsolutePath();
+        Path classes3 = Files.createDirectory(tempDir.resolve("classes3")).toAbsolutePath();
+        Path dirWithSpaces = Files.createDirectories(tempDir.resolve("relative source dir/bar")).toAbsolutePath();
+        Path auxClasspathFile = tempDir.resolve("auxclasspath.cp");
+        Files.write(auxClasspathFile, CollectionUtil.listOf(
+                "# relative paths here should be resolved relative to the current working directory - not relative to this file",
+                currentWorkdirDir.relativize(lib1Jar).toString(),
+                currentWorkdirDir.relativize(lib2Jar).toString(),
+                "# absolute paths work as well",
+                lib3Jar.toString(),
+                "# also directories are possible",
+                currentWorkdirDir.relativize(classes).toString(),
+                currentWorkdirDir.relativize(classes2) + File.separator,
+                classes3.toString(),
+                "# relative current directory",
+                ".",
+                "# a test with a space in the uri",
+                currentWorkdirDir.relativize(dirWithSpaces).toString()
+        ));
 
-        String currentWorkingDirectory = new File("").getAbsoluteFile().toURI().getPath();
-        String relativeFilePath = "src/test/resources/net/sourceforge/pmd/auxclasspath.cp";
         PMDConfiguration configuration = new PMDConfiguration();
-        configuration.prependAuxClasspath("file:" + relativeFilePath);
-        URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-        URI[] uris = new URI[urls.length];
-        for (int i = 0; i < urls.length; i++) {
-            uris[i] = urls[i].toURI();
-        }
-        URI[] expectedUris = new URI[] {
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "lib1.jar", null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "other/directory/lib2.jar", null),
-            new URI(FILE_SCHEME, null, new File("/home/jondoe/libs/lib3.jar").getAbsoluteFile().toURI().getPath(), null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "classes", null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "classes2", null),
-            new URI(FILE_SCHEME, null, new File("/home/jondoe/classes").getAbsoluteFile().toURI().getPath(), null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory, null),
-            new URI(FILE_SCHEME, null, currentWorkingDirectory + "relative source dir/bar", null),
-        };
-        assertArrayEquals(expectedUris, uris);
+        String auxClasspath = "file:" + currentWorkdirDir.relativize(auxClasspathFile);
+        configuration.prependAuxClasspath(auxClasspath);
+        assertEquals(auxClasspath, configuration.getAuxClasspath());
+
+        // new since 7.27.0 - no classloader is created eagerly anymore
+        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -103,6 +103,18 @@ class PmdConfigurationTest {
     }
 
     @Test
+    void auxClasspathWithAbsoluteFileEmpty() throws IOException {
+        Path file = Files.createFile(tempDir.resolve("auxclasspath-empty.cp").toAbsolutePath());
+        PMDConfiguration configuration = new PMDConfiguration();
+        String auxClasspath = file.toUri().toString();
+        configuration.prependAuxClasspath(auxClasspath);
+        assertEquals(auxClasspath, configuration.getAuxClasspath());
+
+        // new since 7.27.0 - no classloader is created eagerly anymore
+        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
+    }
+
+    @Test
     void auxClasspathWithRelativeFileEmpty() {
         String relativeFilePath = "src/test/resources/net/sourceforge/pmd/auxclasspath-empty.cp";
         PMDConfiguration configuration = new PMDConfiguration();
@@ -137,7 +149,6 @@ class PmdConfigurationTest {
         Files.createDirectory(targetTempDir);
 
         try {
-
             // Prepare auxclasspath.cp file and jar files
             Path currentWorkdirDir = Paths.get(".").toAbsolutePath();
             Path lib1Jar = Files.createFile(targetTempDir.resolve("lib1.jar")).toAbsolutePath();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdConfigurationTest.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.io.TempDirDeletionStrategy;
 
 import net.sourceforge.pmd.cache.internal.FileAnalysisCache;
 import net.sourceforge.pmd.cache.internal.NoopAnalysisCache;
@@ -122,39 +123,52 @@ class PmdConfigurationTest {
 
     @Test
     void auxClasspathWithRelativeFile() throws IOException {
-        // Prepare auxclasspath.cp file and jar files
-        Path currentWorkdirDir = Paths.get(".").toAbsolutePath();
-        Path lib1Jar = Files.createFile(tempDir.resolve("lib1.jar")).toAbsolutePath();
-        Path lib2Jar = Files.createFile(Files.createDirectories(tempDir.resolve("other/directory")).resolve("lib2.jar")).toAbsolutePath();
-        Path lib3Jar = Files.createFile(tempDir.resolve("lib3.jar")).toAbsolutePath();
-        Path classes = Files.createDirectory(tempDir.resolve("classes")).toAbsolutePath();
-        Path classes2 = Files.createDirectory(tempDir.resolve("classes2")).toAbsolutePath();
-        Path classes3 = Files.createDirectory(tempDir.resolve("classes3")).toAbsolutePath();
-        Path dirWithSpaces = Files.createDirectories(tempDir.resolve("relative source dir/bar")).toAbsolutePath();
-        Path auxClasspathFile = tempDir.resolve("auxclasspath.cp");
-        Files.write(auxClasspathFile, CollectionUtil.listOf(
-                "# relative paths here should be resolved relative to the current working directory - not relative to this file",
-                currentWorkdirDir.relativize(lib1Jar).toString(),
-                currentWorkdirDir.relativize(lib2Jar).toString(),
-                "# absolute paths work as well",
-                lib3Jar.toString(),
-                "# also directories are possible",
-                currentWorkdirDir.relativize(classes).toString(),
-                currentWorkdirDir.relativize(classes2) + File.separator,
-                classes3.toString(),
-                "# relative current directory",
-                ".",
-                "# a test with a space in the uri",
-                currentWorkdirDir.relativize(dirWithSpaces).toString()
-        ));
+        // when this test runs on a GitHub-hosted Runner under Windows, then the current
+        // working directory is on a different drive then the tempDir and we can't
+        // create relative paths from working directory to tempDir.
+        // That's why we prepare the files for the classpath under the current working directory
+        // target/tempdir - which is repo-root/pmd-core/target/tempdir
+        Path targetTempDir = Paths.get("target/tempdir").toAbsolutePath();
+        Files.createDirectory(targetTempDir);
 
-        PMDConfiguration configuration = new PMDConfiguration();
-        String auxClasspath = "file:" + currentWorkdirDir.relativize(auxClasspathFile);
-        configuration.prependAuxClasspath(auxClasspath);
-        assertEquals(auxClasspath, configuration.getAuxClasspath());
+        try {
 
-        // new since 7.27.0 - no classloader is created eagerly anymore
-        assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
+            // Prepare auxclasspath.cp file and jar files
+            Path currentWorkdirDir = Paths.get(".").toAbsolutePath();
+            Path lib1Jar = Files.createFile(targetTempDir.resolve("lib1.jar")).toAbsolutePath();
+            Path lib2Jar = Files.createFile(Files.createDirectories(targetTempDir.resolve("other/directory")).resolve("lib2.jar")).toAbsolutePath();
+            Path lib3Jar = Files.createFile(targetTempDir.resolve("lib3.jar")).toAbsolutePath();
+            Path classes = Files.createDirectory(targetTempDir.resolve("classes")).toAbsolutePath();
+            Path classes2 = Files.createDirectory(targetTempDir.resolve("classes2")).toAbsolutePath();
+            Path classes3 = Files.createDirectory(targetTempDir.resolve("classes3")).toAbsolutePath();
+            Path dirWithSpaces = Files.createDirectories(targetTempDir.resolve("relative source dir/bar")).toAbsolutePath();
+            Path auxClasspathFile = targetTempDir.resolve("auxclasspath.cp");
+            Files.write(auxClasspathFile, CollectionUtil.listOf(
+                    "# relative paths here should be resolved relative to the current working directory - not relative to this file",
+                    currentWorkdirDir.relativize(lib1Jar).toString(),
+                    currentWorkdirDir.relativize(lib2Jar).toString(),
+                    "# absolute paths work as well",
+                    lib3Jar.toString(),
+                    "# also directories are possible",
+                    currentWorkdirDir.relativize(classes).toString(),
+                    currentWorkdirDir.relativize(classes2) + File.separator,
+                    classes3.toString(),
+                    "# relative current directory",
+                    ".",
+                    "# a test with a space in the uri",
+                    currentWorkdirDir.relativize(dirWithSpaces).toString()
+            ));
+
+            PMDConfiguration configuration = new PMDConfiguration();
+            String auxClasspath = "file:" + currentWorkdirDir.relativize(auxClasspathFile);
+            configuration.prependAuxClasspath(auxClasspath);
+            assertEquals(auxClasspath, configuration.getAuxClasspath());
+
+            // new since 7.27.0 - no classloader is created eagerly anymore
+            assertNull(configuration.getClassLoader(), "ClassLoader should be null - not used");
+        } finally {
+            TempDirDeletionStrategy.Standard.INSTANCE.delete(targetTempDir, null, null);
+        }
     }
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
@@ -15,8 +15,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
+import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
+import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.internal.JavaLanguageProperties;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
@@ -43,10 +45,10 @@ class ClassLoadingChildFirstTest {
                 getClass().getPackage().getName().replace('.', '/'),
                 "custom_java_lang.jar");
 
-        PMDConfiguration config = new PMDConfiguration();
-        config.prependAuxClasspath(file.toAbsolutePath().toString());
+        JavaLanguageProperties languageProperties = (JavaLanguageProperties) JavaLanguageModule.getInstance().newPropertyBundle();
+        languageProperties.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, file.toAbsolutePath().toString());
 
-        TypeSystem typeSystem = TypeSystem.usingClassLoaderClasspath(config.getClassLoader());
+        TypeSystem typeSystem = TypeSystem.usingClassLoaderClasspath(languageProperties.getAnalysisClassLoader());
 
         JClassType voidClass = typeSystem.BOXED_VOID;
         List<JMethodSymbol> declaredMethods = voidClass.getSymbol().getDeclaredMethods();


### PR DESCRIPTION
## Describe the PR

This is my new attempt on fixing #4953.
We keep it simple: PMDConfiguration just manages now a String, which is the auxClasspath. No Classloader anymore, no fancy API (like Classpath...).

This also fixes the problem, that Kotlin is currently facing. Setting the `--aux-classpath` CLI parameter never ended up in JvmLanguagePropertyBundle#AUX_CLASSPATH . The only way was setting the property programmatically. Now the classloader is created not by PMDConfiguration, but by JvmLanguagePropertyBundle (the code was already there but mostly unused). This means, that this commit https://github.com/pmd/pmd/pull/6645/changes/4c043ae7791ede2877c056433258012fcfd5f853 is not needed anymore.

:warning: There is one behavioral change: The provided auxClasspath is verified: If there are any jar files referenced, which don't exist, PMD will throw. This helps when PMD is called with invalid parameters resulting in an incomplete classpath. Related to #5064.

This PR replaces the old PRs #6312 and #6398

## Related issues

- Fix #4952 
- Fix #4953
- Close #6312 
- Close #6398

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

