### PR TITLE
[java] Fix #6768: Resolve record component types before inference

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core
   * [#1995](https://github.com/pmd/pmd/issues/1995): \[core] PMD should display number of rules violated or errors found
+* java
+  * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
 * java-bestpractices
   * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
   * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableResolver.java
@@ -52,6 +52,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTLoopStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTPattern;
+import net.sourceforge.pmd.lang.java.ast.ASTRecordComponent;
+import net.sourceforge.pmd.lang.java.ast.ASTRecordComponentList;
 import net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTResource;
 import net.sourceforge.pmd.lang.java.ast.ASTResourceList;
@@ -301,7 +303,12 @@ public final class SymbolTableResolver {
             setTopSymbolTable(node.getBody());
             if (node instanceof ASTRecordDeclaration) {
                 // Members of a record declaration are in scope in the record header.
-                setTopSymbolTable(node.getRecordComponents());
+                ASTRecordComponentList components = ((ASTRecordDeclaration) node).getRecordComponents();
+                setTopSymbolTable(components);
+                // Synthesized accessor signatures may be requested while processing the body.
+                f.disambig(components.children(ASTRecordComponent.class)
+                               .map(ASTRecordComponent::getTypeNode),
+                           bodyCtx);
             }
 
             // preprocess siblings

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SymbolTableResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SymbolTableResolverTest.java
@@ -14,6 +14,21 @@ import net.sourceforge.pmd.lang.java.BaseParserTest;
 
 class SymbolTableResolverTest extends BaseParserTest {
     @Test
+    void recordComponentTypeShouldBeResolvedBeforeAnonymousClassInference() {
+        ASTCompilationUnit compilationUnit = java.withDefaultVersion("16").parse(
+                "public class J {\n"
+                + "    record Actor(String userView) {}\n"
+                + "    static Object convert(Object a, Object b) { return null; }\n"
+                + "    Object make(Actor actor) { return convert(actor.userView(), new Object() {}); }\n"
+                + "}");
+        ASTRecordDeclaration record = compilationUnit.descendants(ASTRecordDeclaration.class)
+                .crossFindBoundaries().firstOrThrow();
+        ASTRecordComponent component = record.getRecordComponents()
+                .children(ASTRecordComponent.class).firstOrThrow();
+        assertNotNull(((ASTClassType) component.getTypeNode()).getReferencedSym());
+    }
+
+    @Test
     void allClassTypesShouldHaveSymbol() {
         ASTCompilationUnit compilationUnit = parseCode(
                 "import java.util.*;\n"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SymbolTableResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SymbolTableResolverTest.java
@@ -14,21 +14,6 @@ import net.sourceforge.pmd.lang.java.BaseParserTest;
 
 class SymbolTableResolverTest extends BaseParserTest {
     @Test
-    void recordComponentTypeShouldBeResolvedBeforeAnonymousClassInference() {
-        ASTCompilationUnit compilationUnit = java.withDefaultVersion("16").parse(
-                "public class J {\n"
-                + "    record Actor(String userView) {}\n"
-                + "    static Object convert(Object a, Object b) { return null; }\n"
-                + "    Object make(Actor actor) { return convert(actor.userView(), new Object() {}); }\n"
-                + "}");
-        ASTRecordDeclaration record = compilationUnit.descendants(ASTRecordDeclaration.class)
-                .crossFindBoundaries().firstOrThrow();
-        ASTRecordComponent component = record.getRecordComponents()
-                .children(ASTRecordComponent.class).firstOrThrow();
-        assertNotNull(((ASTClassType) component.getTypeNode()).getReferencedSym());
-    }
-
-    @Test
     void allClassTypesShouldHaveSymbol() {
         ASTCompilationUnit compilationUnit = parseCode(
                 "import java.util.*;\n"
@@ -46,5 +31,20 @@ class SymbolTableResolverTest extends BaseParserTest {
         for (ASTClassType type : types) {
             assertNotNull(type.getReferencedSym());
         }
+    }
+
+    @Test
+    void recordComponentTypeShouldBeResolvedBeforeAnonymousClassInference() {
+        ASTCompilationUnit compilationUnit = java.withDefaultVersion("16").parse(
+                "public class J {\n"
+                        + "    record Actor(String userView) {}\n"
+                        + "    static Object convert(Object a, Object b) { return null; }\n"
+                        + "    Object make(Actor actor) { return convert(actor.userView(), new Object() {}); }\n"
+                        + "}");
+        ASTRecordDeclaration record = compilationUnit.descendants(ASTRecordDeclaration.class)
+                .crossFindBoundaries().firstOrThrow();
+        ASTRecordComponent component = record.getRecordComponents()
+                .children(ASTRecordComponent.class).firstOrThrow();
+        assertNotNull(((ASTClassType) component.getTypeNode()).getReferencedSym());
     }
 }


### PR DESCRIPTION
## Describe the PR

Record component types were excluded from early type-header disambiguation so
that record members remain in scope in the record header. However, their type
nodes were not disambiguated after the record body symbol table was installed.

When an anonymous-class argument causes type inference to inspect a sibling
implicit record accessor, the accessor return type therefore reads an unresolved
`ASTClassType` and throws an `IllegalStateException`.

This PR disambiguates only the record component type nodes after applying the
record body scope and before processing body declarations. It also adds a
regression test based on the original reproducer.

This prevents the processing error without changing record accessor or type
inference behavior.

## Related issues

- Fix #6768

## Validation

- Reproduced the processing error with PMD 7.27.0-SNAPSHOT
  (`283f0cba781c2057276cf4049bbe0c4878e9e8ea`), exit code 5
- Recompiled the modified `SymbolTableResolver` against the same snapshot and
  confirmed the reproducer completes with exit code 0
- Checked generic, nested-type, varargs, primitive, annotated, and unresolved
  record component cases
- `./mvnw -pl pmd-java -am -Dtest=SymbolTableResolverTest -Dsurefire.failIfNoSpecifiedTests=false test`
  (2 tests, 0 failures, 0 errors)
- `./mvnw -pl pmd-java -am test`
  (9,751 PMD Java tests, 0 failures, 0 errors, 20 skipped)
- `./mvnw clean verify` (all 44 reactor modules succeeded)
- `git diff --check`

## Ready?

- [x] Added unit tests for fixed bug
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes
- [x] Added in-code documentation where needed
