### PR TITLE
[java] Fix #6900: Modifies isNullCheck to accept negated expressions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -73,6 +73,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
 * java-errorprone
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
+    * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -56,6 +56,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.ast.UnaryOp;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
@@ -502,6 +503,12 @@ public final class JavaRuleUtil {
     }
 
     public static boolean isNullCheck(ASTExpression expr, StablePathMatcher matcher) {
+        while (expr instanceof ASTUnaryExpression) {
+            ASTUnaryExpression unary = (ASTUnaryExpression) expr;
+            if (unary.getOperator() == UnaryOp.NEGATION) {
+                expr = unary.getOperand();
+            }
+        }
         if (expr instanceof ASTInfixExpression) {
             ASTInfixExpression condition = (ASTInfixExpression) expr;
             if (condition.getOperator().hasSamePrecedenceAs(BinaryOp.EQ)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -508,6 +508,9 @@ public final class JavaRuleUtil {
             if (unary.getOperator() == UnaryOp.NEGATION) {
                 expr = unary.getOperand();
             }
+            else {
+                return false;
+            }
         }
         if (expr instanceof ASTInfixExpression) {
             ASTInfixExpression condition = (ASTInfixExpression) expr;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -507,8 +507,7 @@ public final class JavaRuleUtil {
             ASTUnaryExpression unary = (ASTUnaryExpression) expr;
             if (unary.getOperator() == UnaryOp.NEGATION) {
                 expr = unary.getOperand();
-            }
-            else {
+            } else {
                 return false;
             }
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -5,12 +5,15 @@
 package net.sourceforge.pmd.lang.java.rule.internal;
 
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.containsCamelCaseWord;
+import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isNullCheck;
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isUtilityClass;
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.startsWithCamelCaseWord;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,10 @@ import org.junit.jupiter.api.Test;
 import net.sourceforge.pmd.lang.java.BaseParserTest;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 
 class JavaRuleUtilTest extends BaseParserTest {
 
@@ -256,6 +263,95 @@ class JavaRuleUtilTest extends BaseParserTest {
             ASTClassDeclaration classDecl = root.firstChild(ASTClassDeclaration.class);
 
             assertFalse(isUtilityClass(classDecl));
+        }
+    }
+
+
+    @Nested
+    class IsNullCheckTest {
+
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal")
+        void testStandardNullComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Object x) {" +
+                    "if (x == null) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertTrue(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns true when variable is compared as not equal to null literal")
+        void testNotEqualNullComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Object x) {" +
+                    "if (x != null) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertTrue(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns false when variable is compared directly to non-null literal")
+        void testStandardIntegerComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Integer x) {" +
+                    "if (x == 1) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertFalse(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal inside a negation")
+        void testWrappedNullComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Object x) {" +
+                    "if (!(!(x == null))) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertTrue(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns false when condition contains non-negation unary operator")
+        void testNonNegationUnaryOperator() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Integer x) {" +
+                    "x++;}}");
+            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertFalse(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal inside redundant parentheses")
+        void testRedundantParentheses() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Integer x) {" +
+                    "if (((x == null))) {}}}");
+            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertFalse(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal inside redundant parentheses and negations")
+        void testRedundantParenthesesWithNegations() {
+            ASTCompilationUnit acu = java.parse("class Foo {" +
+                    "void Bar(Integer x) {" +
+                    "if (((!((!(x == null)))))) {}}}");
+            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertFalse(isNullCheck(condition, xSymbol));
         }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -324,10 +324,10 @@ class JavaRuleUtilTest extends BaseParserTest {
             ASTCompilationUnit acu = java.parse("class Foo {" +
                     "void Bar(Integer x) {" +
                     "x++;}}");
-            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            ASTExpression unaryExpr = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertFalse(isNullCheck(condition, xSymbol));
+            assertFalse(isNullCheck(unaryExpr, xSymbol));
         }
 
         @Test
@@ -336,10 +336,10 @@ class JavaRuleUtilTest extends BaseParserTest {
             ASTCompilationUnit acu = java.parse("class Foo {" +
                     "void Bar(Integer x) {" +
                     "if (((x == null))) {}}}");
-            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertFalse(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, xSymbol));
         }
 
         @Test
@@ -348,10 +348,10 @@ class JavaRuleUtilTest extends BaseParserTest {
             ASTCompilationUnit acu = java.parse("class Foo {" +
                     "void Bar(Integer x) {" +
                     "if (((!((!(x == null)))))) {}}}");
-            ASTExpression condition = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertFalse(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, xSymbol));
         }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -12,8 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 
@@ -266,6 +265,32 @@ class JavaRuleUtilTest extends BaseParserTest {
         }
     }
 
+    @Nested
+    class OverloadedIsNullCheckTest {
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal in overloaded method")
+        void testStandardNullComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Object x) {"
+                    + "if (x == null) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertTrue(isNullCheck(condition, xSymbol));
+        }
+
+        @Test
+        @DisplayName("Returns false when variable is compared to non-null literal in overloaded method")
+        void testStandardIntegerComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Integer x) {"
+                    + "if (x == 1) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertFalse(isNullCheck(condition, xSymbol));
+        }
+    }
 
     @Nested
     class IsNullCheckTest {
@@ -273,85 +298,97 @@ class JavaRuleUtilTest extends BaseParserTest {
         @Test
         @DisplayName("Returns true when variable is compared to null literal")
         void testStandardNullComparison() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Object x) {" +
-                    "if (x == null) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Object x) {"
+                    + "if (x == null) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertTrue(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
+        }
+
+        @Test
+        @DisplayName("Returns true when variable is compared to null literal as (null == variable)")
+        void testYodaNullComparison() {
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Object x) {"
+                    + "if (null == x) {}}}");
+            ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
+            JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
+
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns true when variable is compared as not equal to null literal")
         void testNotEqualNullComparison() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Object x) {" +
-                    "if (x != null) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Object x) {"
+                    + "if (x != null) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertTrue(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns false when variable is compared directly to non-null literal")
         void testStandardIntegerComparison() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Integer x) {" +
-                    "if (x == 1) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Integer x) {"
+                    + "if (x == 1) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertFalse(isNullCheck(condition, xSymbol));
+            assertFalse(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns true when variable is compared to null literal inside a negation")
         void testWrappedNullComparison() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Object x) {" +
-                    "if (!(!(x == null))) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Object x) {"
+                    + "if (!(!(x == null))) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertTrue(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns false when condition contains non-negation unary operator")
         void testNonNegationUnaryOperator() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Integer x) {" +
-                    "x++;}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Integer x) {"
+                    + "x++;}}");
             ASTExpression unaryExpr = acu.descendants(ASTUnaryExpression.class).firstOrThrow();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertFalse(isNullCheck(unaryExpr, xSymbol));
+            assertFalse(isNullCheck(unaryExpr, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns true when variable is compared to null literal inside redundant parentheses")
         void testRedundantParentheses() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Integer x) {" +
-                    "if (((x == null))) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Integer x) {"
+                    + "if (((x == null))) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertTrue(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
 
         @Test
         @DisplayName("Returns true when variable is compared to null literal inside redundant parentheses and negations")
         void testRedundantParenthesesWithNegations() {
-            ASTCompilationUnit acu = java.parse("class Foo {" +
-                    "void Bar(Integer x) {" +
-                    "if (((!((!(x == null)))))) {}}}");
+            ASTCompilationUnit acu = java.parse("class Foo {"
+                    + "void Bar(Integer x) {"
+                    + "if (((!((!(x == null)))))) {}}}");
             ASTExpression condition = acu.descendants(ASTIfStatement.class).firstOrThrow().getCondition();
             JVariableSymbol xSymbol = acu.descendants(ASTVariableId.class).firstOrThrow().getSymbol();
 
-            assertTrue(isNullCheck(condition, xSymbol));
+            assertTrue(isNullCheck(condition, StablePathMatcher.matching(xSymbol)));
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
@@ -220,7 +220,27 @@ public class Foo {
 public class Foo {
     Object baz;
     Object bar() {
-        if (!(baz == null)) { // negated condition should still trigger rule
+        if (!(baz != null)) { // negated condition should still trigger rule
+            synchronized(this) {
+                if (baz == null) {
+                    baz = new Object();
+                }
+            }
+        }
+        return baz;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6900: DoubleCheckedLocking with nested negated selection conditions</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Object baz;
+    Object bar() {
+        if (!(!(baz == null))) { // nested negated condition should still trigger rule
             synchronized(this) {
                 if (baz == null) {
                     baz = new Object();

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/DoubleCheckedLocking.xml
@@ -212,4 +212,25 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6900: DoubleCheckedLocking with negated selection conditions</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Object baz;
+    Object bar() {
+        if (!(baz == null)) { // negated condition should still trigger rule
+            synchronized(this) {
+                if (baz == null) {
+                    baz = new Object();
+                }
+            }
+        }
+        return baz;
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

Removes false negative by first stripping negations from expressions passed to isNullCheck before performing the original check.

## Related issues

- Fix #6900

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

