### PR TITLE
[apex][visualforce] Update apex-ls from 6.0.2 to 6.1.0

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>io.github.apex-dev-tools</groupId>
             <artifactId>apex-ls_2.13</artifactId>
-            <version>6.0.2</version>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.apex-dev-tools</groupId>

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceRule.java
@@ -30,8 +30,8 @@ import com.google.common.reflect.ClassPath;
  *
  * @since 7.13.0
  * @implNote This finds the available system / schema types by searching for classes in the dependency
- *     io.github.apex-dev-tools:standard-types in the packages {@code com.nawforce.runforce.System}
- *     and {@code com.nawforce.runforce.Schema}.
+ *     io.github.apex-dev-tools:standard-types in the packages {@code io.github.apexdevtools.standardtypes.System}
+ *     and {@code io.github.apexdevtools.standardtypes.Schema}.
  */
 public class TypeShadowsBuiltInNamespaceRule extends AbstractRule {
     private static final ApexVisitor<RuleContext, Void> VISITOR = new Visitor();
@@ -52,7 +52,7 @@ public class TypeShadowsBuiltInNamespaceRule extends AbstractRule {
 
         private Visitor() {
             try {
-                String systemPackageName = com.nawforce.runforce.System.System.class.getPackage().getName();
+                String systemPackageName = io.github.apexdevtools.standardtypes.System.System.class.getPackage().getName();
                 systemTypes = ClassPath.from(ClassLoader.getSystemClassLoader())
                         .getTopLevelClasses(systemPackageName)
                         .stream()
@@ -60,7 +60,7 @@ public class TypeShadowsBuiltInNamespaceRule extends AbstractRule {
                         .map(s -> s.toLowerCase(Locale.ROOT))
                         .collect(Collectors.toSet());
 
-                String schemaPackageName = com.nawforce.runforce.Schema.SObjectType.class.getPackage().getName();
+                String schemaPackageName = io.github.apexdevtools.standardtypes.Schema.SObjectType.class.getPackage().getName();
                 schemaTypes = ClassPath.from(ClassLoader.getSystemClassLoader())
                         .getTopLevelClasses(schemaPackageName)
                         .stream()

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypes.java
@@ -74,7 +74,7 @@ class ObjectFieldTypes extends SalesforceFieldTypes {
             // and https://github.com/apex-dev-tools/sobject-types
             SOBJECTS = Collections.unmodifiableMap(
                     ClassPath.from(ClassLoader.getSystemClassLoader())
-                            .getTopLevelClasses(com.nawforce.runforce.SObjects.Account.class.getPackage().getName())
+                            .getTopLevelClasses(io.github.apexdevtools.sobjecttypes.Account.class.getPackage().getName())
                             .stream()
                             .collect(Collectors.toMap(c -> c.getSimpleName().toLowerCase(Locale.ROOT),
                                     Function.identity()))


### PR DESCRIPTION
## Describe the PR

io.github.apex-dev-tools:apex-ls_2.13:6.0.2 used io.github.apex-dev-tools:sobject-types:65.0.0 and io.github.apex-dev-tools:standard-types:65.0.0
io.github.apex-dev-tools:apex-ls_2.13:6.1.0 uses io.github.apex-dev-tools:sobject-types:67.0.0 and io.github.apex-dev-tools:standard-types:67.0.0

This PR updates apex-ls and fixes the package names, because sobject-types and standard-types completely redid their packages structure.

Is this a breaking change that we need to call out in the release notes?

## Related issues

- Closes #6856 
- See also #6862 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

