### PR TITLE
[java] Fix #6625: New rule: UnusedReturnValue

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,11 @@ Resolved type names, return types, and annotation FQNs are available through
 Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. This will be added in the next version.
 
 ### 🌟️ New and Changed Rules
+#### New Rules
+* The new java rule {% rule java/errorprone/UnusedReturnValue %} finds method calls whose result is not used,
+  although ignoring the result of these method calls is likely a mistake.
+  The rule is referenced in the quickstart.xml ruleset for Java.
+
 #### Renamed Rules
 * The rule {%rule java/design/InstantiableUtilityClass %} (Java Design) was renamed from `UseUtilityClass` to better reflect the problem.
   The old name still works but is deprecated.
@@ -46,6 +51,13 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
   be configured (via `publicMethodCommentRequirement` and `protectedMethodCommentRequirement`). The new property
   defaults to `Ignored`, so existing rule configurations are unaffected.
   This was implemented in [#6880](https://github.com/pmd/pmd/pull/6880).
+
+#### Deprecated Rules
+* The java rule {% rule java/errorprone/CheckSkipResult %} has been deprecated for removal
+  in favor of the new rule {% rule java/errorprone/UnusedReturnValue %}.
+* The java rule {% rule java/errorprone/UselessPureMethodCall %} has been deprecated for removal
+  in favor of the new rule {% rule java/errorprone/UnusedReturnValue %}.
+
 
 ### 🐛️ Fixed Issues
 * apex

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
@@ -63,6 +63,15 @@ public final class AssertionUtil {
         }
     }
 
+    /**
+     * @throws IllegalArgumentException if the name is not a package name
+     */
+    public static void assertValidJavaPackageName(CharSequence name) {
+        if (!isValidJavaPackageName(name)) {
+            throw new IllegalArgumentException("Not a Java package name '" + name + "'");
+        }
+    }
+
     public static boolean isValidJavaPackageName(CharSequence name) {
         requireParamNotNull("name", name);
         return PACKAGE_PATTERN.matcher(name).matches();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
@@ -9,6 +9,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 
+/**
+ * @deprecated since 7.27.0. Use UnusedReturnValueRule instead.
+ */
+@Deprecated
 public class CheckSkipResultRule extends AbstractJavaRulechainRule {
 
     private static final InvocationMatcher SKIP_METHOD = InvocationMatcher.parse("java.io.InputStream#skip(long)");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -7,11 +7,13 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
+import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.Substitution;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
@@ -24,6 +26,12 @@ public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
 
     private static final String CHECK_RETURN_VALUE_ANNOTATION = "CheckReturnValue";
     private static final String CAN_IGNORE_RETURN_VALUE_ANNOTATION = "CanIgnoreReturnValue";
+
+    private static final InvocationMatcher.CompoundInvocationMatcher METHODS_RETURNINING_NUMBER_OF_BYTES_READ = InvocationMatcher.parseAll(
+            "java.io.InputStream#skip(long)",
+            "java.io.InputStream#read(byte[])",
+            "java.io.InputStream#read(byte[],int,int)"
+    );
 
     public UnusedReturnValueRule() {
         super(ASTMethodCall.class);
@@ -47,7 +55,9 @@ public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
     }
 
     private boolean shouldCheckResult(ASTMethodCall call) {
-        return isCheckReturnValueAnnotated(call);
+        return isCheckReturnValueAnnotated(call)
+                || JavaRuleUtil.isKnownPure(call)
+                || METHODS_RETURNINING_NUMBER_OF_BYTES_READ.anyMatch(call);
     }
 
     // visible for testing

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -1,0 +1,87 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
+import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
+import net.sourceforge.pmd.lang.java.types.JMethodSig;
+import net.sourceforge.pmd.lang.java.types.Substitution;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+/**
+ * @since 7.27.0
+ */
+public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
+
+    private static final String CHECK_RETURN_VALUE_ANNOTATION = "CheckReturnValue";
+    private static final String CAN_IGNORE_RETURN_VALUE_ANNOTATION = "CanIgnoreReturnValue";
+
+    public UnusedReturnValueRule() {
+        super(ASTMethodCall.class);
+    }
+
+    @Override
+    public RuleContext visit(ASTMethodCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
+        if (shouldCheckResult(call) && !isResultUsed(call)) {
+            ctx.addViolation(call, formatCall(call));
+        }
+
+        return ctx;
+    }
+
+    private String formatCall(ASTMethodCall call) {
+        JMethodSig methodSig = call.getMethodType();
+
+        return methodSig.getDeclaringType() + "." + methodSig.getName() + "()";
+    }
+
+    private boolean shouldCheckResult(ASTMethodCall call) {
+        return isCheckReturnValueAnnotated(call);
+    }
+
+    // visible for testing
+    /* private */ static boolean isCheckReturnValueAnnotated(ASTMethodCall call) {
+        JExecutableSymbol methodSymbol = call.getMethodType().getSymbol();
+        if (methodSymbol.getReturnType(Substitution.EMPTY).isVoid()) {
+            return false;
+        }
+
+        if (isAnnotatedWith(methodSymbol, CHECK_RETURN_VALUE_ANNOTATION)) {
+            return true;
+        }
+
+        JTypeDeclSymbol classSymbol = call.getMethodType().getDeclaringType().getSymbol();
+        if (isAnnotatedWith(classSymbol, CHECK_RETURN_VALUE_ANNOTATION)
+                && !isAnnotatedWith(methodSymbol, CAN_IGNORE_RETURN_VALUE_ANNOTATION)
+        ) {
+            return true;
+        }
+
+        TypeSystem typeSystem = classSymbol.getTypeSystem();
+        SymbolResolver resolver = typeSystem.bootstrapResolver();
+        JClassSymbol packageSymbol = resolver.resolveClassFromCanonicalName(classSymbol.getPackageName() + ".package-info");
+        return packageSymbol != null
+                && isAnnotatedWith(packageSymbol, CHECK_RETURN_VALUE_ANNOTATION)
+                && !isAnnotatedWith(classSymbol, CAN_IGNORE_RETURN_VALUE_ANNOTATION)
+                && !isAnnotatedWith(methodSymbol, CAN_IGNORE_RETURN_VALUE_ANNOTATION);
+    }
+
+    private static boolean isAnnotatedWith(AnnotableSymbol symbol, String name) {
+        return symbol.getDeclaredAnnotations().stream().anyMatch(annotation -> name.equals(annotation.getSimpleName()));
+    }
+
+    private boolean isResultUsed(ASTMethodCall call) {
+        return !(call.getParent() instanceof ASTExpressionStatement);
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -9,7 +9,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
@@ -79,8 +78,7 @@ public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
         }
 
         TypeSystem typeSystem = classSymbol.getTypeSystem();
-        SymbolResolver resolver = typeSystem.bootstrapResolver();
-        JClassSymbol packageSymbol = resolver.resolveClassFromCanonicalName(classSymbol.getPackageName() + ".package-info");
+        AnnotableSymbol packageSymbol = typeSystem.getPackageSymbol(classSymbol.getPackageName());
         return packageSymbol != null
                 && isAnnotatedWith(packageSymbol, CHECK_RETURN_VALUE_ANNOTATION)
                 && !isAnnotatedWith(classSymbol, CAN_IGNORE_RETURN_VALUE_ANNOTATION)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -11,7 +11,6 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
-import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.Substitution;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessPureMethodCallRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessPureMethodCallRule.java
@@ -13,7 +13,9 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
  * Reports usages of pure methods where the result is ignored.
  *
  * @since 7.17.0
+ * @deprecated since 7.27.0. Use UnusedReturnValueRule instead.
  */
+@Deprecated
 public class UselessPureMethodCallRule extends AbstractJavaRulechainRule {
 
     public UselessPureMethodCallRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
@@ -35,6 +35,13 @@ public interface SymbolResolver {
     @Nullable JModuleSymbol resolveModule(@NonNull String moduleName);
 
     /**
+     * @since 7.27.0
+     */
+    default @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
+        return null;
+    }
+
+    /**
      * Resolves a class symbol from its canonical name. Periods ('.') may
      * be interpreted as nested-class separators, so for n segments, this
      * performs at most n classloader lookups.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
@@ -15,6 +15,7 @@ import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JModuleSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
@@ -85,6 +86,11 @@ public class AsmSymbolResolver implements SymbolResolver {
             return new ModuleStub(this, moduleName, new StreamLoader(moduleName, inputStream));
         }
         return null;
+    }
+
+    @Override
+    public @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
+        return resolveClassFromBinaryName(packageName + ".package-info");
     }
 
     SignatureParser getSigParser() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
@@ -11,6 +11,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JModuleSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
@@ -42,6 +43,11 @@ final class MapSymResolver implements SymbolResolver {
 
     @Override
     public @Nullable JModuleSymbol resolveModule(@NonNull String moduleName) {
+        return null;
+    }
+
+    @Override
+    public @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
@@ -24,6 +24,7 @@ import org.pcollections.HashTreePSet;
 import org.pcollections.PSet;
 
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
@@ -403,6 +404,20 @@ public final class TypeSystem {
      */
     public @Nullable JModuleSymbol getModuleSymbol(String moduleName) {
         return resolver.resolveModule(moduleName);
+    }
+
+    /**
+     * Returns a symbol for the pseudo-class representing a package (usually called "package-info.java")
+     *
+     * Returns a AnnotableSymbol, since the only thing this is used for is to check for annotations - and
+     * to keep the option of introducing a JPackageSymbol later.
+     *
+     * @since 7.27.0
+     */
+    public @Nullable AnnotableSymbol getPackageSymbol(String packageName) {
+        AssertionUtil.assertValidJavaPackageName(packageName);
+
+        return resolver.resolvePackage(packageName);
     }
 
     /**

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -928,11 +928,15 @@ public class DummyActivity extends Activity {
     <rule name="CheckSkipResult"
           language="java"
           since="5.0"
+          deprecated="true"
           message="Check the value returned by the skip() method of an InputStream to see if the requested number of bytes has been skipped."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.CheckSkipResultRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#checkskipresult">
         <description>
 The skip() method may skip a smaller number of bytes than requested. Check the returned value to find out if it was the case or not.
+
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0.
+This rule has been replaced by {% rule UnusedReturnValue %}
         </description>
         <priority>3</priority>
         <example>
@@ -3570,15 +3574,16 @@ public class Test {
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedReturnValueRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedreturnvalue">
         <description>
-The UnusedReturnValue rule ensures that developers do not ignore the return values of methods annotated with
-`@CheckReturnValue` or methods within annotated classes and packages.
+The UnusedReturnValue rule ensures that developers do not ignore the return values of methods where doing so value would likely be a bug.
 
-Ignoring these return values often indicates a bug, such as treating a mutation-by-copy operation
-(like String.concat() or BigDecimal.add()) as an in-place mutation, or forgetting to handle a critical validation result, error code, or stream.
+This could be because you are treating a mutation-by-copy operation (like String.concat() or BigDecimal.add())
+as an in-place mutation, or forgetting to handle a critical validation result, error code, or stream.
 By enforcing that the returned object is assigned to a variable, passed to another method, or explicitly handled,
 this rule prevents silent logic failures.
 
 See {% rule "UnusedAssignment" %} if you think assigning to a variable isn't enough.
+
+This rule replaces the old rules {% rule CheckSkipResult %} and {% rule UselessPureMethodCall %}.
         </description>
         <priority>3</priority>
         <example>
@@ -3709,6 +3714,7 @@ class Test {
     <rule name="UselessPureMethodCall"
           language="java"
           since="7.17.0"
+          deprecated="true"
           message="Do not call pure method {0} if the result is not used."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UselessPureMethodCallRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#uselesspuremethodcall">
@@ -3717,6 +3723,9 @@ This rule detects method calls of pure methods whose result is unused. A pure me
 side effects. Therefore, ignoring the result of such a method call is likely a mistake.
 
 Either the method call can be removed or the result should be used.
+
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0.
+This rule has been replaced by {% rule UnusedReturnValue %}
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3581,7 +3581,7 @@ as an in-place mutation, or forgetting to handle a critical validation result, e
 By enforcing that the returned object is assigned to a variable, passed to another method, or explicitly handled,
 this rule prevents silent logic failures.
 
-See {% rule "UnusedAssignment" %} if you think assigning to a variable isn't enough.
+See {% rule "java/bestpractices/UnusedAssignment" %} if you think assigning to a variable isn't enough.
 
 This rule replaces the old rules {% rule CheckSkipResult %} and {% rule UselessPureMethodCall %}.
         </description>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3531,8 +3531,8 @@ public class Test {
 
     public void method(String a) {
         String b;
-        // I don't know it method1() can be "null"
-        // but I know "a" is not null..
+        // I don't know if method1() can be "null"
+        // but I know "a" is not null.
         // I'd better write a.equals(method1())
 
         if (a!=null && method1().equals(a)) { // will trigger the rule
@@ -3560,6 +3560,40 @@ public class Test {
     }
 }
 ]]>
+        </example>
+    </rule>
+
+    <rule name="UnusedReturnValue"
+          language="java"
+          since="7.27.0"
+          message="Result of ''{0}'' is ignored."
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedReturnValueRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedreturnvalue">
+        <description>
+The UnusedReturnValue rule ensures that developers do not ignore the return values of methods annotated with
+`@CheckReturnValue` or methods within annotated classes and packages.
+
+Ignoring these return values often indicates a bug, such as treating a mutation-by-copy operation
+(like String.concat() or BigDecimal.add()) as an in-place mutation, or forgetting to handle a critical validation result, error code, or stream.
+By enforcing that the returned object is assigned to a variable, passed to another method, or explicitly handled,
+this rule prevents silent logic failures.
+
+See {% rule "UnusedAssignment" %} if you think assigning to a variable isn't enough.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+public class Foo {
+    public void foo() {
+        bar();
+    }
+
+    @CheckReturnValue
+    private int bar() {
+        return 42;
+    }
+}
+            ]]>
         </example>
     </rule>
 

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -291,6 +291,7 @@
     <!-- <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange" /> -->
     <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary"/>
     <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals"/>
+    <rule ref="category/java/errorprone.xml/UnusedReturnValue"/>
     <!-- <rule ref="category/java/errorprone.xml/UnsupportedJdkApiUsage" /> -->
     <!-- <rule ref="category/java/errorprone.xml/UseCorrectExceptionLogging" /> -->
     <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings"/>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -225,7 +225,6 @@
     <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
     <!-- <rule ref="category/java/errorprone.xml/CallSuperFirst" /> -->
     <!-- <rule ref="category/java/errorprone.xml/CallSuperLast" /> -->
-    <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
     <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray"/>
     <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic"/>
     <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable"/>
@@ -295,7 +294,6 @@
     <!-- <rule ref="category/java/errorprone.xml/UnsupportedJdkApiUsage" /> -->
     <!-- <rule ref="category/java/errorprone.xml/UseCorrectExceptionLogging" /> -->
     <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings"/>
-    <rule ref="category/java/errorprone.xml/UselessPureMethodCall"/>
     <rule ref="category/java/errorprone.xml/UseLocaleWithCaseConversions"/>
     <!-- <rule ref="category/java/errorprone.xml/UseProperClassLoader" /> -->
     <!-- <rule ref="category/java/errorprone.xml/WrongTestAnnotation" /> -->

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/AnUnrelatedAnnotation.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/AnUnrelatedAnnotation.java
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
+public @interface AnUnrelatedAnnotation {
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/AnnotatedClass.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/AnnotatedClass.java
@@ -1,0 +1,21 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue;
+
+@CheckReturnValue
+public class AnnotatedClass {
+    private AnnotatedClass() {}
+
+    public static int shouldBeChecked() {
+        return 42;
+    }
+
+    @CanIgnoreReturnValue
+    public static int doesNotNeedToBeChecked() {
+        return 4;
+    }
+
+    public static void returnsVoid() {}
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/CanIgnoreReturnValue.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/CanIgnoreReturnValue.java
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
+public @interface CanIgnoreReturnValue {
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/CheckReturnValue.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/CheckReturnValue.java
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
+public @interface CheckReturnValue {
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/HasAnnotatedMethod.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/HasAnnotatedMethod.java
@@ -1,0 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue;
+
+public class HasAnnotatedMethod {
+    private HasAnnotatedMethod() {}
+
+    @CheckReturnValue
+    public static int annotatedMethod() {
+        return 42;
+    }
+
+    public static int notAnnotatedMethod() {
+        return 4;
+    }
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/ClassInAnnotatedPackage.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/ClassInAnnotatedPackage.java
@@ -1,0 +1,20 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage;
+
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CanIgnoreReturnValue;
+
+public class ClassInAnnotatedPackage {
+    private ClassInAnnotatedPackage() {}
+
+    public static int shouldBeChecked() {
+        return 42;
+    }
+
+    @CanIgnoreReturnValue
+    public static int doesNotNeedToBeChecked() {
+        return 4;
+    }
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/ClassWithCanIgnoreReturnValue.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/ClassWithCanIgnoreReturnValue.java
@@ -1,0 +1,22 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage;
+
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CanIgnoreReturnValue;
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+@CanIgnoreReturnValue
+public class ClassWithCanIgnoreReturnValue {
+    private ClassWithCanIgnoreReturnValue() {}
+
+    @CheckReturnValue
+    public static int shouldBeChecked() {
+        return 42;
+    }
+
+    public static int doesNotNeedToBeChecked() {
+        return 4;
+    }
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/package-info.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/annotatedpackage/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+@CheckReturnValue
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage;
+
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/packagewithadifferentannotation/SomeClass.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/packagewithadifferentannotation/SomeClass.java
@@ -1,0 +1,13 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.packagewithadifferentannotation;
+
+public class SomeClass {
+    private SomeClass() {}
+
+    public static int doesNotNeedToBeChecked() {
+        return 42;
+    }
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/packagewithadifferentannotation/package-info.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/errorprone/unusedreturnvalue/packagewithadifferentannotation/package-info.java
@@ -1,0 +1,8 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+@AnUnrelatedAnnotation
+package net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.packagewithadifferentannotation;
+
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.AnUnrelatedAnnotation;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueTest.java
@@ -1,0 +1,125 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import static net.sourceforge.pmd.lang.java.rule.errorprone.UnusedReturnValueRule.isCheckReturnValueAnnotated;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.java.JavaParsingHelper;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class UnusedReturnValueTest extends PmdRuleTst {
+
+    private final JavaParsingHelper java = JavaParsingHelper.DEFAULT.withResourceContext(getClass());
+
+    @Nested
+    class IsCheckReturnValueAnnotated {
+        @Test
+        @DisplayName("If a method is not annotated with @CheckReturnValue, the return value doesn't need to be checked")
+        void notAnnotatedMethod() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.HasAnnotatedMethod.notAnnotatedMethod(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is annotated with @CheckReturnValue, the return value should be checked")
+        void annotatedMethod() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.HasAnnotatedMethod.annotatedMethod(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertTrue(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class annotated with @CheckReturnValue, the return value should be checked")
+        void annotatedClass() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.AnnotatedClass.shouldBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertTrue(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class annotated with @CheckReturnValue but the method is annotated with @CanIgnoreReturnValue, the return value doesn't need to be checked")
+        void annotatedClassMethodShouldNotBeChecked() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.AnnotatedClass.doesNotNeedToBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class annotated with @CheckReturnValue but the method returns void, the return value doesn't need to be checked")
+        void returningVoid() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.AnnotatedClass.returnsVoid(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class in a package annotated with @CheckReturnValue, the return value should be checked")
+        void annotatedPackage() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage.ClassInAnnotatedPackage.shouldBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertTrue(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class in a package annotated with @CheckReturnValue but the method is annotated with @CanIgnoreReturnValue, the return value doesn't need to be checked")
+        void annotatedPackageMethodShouldNotBeChecked() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage.ClassInAnnotatedPackage.doesNotNeedToBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("If a method is in a class in a package annotated with @CheckReturnValue but the class is annotated with @CanIgnoreReturnValue, the return value doesn't need to be checked")
+        void annotatedPackageClassShouldNotBeChecked() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage.ClassWithCanIgnoreReturnValue.doesNotNeedToBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("Package, class and method are annotated (alternating)")
+        void annotatedPackageClassAndMethod() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.annotatedpackage.ClassWithCanIgnoreReturnValue.shouldBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertTrue(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("A package with an unrelated annotation")
+        void packageWithUnrelatedAnnotation() {
+            ASTCompilationUnit root = java.parse("public class Foo { { net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.packagewithadifferentannotation.SomeClass.doesNotNeedToBeChecked(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+
+        @Test
+        @DisplayName("Calling an unresolved method shouldn't crash the rule")
+        void unresolvedMethod() {
+            ASTCompilationUnit root = java.parse("import a.b.Foo; public class Foo { { Foo.bar(); } }");
+            ASTMethodCall methodCall = root.descendants(ASTMethodCall.class).first();
+
+            assertFalse(isCheckReturnValueAnnotated(methodCall));
+        }
+    }
+}

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeSystemTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeSystemTest.kt
@@ -120,6 +120,14 @@ class TypeSystemTest : IntelliMarker, FunSpec({
         }
     }
 
+    test("Test getModuleSymbol") {
+        ts.getModuleSymbol("java.base")?.simpleName shouldBe "java.base"
+    }
+
+    test("Test getPackageSymbol") {
+        ts.getPackageSymbol("java.net")?.simpleName shouldBe "package-info"
+    }
+
     test("Test parameterize special types") {
         ts.parameterise(ts.INT.symbol, emptyList()) shouldBeSameInstanceAs ts.INT
         shouldThrow<java.lang.IllegalArgumentException> {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_1_1_0.xsd">
+
+    <test-code>
+        <description>Method annotated with @CheckReturnValue - Verify location of violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5-5</expected-linenumbers>
+        <code>
+            <![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+public class Foo {
+    public void foo() {
+        bar();
+    }
+
+    @CheckReturnValue
+    private int bar() {
+        return 42;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Verify violation message</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Result of 'Foo.bar()' is ignored.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+public class Foo {
+    public void foo() {
+        bar();
+    }
+
+    @CheckReturnValue
+    private int bar() {
+        return 42;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Method not annotated with @CheckReturnValue</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+public class Foo {
+    public void foo() {
+        bar();
+    }
+
+    private int bar() {
+        return 42;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Return value is assigned to a variable</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+public class Foo {
+    public void foo() {
+        int x = bar();
+    }
+
+    @CheckReturnValue
+    private int bar() {
+        return 42;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Return value is passed to another function</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
+
+public class Foo {
+    public void foo() {
+        qux(bar());
+    }
+
+    @CheckReturnValue
+    private int bar() {
+        return 42;
+    }
+
+    private void qux(int x) {}
+}
+            ]]>
+        </code>
+    </test-code>
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
@@ -114,4 +114,639 @@ public class Foo {
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Collection methods (from UselessPureMethodCall)</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>8,9,10,11</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+
+public class Foo {
+    private List list = List.of(5);
+
+    private void foo() {
+        int size = list.size();
+        list.size();
+        list.isEmpty();
+        list.toString();
+        list.contains(7);
+    }
+
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>Throwable methods (formerly rule AvoidLosingExceptionInformation) (from UselessPureMethodCall)</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,7,8,9</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private Exception ex = new RuntimeException();
+
+    private void foo() {
+        System.out.println(ex.getMessage());
+        ex.getMessage();
+        ex.getLocalizedMessage();
+        ex.getCause();
+        ex.getStackTrace();
+        if ("" != null) {
+            throw ex.getCause();
+        }
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5881 [java] AvoidLosingExceptionInformation does not trigger when inside if-else (from UselessPureMethodCall)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,9</expected-linenumbers>
+        <code><![CDATA[
+class AvoidLosingExceptionInformation {
+    public void showBug() {
+        try {
+            throw new Exception("This is a test exception");
+        } catch (Exception se) {
+            if (true) {
+                se.getMessage();    // should raise flag
+            } else {
+                se.getLocalizedMessage();    // should raise flag
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>String methods (from UselessPureMethodCall)</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>5,8,9</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private String name = "Foo";
+
+    private String foo() {
+        name.indexOf("F");
+        name.getChars(0, 1, new char[1], 0);
+        name.getBytes(0, 1, new byte[1], 0);
+        name.getBytes();
+        name.getBytes("UTF8");
+        return name.substring(1);
+    }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>useless operation on BigDecimal (from UselessPureMethodCall)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public void foo() {
+        BigDecimal bd = new BigDecimal(5);
+        bd.divideToIntegralValue(new BigDecimal(5));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>useless operation on BigInteger (from UselessPureMethodCall)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public void foo() {
+        BigInteger bi = new BigInteger(5);
+        bi.modPow(new BigInteger(1), new BigInteger(5));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>using the result, so OK (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public void foo() {
+        BigInteger bi = new BigInteger(5);
+        bi = bi.add(new BigInteger(5));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>using the result in a method call, so OK (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public void foo() {
+        BigInteger bi = new BigInteger(5);
+        bar(bi.add(new BigInteger(5)));
+    }
+
+    private void bar(BigInteger bi);
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>BigInteger obtained from compound method call (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Bar {
+    class C { BigInteger n; }
+    C getBigIntContainer() { return null; }
+    public String toString() {
+        Bar _b;
+        java.math.BigInteger n = _b.getBigIntContainer().n;
+        return n.toString();
+    }
+}
+         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Using generics on List, OK (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+import java.util.*;
+public class Foo {
+    List<BigDecimal> getSolution() {
+        List<BigDecimal> result = new ArrayList<BigDecimal>();
+        for (int i = 0; i < size(); i++) {
+           result.add(entry(size(),i).negate());
+           result.add(this.equations[i].check(solution));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>BigInteger in conditional statement (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public Object get() {
+        java.math.BigDecimal bigDecimal = new java.math.BigDecimal(1);
+        return bigDecimal==null ? null : bigDecimal.setScale(0, java.math.BigDecimal.ROUND_UNNECESSARY);
+    }
+}
+         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>1702782, Immutable used in comparison (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class RuleViolator {
+    public BigInteger foo() {
+        // some boiler plate code
+        final BigInteger anImmutable = BigInteger.ZERO;
+        final BigInteger anotherImmutable = BigInteger.ONE;
+        BigInteger unrelated = BigInteger.valueOf(42);
+
+        // the actual PMD problem occurs with the next statement
+        if (anImmutable.add(BigInteger.TEN).compareTo(anotherImmutable) == 0) {
+            // do something here that is not related to the actual comparison in
+            // the if clause
+            unrelated = unrelated.multiply(BigInteger.TEN);
+        }
+
+        return unrelated;
+    }
+}
+         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>String calls in expressions (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        String s;
+        String s2 = "foo" + s.substring( 0, delimiterIndex ) + "/";
+        s2 = "foo" + s.substring( 0, delimiterIndex );
+        if (s.trim().length() > 0) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>String::getChars is allowed (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String s, char[] buf) {
+        s.getChars(0,0, buf, 2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>BigInteger calls in expression (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+public class Foo {
+    public void foo() {
+        BigInteger temp = BigInteger.valueOf((long) startMonth).add(dMonths);
+        setMonth(temp.subtract(BigInteger.ONE).mod(TWELVE).intValue() + 1);
+    }
+
+    private void setMonth(int x) {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>2645268, ClassCastException using Annotation on Local Field (from UselessPureMethodCall)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.math.*;
+@interface NotNull {}
+public class Foo {
+    public void foo() {
+        @NotNull
+        BigDecimal bd = new BigDecimal(5);
+        bd.divideToIntegralValue(new BigDecimal(5));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOperationOnImmutable various false negatives with String #4513 (from UselessPureMethodCall)</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>3,6,9</expected-linenumbers>
+        <code><![CDATA[
+public class TestCase {
+  public void method1(String s) {
+    s.trim();
+  }
+  public void method2() {
+   String.valueOf(0);
+  }
+  public void method3() {
+   String.valueOf(0).trim();
+  }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOperationOnImmutable should detect java.time types #5244 (from UselessPureMethodCall)</description>
+        <expected-problems>44</expected-problems>
+        <expected-linenumbers>7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,61,66,71,76</expected-linenumbers>
+        <code><![CDATA[
+import java.time.*;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+class Tester {
+    void violationsWithInstant() {
+        Instant instant = Instant.now();
+        instant.atOffset(ZoneOffset.UTC); // violation
+        instant.atZone(ZoneId.systemDefault()); // violation
+        instant.minus(1, ChronoUnit.SECONDS); // violation
+        instant.minus(Duration.ofSeconds(1)); // violation
+        instant.minusMillis(1); // violation
+        instant.minusNanos(1); // violation
+        instant.minusSeconds(1); // violation
+        instant.plus(1, ChronoUnit.SECONDS); // violation
+        instant.plus(Duration.ofSeconds(1)); // violation
+        instant.plusMillis(1); // violation
+        instant.plusNanos(1); // violation
+        instant.plusSeconds(1); // violation
+        instant.truncatedTo(ChronoUnit.MINUTES); // violation
+        instant.with(LocalDateTime.now()); // violation
+        instant.with(ChronoField.INSTANT_SECONDS, 1); // violation
+    }
+    void correctInstantExample() {
+        Instant instant = Instant.now();
+        instant = instant.plusSeconds(1);
+    }
+    void violationsWithLocalDate() {
+        LocalDate localDate = LocalDate.now();
+        localDate.atStartOfDay(); // violation
+        localDate.atStartOfDay(ZoneId.systemDefault()); // violation
+        localDate.atTime(10, 11); // violation
+        localDate.atTime(10, 11, 12); // violation
+        localDate.atTime(10, 11, 12, 13); // violation
+        localDate.atTime(LocalTime.now()); // violation
+        localDate.atTime(OffsetTime.now()); // violation
+        localDate.minus(1, ChronoUnit.SECONDS); // violation
+        localDate.minus(Duration.ofSeconds(1)); // violation
+        localDate.minusDays(1); // violation
+        localDate.minusMonths(1); // violation
+        localDate.minusWeeks(1); // violation
+        localDate.minusYears(1); // violation
+        localDate.plus(1, ChronoUnit.SECONDS); // violation
+        localDate.plus(Duration.ofSeconds(1)); // violation
+        localDate.plusDays(1); // violation
+        localDate.plusMonths(1); // violation
+        localDate.plusWeeks(1); // violation
+        localDate.plusYears(1); // violation
+        localDate.with(LocalDateTime.now()); // violation
+        localDate.with(ChronoField.DAY_OF_MONTH, 1); // violation
+        localDate.withDayOfMonth(1); // violation
+        localDate.withDayOfYear(1); // violation
+        localDate.withMonth(1); // violation
+        localDate.withYear(1); // violation
+    }
+    void correctLocalDateExample() {
+        LocalDate localDate = LocalDate.now();
+        localDate = localDate.plusDays(1);
+    }
+    void localTimeExamples() {
+        LocalTime localTime = LocalTime.now();
+        localTime.minusHours(1); // violation
+        localTime = localTime.plusMinutes(1); // ok
+    }
+    void localDateTimeExamples() {
+        LocalDateTime localDateTime = LocalDateTime.now();
+        localDateTime.minusDays(1); // violation
+        localDateTime = localDateTime.plusHours(1); // ok
+    }
+    void zonedDateTimeExamples() {
+        ZonedDateTime zonedDateTime = new ZonedDateTime.now();
+        zonedDateTime.minusMonths(1); // violation
+        zonedDateTime = zonedDateTime.plusWeeks(1); // ok
+    }
+    void offsetDateTimeExamples() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        offsetDateTime.minusDays(1); // violation
+        offsetDateTime = offsetDateTime.plusYears(1); // ok
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOperationOnImmutable should detect java.time types #5244 - Duration, Period (from UselessPureMethodCall)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,10</expected-linenumbers>
+        <code><![CDATA[
+import java.time.*;
+class Tester {
+    void durationExamples() {
+        Duration duration = Duration.ofSeconds(1);
+        duration.minusMillis(1); // violation
+        duration = duration.plusDays(1); //ok
+    }
+    void periodExamples() {
+        Period period = Period.ofMonths(1);
+        period.minusDays(1); // violation
+        period = period.plusMonths(1); // ok
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>False positive for package private method calls in openjdk (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package java.time;
+import java.io.ObjectOutput;
+class Tester {
+    static void writeExternal(ZonedDateTime zonedDateTime, ObjectOutput out) {
+        zonedDateTime.writeExternal(out); // false positive
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6055 Atomic increments (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+        import java.util.concurrent.atomic.AtomicInteger;
+        import java.util.concurrent.atomic.AtomicLong;
+        class Atomics {
+            private final AtomicInteger atomicInt = new AtomicInteger(1);
+            private final AtomicLong atomicLong = new AtomicLong(1);
+            public void test() {
+                atomicInt.getAndIncrement();
+                atomicInt.getAndDecrement();
+                atomicLong.getAndIncrement();
+                atomicLong.getAndDecrement();
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6060 Stream methods with side-effects (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+        import java.util.zip.ZipInputStream;
+        import java.util.jar.JarInputStream;
+        class Atomics {
+            private final ZipInputStream zip = new ZipInputStream(null);
+            private final JarInputStream jar = new JarInputStream(null);
+            public void test() {
+                zip.getNextEntry();
+                jar.getNextEntry();
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessPureMethodCall false negative for primitive stream peek #6517 (from UselessPureMethodCall)</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>8,11,14,17</expected-linenumbers>
+        <code><![CDATA[
+import java.util.stream.Stream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.DoubleStream;
+
+public class a {
+    public void tp() {
+        Stream.of("A", "B").peek(System.out::println);
+    }
+    public void fn1() {
+        IntStream.of(1, 2).peek(System.out::println);
+    }
+    public void fn2() {
+        LongStream.of(1, 2).peek(System.out::println);
+    }
+    public void fn3() {
+        DoubleStream.of(1.0, 2.0).peek(System.out::println);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessPureMethodCall false negative for unresolved type #6781 (from UselessPureMethodCall)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Tester {
+    void triggersUselessPureMethodCall(List<Object> source) {
+        var varResult = source.stream()
+            .collect(Collectors.toCollection(ArrayList::new));
+        source.stream().forEach(varResult::add);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>failure case (from CheckSkipResult, but added test for read())</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>9,10,11</expected-linenumbers>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo {
+
+    private FileInputStream _s = new FileInputStream("file");
+
+    public void skip(int n, byte[] buf) throws IOException {
+        _s.skip(n); // You are not sure that exactly n bytes are skipped
+        _s.read(buf);
+        _s.read(buf, 1, 1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>failure case but obfuscated (from CheckSkipResult)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo {
+
+    private FileInputStream _s = new FileInputStream("file");
+
+    public void skip(int n) throws IOException {
+        (_s.skip(n));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>return value is assigned to a variable (from CheckSkipResult)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.EOFException;
+
+public class Foo {
+
+    private FileInputStream _s = new FileInputStream("file");
+
+    public void skip(int n) throws IOException {
+        while (n != 0) {
+            long skipped = _s.skip(n);
+            if (skipped == 0)
+                throw new EOFException();
+            n -= skipped;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>return value is used in a function (from CheckSkipResult)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo {
+
+    private FileInputStream _s = new FileInputStream("file");
+
+    public void skip(int n) throws IOException {
+        System.out.println(_s.skip(n));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>return value is returned (from CheckSkipResult)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo {
+
+    private FileInputStream _s = new FileInputStream("file");
+
+    public int skip(int n) throws IOException {
+        return _s.skip(n);
+   }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>NPE when using Pattern matching variables #3169 (from CheckSkipResult)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.io.InputStream;
+
+            public class Foo {
+                public void service(Object servletRequest) {
+                    if (servletRequest instanceof InputStream nanoRequest) {
+                        // ...
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5207 FP with skip overload on custom FileInputStream class (from CheckSkipResult)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo extends FileInputStream {
+    public void bar() {
+        skip(1);
+    }
+
+    public void skip(int n) throws IOException {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
@@ -250,11 +250,11 @@ public class Foo {
 import java.math.*;
 public class Foo {
     public void foo() {
-        BigInteger bi = new BigInteger(5);
-        bar(bi.add(new BigInteger(5)));
+        BigInteger bi = new BigInteger("5");
+        bar(bi.add(new BigInteger("5")));
     }
 
-    private void bar(BigInteger bi);
+    private void bar(BigInteger bi) {};
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
@@ -141,6 +141,8 @@ public class Foo {
         BigInteger bi = new BigInteger(5);
         bar(bi.add(new BigInteger(5)));
     }
+
+    private void bar(BigInteger bi);
 }
         ]]></code>
     </test-code>
@@ -257,6 +259,8 @@ public class Foo {
         BigInteger temp = BigInteger.valueOf((long) startMonth).add(dMonths);
         setMonth(temp.subtract(BigInteger.ONE).mod(TWELVE).intValue() + 1);
     }
+
+    private void setMonth(int x) {}
 }
         ]]></code>
     </test-code>
@@ -398,7 +402,7 @@ class Tester {
     void periodExamples() {
         Period period = Period.ofMonths(1);
         period.minusDays(1); // violation
-        period = period.plusWeeks(1); // ok
+        period = period.plusMonths(1); // ok
     }
 }
 ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessPureMethodCall.xml
@@ -138,11 +138,11 @@ public class Foo {
 import java.math.*;
 public class Foo {
     public void foo() {
-        BigInteger bi = new BigInteger(5);
-        bar(bi.add(new BigInteger(5)));
+        BigInteger bi = new BigInteger("5");
+        bar(bi.add(new BigInteger("5")));
     }
 
-    private void bar(BigInteger bi);
+    private void bar(BigInteger bi) {};
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This rule uses multiple ways to find method calls where the return value is ignored but shouldn't be:
* @<!-- -->CheckReturnValue annotation on method/class/package, unless overridden by a @<!-- -->CanIgnoreReturnValue annotation
* methods that `JavaRuleUtil.isKnownPure` determines to be pure. The existing rule UselessPureMethodCallRule is deprecated
* methods in InputStream, that return the number of bytes read. The existing rule CheckSkipResultRule is deprecated. CheckSkipResultRule only checked .skip(), but ignoring the return value of .read() has the same problem

I did not include CheckResultSet. Although the rule claims it is about the return value of .next() and siblings, it is really about making sure that .getFoo() is only called when the object is in the correct state.

## Related issues

- Fix #6625 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

