### PR TITLE
[kotlin] Fix #6891: Use KtModifiers container in AnnotationFqnAnnotator

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -57,6 +57,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
+    * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes
 
 ### 🚨️ API Changes
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/types/internal/AnnotationFqnAnnotator.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/types/internal/AnnotationFqnAnnotator.java
@@ -93,7 +93,7 @@ final class AnnotationFqnAnnotator {
         return declNode
                 .children(KtModifiers.class)
                 .children(KtAnnotation.class)
-                .children()
+                .children() // Either KtSingleAnnotation or KtMultiAnnotation
                 .children(KtUnescapedAnnotation.class)
                 .toList();
     }

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/types/internal/AnnotationFqnAnnotator.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/types/internal/AnnotationFqnAnnotator.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinNode;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtConstructorInvocation;
-import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtModifier;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtModifiers;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtSingleAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtUnescapedAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtUserType;
@@ -91,9 +91,9 @@ final class AnnotationFqnAnnotator {
      */
     private static List<KtUnescapedAnnotation> collectAnnotationNodes(KotlinNode declNode) {
         return declNode
-                .children(KtModifier.class)
+                .children(KtModifiers.class)
                 .children(KtAnnotation.class)
-                .children() // Either KtSingleAnnotation or KtMultiAnnotation
+                .children()
                 .children(KtUnescapedAnnotation.class)
                 .toList();
     }

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/types/internal/KotlinTypeAnnotationVisitorTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/types/internal/KotlinTypeAnnotationVisitorTest.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionValueParameter;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtKotlinFile;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtPropertyDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtSingleAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtUnescapedAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParsingHelper;
 import net.sourceforge.pmd.lang.kotlin.types.KotlinNodeTypeData;
@@ -227,6 +228,14 @@ class KotlinTypeAnnotationVisitorTest {
     void unescapedAnnotationOnFunctionHasTypeName() {
         KtKotlinFile root = PARSER.parse("@Deprecated(\"use X\") fun foo(): String = \"\"");
         KtUnescapedAnnotation ann = root.descendants(KtUnescapedAnnotation.class).first();
+        assertNotNull(ann);
+        assertEquals("kotlin.Deprecated", KotlinNodeTypeData.getTypeName(ann));
+    }
+
+    @Test
+    void singleAnnotationHasTypeName() {
+        KtKotlinFile root = PARSER.parse("@Deprecated(\"use X\") fun foo(): String = \"\"");
+        KtSingleAnnotation ann = root.descendants(KtSingleAnnotation.class).first();
         assertNotNull(ann);
         assertEquals("kotlin.Deprecated", KotlinNodeTypeData.getTypeName(ann));
     }

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/types/internal/KotlinTypeAnnotationVisitorTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/types/internal/KotlinTypeAnnotationVisitorTest.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionDeclaration;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtFunctionValueParameter;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtKotlinFile;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtPropertyDeclaration;
+import net.sourceforge.pmd.lang.kotlin.ast.KotlinParser.KtUnescapedAnnotation;
 import net.sourceforge.pmd.lang.kotlin.ast.KotlinParsingHelper;
 import net.sourceforge.pmd.lang.kotlin.types.KotlinNodeTypeData;
 
@@ -218,5 +219,15 @@ class KotlinTypeAnnotationVisitorTest {
         assertNotNull(prop);
         assertEquals(1, prop.getBeginLine(), "PMD node must start on line 1");
         assertEquals("kotlin.String", KotlinNodeTypeData.getTypeName(prop));
+    }
+
+    // --- Regression: #6891 KtModifiers vs KtModifier in collectAnnotationNodes ---
+
+    @Test
+    void unescapedAnnotationOnFunctionHasTypeName() {
+        KtKotlinFile root = PARSER.parse("@Deprecated(\"use X\") fun foo(): String = \"\"");
+        KtUnescapedAnnotation ann = root.descendants(KtUnescapedAnnotation.class).first();
+        assertNotNull(ann);
+        assertEquals("kotlin.Deprecated", KotlinNodeTypeData.getTypeName(ann));
     }
 }


### PR DESCRIPTION
Fixes #6891

`AnnotationFqnAnnotator.collectAnnotationNodes()` used `.children(KtModifier.class)`
but `KtModifier` (singular) is an individual modifier keyword — annotations live under
`KtModifiers` (plural, the container rule). The chain returned empty for all declaration
types, so `@TypeName` was never set on `UnescapedAnnotation`/`SingleAnnotation` nodes.

Fix: use `.children(KtModifiers.class)` as the first step.

Added regression test `unescapedAnnotationOnFunctionHasTypeName` in `KotlinTypeAnnotationVisitorTest`.