### PR TITLE
Fix Regression-Tester config: Replace Schedul-o-matic-9000 with declarative-lookup-rollup-summaries

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -193,10 +193,10 @@ EOF
   </project>
 
   <project>
-    <name>Schedul-o-matic-9000</name>
+    <name>declarative-lookup-rollup-summaries</name>
     <type>git</type>
-    <connection>https://github.com/SalesforceLabs/Schedul-o-matic-9000</connection>
-    <tag>6b1229ba43b38931fbbab5924bc9b9611d19a786</tag>
+    <connection>https://github.com/SFDO-Community/declarative-lookup-rollup-summaries</connection>
+    <tag>5dbd186bb057bc8aea13d24dcf94d561830376c1</tag>
     <cpd-options>
       <language>apex</language>
       <minimum-tokens>100</minimum-tokens>


### PR DESCRIPTION
## Describe the PR

Recently, the regression tester has stopped working. [Example](https://github.com/pmd/pmd/actions/runs/30155266128/job/89676007310). This is because the Schedul-o-matic-9000 repository no longer exists. https://github.com/SalesforceLabs/Schedul-o-matic-9000 is 404

This PR replaces Schedul-o-matic-9000 with another large apex project recommended by Copilot.

## Related issues

- None

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

