### PR TITLE
[java] chore: Add test for ReportStatsListener

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
  *
  * @param <T> Type of the result
  */
-// TODO remove implements AutoCloseable.
+// TODO: PMD 8: remove implements AutoCloseable.
 // Implementing AutoCloseable implies that the class is intended to be used with try-with-resources.
 // A BaseResultProducingCloseable is supposed to produce a result AFTER it has been closed,
 // which won't work inside a try-with-resources. At that point is has gone out of scope.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
@@ -8,11 +8,15 @@ import java.io.Closeable;
 import java.util.function.Consumer;
 
 /**
- * Base class for an autocloseable that produce a result once it has
+ * Base class for a class that produces a result once it has
  * been closed. None of the methods of this class are synchronized.
  *
  * @param <T> Type of the result
  */
+// TODO remove implements AutoCloseable.
+// Implementing AutoCloseable implies that the class is intended to be used with try-with-resources.
+// A BaseResultProducingCloseable is supposed to produce a result AFTER it has been closed,
+// which won't work inside a try-with-resources. At that point is has gone out of scope.
 public abstract class BaseResultProducingCloseable<T> implements AutoCloseable {
 
     private boolean closed;
@@ -50,7 +54,8 @@ public abstract class BaseResultProducingCloseable<T> implements AutoCloseable {
 
     /**
      * Close this closeable as per the contract of {@link Closeable#close()}.
-     * Called exactly once. By default does nothing.
+     * Called exactly once.
+     * @implSpec This implementation is empty.
      */
     protected void closeImpl() {
         // override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportStatsListenerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportStatsListenerTest.java
@@ -1,0 +1,75 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.reporting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class ReportStatsListenerTest {
+
+    /**
+     * This test fires events from multiple threads and checks that the total number matches in the end.
+     */
+    @Test
+    void testConcurrency() throws InterruptedException {
+        int numFiles = 1000;
+
+        int totalErrors = 0;
+        int totalViolations = 0;
+
+        Random r = new Random();
+
+        ReportStatsListener subject = new ReportStatsListener();
+
+        ExecutorService executor = Executors.newFixedThreadPool(numFiles);
+
+        for (int i = 0; i < numFiles; i++) {
+            int numErrors = r.nextInt(10);
+            int numViolations = r.nextInt(100);
+
+            totalErrors += numErrors;
+            totalViolations += numViolations;
+
+            executor.submit(() -> {
+                try (FileAnalysisListener fileAnalysisListener = subject.startFileAnalysis(null)) {
+                    List<Runnable> events = new ArrayList<>();
+                    for (int j = 0; j < numErrors; j++) {
+                        events.add(() -> fileAnalysisListener.onError(null));
+                    }
+                    for (int j = 0; j < numViolations; j++) {
+                        events.add(() -> fileAnalysisListener.onRuleViolation(null));
+                    }
+                    Collections.shuffle(events);
+
+                    for (Runnable event : events) {
+                        event.run();
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        // If we ever update to Java >= 19, replace the following two lines with executor.close() (or try-with-resources)
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+
+        subject.close();
+
+        ReportStats stats = subject.getResult();
+
+        assertEquals(totalErrors, stats.getNumErrors());
+        assertEquals(totalViolations, stats.getNumViolations());
+    }
+}


### PR DESCRIPTION
## Describe the PR

This PR does 2 things:

* Add a test that exercises `ReportStatsListener` using multiple threads. The class is intended to be used from multiple threads. The implementation is kinda-simple - but it's still better to have a test.
* Add a note to `BaseResultProducingCloseable` (the base class for `ReportStatsListener`), explaining why it shouldn't be `AutoCloseable`. Actually removing `implements AutoCloseable` would be a breaking change, so this has to wait until PMD 8.

## Related issues

- None

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

