### PR TITLE
[core] Fix #6865: Improve missing rule reference error

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
     * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
+    * [#6865](https://github.com/pmd/pmd/issues/6865): \[core] Include the running PMD version in the "Unable to find referenced rule" error
 * java
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
@@ -535,9 +535,11 @@ final class RuleSetFactory {
 
         if (referencedRule == null) {
             throw err.at(ruleNode).error(
-                "Unable to find referenced rule {0}"
-                    + "; perhaps the rule name is misspelled?",
-                otherRuleSetReferenceId.getRuleName());
+                "Unable to find rule ''{0}'' in ruleset ''{1}'' (PMD {2})."
+                    + " Check the spelling and whether the rule is available in this PMD version.",
+                otherRuleSetReferenceId.getRuleName(),
+                otherRuleSetReferenceId.getRuleSetFileName(),
+                PMDVersion.VERSION);
         }
 
         if (warnDeprecated && referencedRule.isDeprecated()) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryMessagesTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryMessagesTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.util.internal.xml.SchemaConstants;
 import net.sourceforge.pmd.util.internal.xml.XmlErrorMessages;
 
@@ -39,6 +40,22 @@ class RuleSetFactoryMessagesTest extends RulesetFactoryTestBase {
                 + " 8| <rule name=\"MockRuleName\" language=\"dummy\" class=\"net.sourceforge.pmd.lang.rule.MockRuleWithNoProperties\" message=\"avoid the mock rule\">\n"
                 + " 9| <priority>not a priority</priority></rule></ruleset>\n"
                 + "    ^^^^^^^^^ Not a valid priority: 'not a priority', expected a number in [1,5]"
+        ));
+    }
+
+    @Test
+    void testMissingRuleReferenceMessage() throws Exception {
+        String ruleset = "net/sourceforge/pmd/lang/rule/TestRuleset1.xml";
+        String missingRule = "ThisRuleDoesNotExist";
+
+        String log = SystemLambda.tapSystemErr(() -> assertCannotParse(
+            rulesetXml(ruleRef(ruleset + "/" + missingRule))
+        ));
+
+        assertThat(log, containsString(
+            "Unable to find rule '" + missingRule + "' in ruleset '" + ruleset
+                + "' (PMD " + PMDVersion.VERSION + "). Check the spelling and whether the rule is available"
+                + " in this PMD version."
         ));
     }
 


### PR DESCRIPTION
## Describe the PR

When a ruleset references a rule that is not available in the running PMD version, the current error only suggests that the rule name may be misspelled. This makes version mismatches difficult to identify, especially when PMD is bundled by another tool.

This change improves the diagnostic by:

- including the referenced ruleset and the running PMD version;
- replacing the misspelling-only hint with a neutral suggestion to verify whether the rule is available in that PMD version;
- adding regression coverage for the rendered error message in `RuleSetFactoryMessagesTest`;
- documenting the fix in the release notes.

For example, the error now provides enough context to distinguish a typo from a version mismatch:

```text
Unable to find rule 'ThisRuleDoesNotExist' in ruleset 'category/apex/errorprone.xml' (PMD 7.25.0). Check the spelling and whether the rule is available in this PMD version.
```

This does not change ruleset loading behavior. An unresolved rule reference remains a fatal validation error.

### Validation

- `git diff --check` passes.
- `./mvnw -pl pmd-core -Dtest=RuleSetFactoryMessagesTest,RuleSetFactoryTest test` passes (67 tests, 0 failures, 0 errors, 0 skipped).
- `./mvnw clean verify` passes (44 modules, including 31 distribution integration tests; `BUILD SUCCESS`).

## Related issues

- Fix #6865

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
