### PR TITLE
[java] Fix #6742: CloseResource false positive for a wrapped resource assigned without an initializer

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -75,6 +75,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
 * java-errorprone
+    * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
 * kotlin

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -281,7 +281,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     }
 
     private TypeNode getWrappedResourceType(ASTVariableId var) {
-        ASTExpression initExpr = initializerExpressionOf(var);
+        ASTExpression initExpr = initializerOrFirstAssignedValueOf(var);
         if (initExpr != null) {
             ASTConstructorCall resAlloc = getLastResourceAllocation(initExpr);
             if (resAlloc != null) {
@@ -294,6 +294,28 @@ public class CloseResourceRule extends AbstractJavaRule {
 
     private ASTExpression initializerExpressionOf(ASTVariableId var) {
         return var.getInitializer();
+    }
+
+    /**
+     * Returns the expression the variable gets its value from: its initializer, or - for a
+     * variable declared without one - the value of its first assignment. Per JLS 14.4.2 a
+     * declaration with an initializer is equivalent to a declaration followed by a separate
+     * assignment, so both shapes have to be recognized the same way.
+     */
+    private ASTExpression initializerOrFirstAssignedValueOf(ASTVariableId var) {
+        ASTExpression initExpr = var.getInitializer();
+        if (initExpr != null) {
+            return initExpr;
+        }
+        for (ASTNamedReferenceExpr usage : var.getLocalUsages()) {
+            if (usage.getParent() instanceof ASTAssignmentExpression) {
+                ASTAssignmentExpression assignment = (ASTAssignmentExpression) usage.getParent();
+                if (assignment.getLeftOperand() == usage) {
+                    return assignment.getRightOperand();
+                }
+            }
+        }
+        return null;
     }
 
     private ASTConstructorCall getLastResourceAllocation(ASTExpression expr) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2331,4 +2331,79 @@ public class CastNullAfter {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] CloseResource: resource returned from the method directly (#2840)</description>
+        <rule-property name="types">java.sql.Connection</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+    Connection bar(Pool pool) {
+        Connection c = pool.getConnection();
+        return c;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] CloseResource: resource declared inside a nested block and returned (#2840)</description>
+        <rule-property name="types">java.sql.Connection</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
+
+public class Foo {
+    Connection bar(Pool pool, boolean flag) {
+        if (flag) {
+            Connection c = pool.getConnection();
+            return c;
+        }
+        return null;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] CloseResource: plain close, declaration with initializer (#6742 control, rule defaults)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+public class SplitDeclBefore {
+    public static void main(String[] args) throws Exception {
+        ByteArrayOutputStream pout = new ByteArrayOutputStream();
+        ObjectOutputStream oout = new ObjectOutputStream(pout);
+        oout.writeObject("x");
+        oout.close();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] CloseResource: plain close, split declaration and assignment (#6742)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+public class SplitDeclAfter {
+    public static void main(String[] args) throws Exception {
+        ByteArrayOutputStream pout = new ByteArrayOutputStream();
+        ObjectOutputStream oout;
+        oout = new ObjectOutputStream(pout);
+        oout.writeObject("x");
+        oout.close();
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2332,42 +2332,7 @@ public class CastNullAfter {
         ]]></code>
     </test-code>
 
-    <test-code>
-        <description>[java] CloseResource: resource returned from the method directly (#2840)</description>
-        <rule-property name="types">java.sql.Connection</rule-property>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-import java.sql.Connection;
-import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
 
-public class Foo {
-    Connection bar(Pool pool) {
-        Connection c = pool.getConnection();
-        return c;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>[java] CloseResource: resource declared inside a nested block and returned (#2840)</description>
-        <rule-property name="types">java.sql.Connection</rule-property>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-import java.sql.Connection;
-import net.sourceforge.pmd.lang.java.rule.errorprone.closeresource.Pool;
-
-public class Foo {
-    Connection bar(Pool pool, boolean flag) {
-        if (flag) {
-            Connection c = pool.getConnection();
-            return c;
-        }
-        return null;
-    }
-}
-        ]]></code>
-    </test-code>
 
     <test-code>
         <description>[java] CloseResource: plain close, declaration with initializer (#6742 control, rule defaults)</description>


### PR DESCRIPTION
Fixes #6742

`CloseResource` recognizes that a resource wrapped by another resource does not need to be closed on
its own — but only when the wrapper is created in the variable's *initializer*. The runtime-equivalent
split form is flagged:

```java
ObjectOutputStream oout = new ObjectOutputStream(pout);   // no violation
oout.close();

ObjectOutputStream oout;                                  // violation
oout = new ObjectOutputStream(pout);
oout.close();
```

The whole wrapping decision hangs on `var.getInitializer()`:

```java
private TypeNode getWrappedResourceType(ASTVariableId var) {
    ASTExpression initExpr = initializerExpressionOf(var);   // null for a split declaration
    if (initExpr != null) {
        ASTConstructorCall resAlloc = getLastResourceAllocation(initExpr);
        ...
```

With an initializer, `getWrappedResourceType` finds the `new ObjectOutputStream(...)` call, picks up
`pout` through `getFirstArgumentVariableIfResource`, and `checkForResources` uses that as the effective
type — so `shouldVarOfTypeBeClosedInMethod` returns false. Without one, the wrapping is simply invisible
and the declared type is used instead.

Per JLS §14.4.2 a local declaration with an initializer is equivalent to a declaration followed by a
separate assignment, so both shapes should reach the same verdict. This adds
`initializerOrFirstAssignedValueOf()`, which falls back to the value of the variable's first assignment,
and uses it in `getWrappedResourceType()`.

I deliberately left `initializerExpressionOf()` itself alone: it is also used by
`getFirstReassigningStatementBeforeBeingClosed()`, which distinguishes initialized from uninitialized
variables on purpose (`isNotNullInitialized`), and widening it there would change the
"reassigned before being closed" behaviour too. If you would rather have the fallback applied
consistently in both places, say so and I will do that instead.

### Before / after

Two cases added to `CloseResource.xml` — the reporter's snippet in both shapes, with rule defaults:

```
before:  Tests run: 103, Failures: 1
           [java] CloseResource: plain close, split declaration and assignment (#6742)
           -> Expected 0 problem(s), 1 problem(s) found.
after:   Tests run: 103, Failures: 0, Errors: 0, Skipped: 0
         BUILD SUCCESS
```

Run with `mvn -pl pmd-java test -Dtest=CloseResourceTest` on temurin-25. The control case
(declaration with initializer) passes before and after, so the change only affects the split form.

AI-assisted (LLM used for drafting); the change and both runs above are mine.
