### PR TITLE
[java] CommentRequired: add packageMethodCommentRequirement property

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -24,6 +24,14 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚀️ New and noteworthy
 
+#### Changed Rules
+* The Java rule [`CommentRequired`](https://docs.pmd-code.org/pmd-doc-7.27.0-SNAPSHOT/pmd_rules_java_documentation.html#commentrequired)
+  has a new property `packageMethodCommentRequirement`. It controls whether Javadoc comments are required (or
+  unwanted) for package-private methods and constructors. Previously, only `public` and `protected` methods could
+  be configured (via `publicMethodCommentRequirement` and `protectedMethodCommentRequirement`). The new property
+  defaults to `Ignored`, so existing rule configurations are unaffected.
+  This was implemented in [#6880](https://github.com/pmd/pmd/pull/6880).
+
 ### 🐛️ Fixed Issues
 * chore
   * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -52,6 +52,9 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
         = requirementPropertyBuilder("publicMethodCommentRequirement", "Public method and constructor comments").build();
     private static final PropertyDescriptor<CommentRequirement> PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("protectedMethodCommentRequirement", "Protected method constructor comments").build();
+    private static final PropertyDescriptor<CommentRequirement> PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR
+        = requirementPropertyBuilder("packageMethodCommentRequirement", "Package-private method and constructor comments")
+        .defaultValue(CommentRequirement.IGNORED).build();
     private static final PropertyDescriptor<CommentRequirement> ENUM_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("enumCommentRequirement", "Enum comments").build();
     private static final PropertyDescriptor<CommentRequirement> SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR
@@ -72,6 +75,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
         definePropertyDescriptor(FIELD_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
+        definePropertyDescriptor(PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(ENUM_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(SERIAL_PERSISTENT_FIELDS_CMT_REQUIREMENT_DESCRIPTOR);
@@ -84,6 +88,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
         propertyValues.put(FIELD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(FIELD_CMT_REQUIREMENT_DESCRIPTOR));
         propertyValues.put(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR));
         propertyValues.put(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR));
         propertyValues.put(ENUM_CMT_REQUIREMENT_DESCRIPTOR, getProperty(ENUM_CMT_REQUIREMENT_DESCRIPTOR));
         propertyValues.put(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR,
                 getProperty(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR));
@@ -155,6 +160,8 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
             checkCommentMeetsRequirement(data, decl, PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
         } else if (decl.getVisibility() == Visibility.V_PROTECTED) {
             checkCommentMeetsRequirement(data, decl, PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
+        } else if (decl.getVisibility() == Visibility.V_PACKAGE) {
+            checkCommentMeetsRequirement(data, decl, PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
         }
     }
 
@@ -187,6 +194,7 @@ public class CommentRequiredRule extends AbstractJavaRulechainRule {
                 && getProperty(FIELD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
                 && getProperty(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
                 && getProperty(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
+                && getProperty(PACKAGE_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
                 && getProperty(ENUM_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
                 && getProperty(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED
                 && getProperty(SERIAL_PERSISTENT_FIELDS_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.IGNORED;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
@@ -83,6 +83,68 @@ public class Foo {
         <code-ref id="with-all-comments"/>
     </test-code>
 
+    <code-fragment id="package-private-without-comments"><![CDATA[
+public class Foo {
+    Foo(int a) {}
+    void doNothing() {}
+    void doSomething() {}
+}
+    ]]></code-fragment>
+
+    <code-fragment id="package-private-with-comments"><![CDATA[
+public class Foo {
+    /** Constructor comment. */
+    Foo(int a) {}
+    /** Method comment. */
+    void doNothing() {}
+    /** Another method comment. */
+    void doSomething() {}
+}
+    ]]></code-fragment>
+
+    <test-code>
+        <description>[java] Package-private methods and constructors required but missing comments</description>
+        <rule-property name="classCommentRequirement">ignored</rule-property>
+        <rule-property name="packageMethodCommentRequirement">required</rule-property>
+        <expected-problems>3</expected-problems>
+        <code-ref id="package-private-without-comments"/>
+    </test-code>
+
+    <test-code>
+        <description>[java] Package-private methods and constructors required and present</description>
+        <rule-property name="classCommentRequirement">ignored</rule-property>
+        <rule-property name="packageMethodCommentRequirement">required</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="package-private-with-comments"/>
+    </test-code>
+
+    <test-code>
+        <description>[java] Package-private methods ignored by default (backwards compatible)</description>
+        <rule-property name="classCommentRequirement">ignored</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="package-private-without-comments"/>
+    </test-code>
+
+    <test-code>
+        <description>[java] Package-private methods unwanted but present</description>
+        <rule-property name="classCommentRequirement">ignored</rule-property>
+        <rule-property name="packageMethodCommentRequirement">unwanted</rule-property>
+        <expected-problems>3</expected-problems>
+        <code-ref id="package-private-with-comments"/>
+    </test-code>
+
+    <test-code>
+        <description>[java] Package-private requirement does not affect public or protected methods</description>
+        <rule-property name="classCommentRequirement">ignored</rule-property>
+        <rule-property name="fieldCommentRequirement">ignored</rule-property>
+        <rule-property name="publicMethodCommentRequirement">ignored</rule-property>
+        <rule-property name="enumCommentRequirement">ignored</rule-property>
+        <rule-property name="packageMethodCommentRequirement">required</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="without-any-comments"/>
+    </test-code>
+
+
     <test-code>
         <description>#1115 commentRequiredRule in pmd 5.1 is not working properly</description>
         <expected-problems>2</expected-problems>


### PR DESCRIPTION
## Describe the PR

**Rule:** [CommentRequired](https://docs.pmd-code.org/latest/pmd_rules_java_documentation.html#commentrequired)

This PR adds a new property `packageMethodCommentRequirement` to the `CommentRequired` rule. It controls whether Javadoc comments are required (or unwanted) for **package-private methods and constructors**.

Previously, method/constructor comment requirements could only be configured for `public` (`publicMethodCommentRequirement`) and `protected` (`protectedMethodCommentRequirement`) visibility. Package-private members were silently ignored, with no way to enforce documentation on them.

Implementation notes:
- Uses `ASTExecutableDeclaration.getVisibility() == V_PACKAGE`, which correctly distinguishes genuinely package-private members from `public`/`protected` members that merely reside in a package-private class.
- Reuses the existing `getJavadocComment()` mechanism, consistent with how the other visibility levels are handled.
- The new property defaults to `Ignored`, so existing rule configurations are completely unaffected and no new violations appear for current users.

Note: this is distinct from the package-level Javadoc idea discussed in #1683 — that concerned `package-info.java`, whereas this targets package-private methods and constructors.

## Related issues

No dedicated issue yet; happy to open one or start a discussion if preferred.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes
- [x] Added (in-code) documentation (if needed)
