### PR TITLE
[java] Fix AvoidThrowingNewInstanceOfSameException false positive

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -31,6 +31,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
 * java-codestyle
   * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
+* java-design
+  * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
 * java-errorprone
   * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -118,6 +118,7 @@ code size and runtime complexity.
     [count(Block/*) = 1]
     [CatchParameter/ClassType/@SimpleName = Block/ThrowStatement/ConstructorCall/ClassType/@SimpleName]
     [Block/ThrowStatement/ConstructorCall/ArgumentList/@Size = 1]
+    [Block/ThrowStatement/ConstructorCall/ArgumentList//VariableAccess/@Name = CatchParameter/VariableId/@Name]
     /Block/ThrowStatement/ConstructorCall
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNewInstanceOfSameException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNewInstanceOfSameException.xml
@@ -143,4 +143,25 @@ class SomeException extends Exception {}
 class OtherException extends Exception {}
         ]]></code>
     </test-code>
+
+<test-code>
+        <description>#6844 new instance of same exception type with unrelated message, ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Tree parseMethod(String methodSource) {
+        Tree member;
+        try {
+            member = parseTypeMember(methodSource);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid method: " + methodSource);
+        }
+        return member;
+    }
+    Tree parseTypeMember(String s) { return null; }
+}
+class Tree {}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNewInstanceOfSameException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNewInstanceOfSameException.xml
@@ -144,7 +144,7 @@ class OtherException extends Exception {}
         ]]></code>
     </test-code>
 
-<test-code>
+    <test-code>
         <description>#6844 new instance of same exception type with unrelated message, ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR
The `AvoidThrowingNewInstanceOfSameException` rule flagged catch blocks that throw
a new instance of the same exception type, even when the new exception doesn't
reference the caught exception at all (e.g. a brand new message string).

For example, this was incorrectly flagged:
```java
catch (IllegalArgumentException e) {
    throw new IllegalArgumentException("Invalid method: " + methodSource);
}
```

The rule's XPath checked that the constructor call had exactly one argument of
the same exception type, but never checked that the argument actually referenced
the caught exception. This fix adds a check that the constructor argument
references the caught exception variable, either directly (`throw new Foo(e)`)
or as a method-call receiver (`throw new Foo(e.getMessage())`).

## Related issues
- Fixes #6844

## Ready?
- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)