### PR TITLE
[java] Prepare deprecation of asCtx in java-bestpractices (part of #4814)

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
@@ -8,6 +8,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AbstractClassWithoutAbstractMethodRule extends AbstractJavaRulechainRule {
 
@@ -17,14 +18,16 @@ public class AbstractClassWithoutAbstractMethodRule extends AbstractJavaRulechai
 
     @Override
     public Object visit(ASTClassDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.isInterface() || !node.isAbstract() || doesExtend(node) || doesImplement(node)) {
             return data;
         }
 
         if (node.getDeclarations(ASTMethodDeclaration.class).none(ASTMethodDeclaration::isAbstract)) {
-            asCtx(data).addViolation(node);
+            ctx.addViolation(node);
         }
-        return data;
+        return null;
     }
 
     private boolean doesExtend(ASTClassDeclaration node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
@@ -44,16 +44,20 @@ public class AccessorClassGenerationRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (!node.isAnonymousClass()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorMethodGenerationRule.checkMemberAccess(ctx, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }
 
     @Override
     public Object visit(ASTExplicitConstructorInvocation node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.isSuper()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorMethodGenerationRule.checkMemberAccess(ctx, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -38,13 +38,17 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTFieldAccess node, Object data) {
-        checkMemberAccessIfConstValueIsNull(node, (RuleContext) data, node.getReferencedSym());
+        RuleContext ctx = (RuleContext) data;
+
+        checkMemberAccessIfConstValueIsNull(node, ctx, node.getReferencedSym());
         return null;
     }
 
     @Override
     public Object visit(ASTVariableAccess node, Object data) {
-        checkMemberAccessIfConstValueIsNull(node, (RuleContext) data, node.getReferencedSym());
+        RuleContext ctx = (RuleContext) data;
+
+        checkMemberAccessIfConstValueIsNull(node, ctx, node.getReferencedSym());
         return null;
     }
 
@@ -56,7 +60,9 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
-        checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol());
+        RuleContext ctx = (RuleContext) data;
+
+        checkMemberAccess(ctx, node, node.getMethodType().getSymbol());
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -39,14 +39,18 @@ public class ArrayIsStoredDirectlyRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
-        checkAssignments((RuleContext) data, node);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        checkAssignments(ctx, node);
+        return null;
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        checkAssignments((RuleContext) data, node);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        checkAssignments(ctx, node);
+        return null;
     }
 
     private void checkAssignments(RuleContext context, ASTExecutableDeclaration method) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AssertStatementInTestRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AssertStatementInTestRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAssertStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @since 7.25.0
@@ -20,10 +21,12 @@ public class AssertStatementInTestRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (TestFrameworksUtil.isTestMethod(method)
                 || TestFrameworksUtil.isTestConfigurationMethod(method)) {
             method.descendants(ASTAssertStatement.class).forEach(
-                node -> asCtx(data).addViolation(node));
+                node -> ctx.addViolation(node));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningCatchVariablesRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCatchParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidReassigningCatchVariablesRule extends AbstractJavaRule {
 
@@ -22,13 +23,15 @@ public class AvoidReassigningCatchVariablesRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTCatchParameter catchParam, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTVariableId caughtExceptionId = catchParam.getVarId();
         for (ASTNamedReferenceExpr usage : caughtExceptionId.getLocalUsages()) {
             if (usage.getAccessType() == AccessType.WRITE) {
-                asCtx(data).addViolation(usage, caughtExceptionId.getName());
+                ctx.addViolation(usage, caughtExceptionId.getName());
             }
 
         }
-        return data;
+        return null;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -60,9 +60,11 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
 
     @Override
     public Object visit(ASTForeachStatement loopStmt, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ForeachReassignOption behavior = getProperty(FOREACH_REASSIGN);
         if (behavior == ForeachReassignOption.ALLOW) {
-            return data;
+            return null;
         }
         ASTVariableId loopVar = loopStmt.getVarId();
         boolean ignoreNext = behavior == ForeachReassignOption.FIRST_ONLY;
@@ -72,7 +74,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                     ignoreNext = false;
                     continue;
                 }
-                asCtx(data).addViolation(usage, loopVar.getName());
+                ctx.addViolation(usage, loopVar.getName());
             } else {
                 ignoreNext = false;
             }
@@ -82,9 +84,11 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
 
     @Override
     public Object visit(ASTForStatement loopStmt, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ForReassignOption behavior = getProperty(FOR_REASSIGN);
         if (behavior == ForReassignOption.ALLOW) {
-            return data;
+            return null;
         }
         NodeStream<ASTVariableId> loopVars = JavaAstUtils.getLoopVariables(loopStmt);
         if (behavior == ForReassignOption.DENY) {
@@ -95,7 +99,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                         if (update != null && usage.ancestors(ASTForUpdate.class).first() == update) {
                             continue;
                         }
-                        asCtx(data).addViolation(usage, loopVar.getName());
+                        ctx.addViolation(usage, loopVar.getName());
                     }
                 }
             }
@@ -208,7 +212,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
                 .filter(it -> loopVarNames.contains(it.getName()))
                 .filter(it -> onlyConsiderWrite ? it.getAccessType() == AccessType.WRITE && !isSimpleSkipOperation(it)
                                                 : JavaAstUtils.isVarAccessReadAndWrite(it))
-                .forEach(it -> asCtx(ruleCtx).addViolation(it, it.getName()));
+                .forEach(it -> ruleCtx.addViolation(it, it.getName()));
         }
 
         private boolean isSimpleSkipOperation(ASTNamedReferenceExpr expr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class AvoidReassigningParametersRule extends AbstractJavaRulechainRule {
 
@@ -21,23 +22,27 @@ public class AvoidReassigningParametersRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        lookForViolations(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        lookForViolations(node, ctx);
+        return null;
     }
 
 
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
-        lookForViolations(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        lookForViolations(node, ctx);
+        return null;
     }
 
-    private void lookForViolations(ASTExecutableDeclaration node, Object data) {
+    private void lookForViolations(ASTExecutableDeclaration node, RuleContext ctx) {
         for (ASTFormalParameter formal : node.getFormalParameters()) {
             ASTVariableId varId = formal.getVarId();
             for (ASTNamedReferenceExpr usage : varId.getLocalUsages()) {
                 if (usage.getAccessType() == AccessType.WRITE) {
-                    asCtx(data).addViolation(usage, varId.getName());
+                    ctx.addViolation(usage, varId.getName());
                     // only the first assignment should be reported
                     break;
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -68,6 +68,8 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTStringLiteral node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         final String image = node.getConstValue();
 
         // Note: We used to check the addresses using
@@ -81,10 +83,10 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRulechainRule {
             boolean checkIPv4MappedIPv6 = kindsToCheck.contains(AddressKinds.IPV4_MAPPED_IPV6);
 
             if (checkIPv4 && isIPv4(firstChar, image) || isIPv6(firstChar, image, checkIPv6, checkIPv4MappedIPv6)) {
-                asCtx(data).addViolation(node, image);
+                ctx.addViolation(node, image);
             }
         }
-        return data;
+        return null;
     }
 
     private boolean isLatinDigit(char c) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/CheckResultSetRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.ReturnScopeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Rule that verifies, that the return values of next(), first(), last(), etc.
@@ -30,23 +31,25 @@ public class CheckResultSetRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTWhileStatement node, Object data) {
-        return data;
+        return null;
     }
 
     @Override
     public Object visit(ASTReturnStatement node, Object data) {
-        return data;
+        return null;
     }
 
     @Override
     public Object visit(ASTIfStatement node, Object data) {
-        return data;
+        return null;
     }
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (isResultSetMethod(node) && !isCheckedIndirectly(node)) {
-            asCtx(data).addViolation(node);
+            ctx.addViolation(node);
         }
         return super.visit(node, data);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -39,6 +39,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @author Clément Fournier
@@ -58,6 +59,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTForStatement forLoop, Object data) {
+        RuleContext ctx = (RuleContext) data;
 
         final @Nullable ASTStatement init = forLoop.getInit();
         final @Nullable ASTStatementExpressionList update = forLoop.getUpdate();
@@ -71,7 +73,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
         ASTVariableId index = getIndexVarDeclaration(init, update);
 
         if (index == null) {
-            return data;
+            return null;
         }
 
         if (index.getTypeMirror().isPrimitive(INT)) {
@@ -79,17 +81,17 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRulechainRule {
             if (iterable != null) {
                 if (isReplaceableArrayLoop(forLoop, index, iterable)
                     || isReplaceableListLoop(forLoop, index, iterable)) {
-                    asCtx(data).addViolation(forLoop);
+                    ctx.addViolation(forLoop);
                 }
             }
         } else if (TypeTestUtil.isA(Iterator.class, index.getTypeMirror())) {
             if (isReplaceableIteratorLoop(index, forLoop)) {
-                asCtx(data).addViolation(forLoop);
+                ctx.addViolation(forLoop);
             }
-            return data;
+            return null;
         }
 
-        return data;
+        return null;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -98,6 +98,8 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTExpressionStatement node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTExpression expr = node.getExpr();
         if (!(expr instanceof ASTMethodCall)) {
             return null;
@@ -107,7 +109,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         String logLevel = getLogLevelName(methodCall);
         if (logLevel != null && guardStmtByLogLevel.containsKey(logLevel)) {
             if (needsGuard(methodCall) && !hasGuard(methodCall, logLevel)) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class ImplicitFunctionalInterfaceRule extends AbstractJavaRulechainRule {
     public ImplicitFunctionalInterfaceRule() {
@@ -17,12 +18,14 @@ public class ImplicitFunctionalInterfaceRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTClassDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.isRegularInterface()
             && !node.isAnnotationPresent(FunctionalInterface.class)
             && !node.hasModifiers(JModifier.SEALED)) {
             JMethodSig fun = TypeOps.findFunctionalInterfaceMethod(node.getTypeMirror());
             if (fun != null) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule finds code like this:
@@ -45,11 +46,13 @@ public class JUnitUseExpectedRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTBlock body = node.getBody();
         if (body != null && isJUnitMethod(node)) {
             body.descendants(ASTTryStatement.class)
                 .filter(this::isWeirdTry)
-                .forEach(it -> asCtx(data).addViolation(it));
+                .forEach(it -> ctx.addViolation(it));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -32,16 +32,18 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if ("equals".equals(call.getMethodName())
             && call.getArguments().size() == 1
             && isEqualsObjectAndNotAnOverload(call)) {
-            checkArgs((RuleContext) data, call);
+            checkArgs(ctx, call);
         } else if (STRING_COMPARISONS.contains(call.getMethodName())
             && call.getArguments().size() == 1
             && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType())) {
-            checkArgs((RuleContext) data, call);
+            checkArgs(ctx, call);
         }
-        return data;
+        return null;
     }
 
     private boolean isEqualsObjectAndNotAnOverload(ASTMethodCall call) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class LooseCouplingRule extends AbstractJavaRulechainRule {
 
@@ -43,12 +44,14 @@ public class LooseCouplingRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTClassType node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (isConcreteCollectionType(node)
             && !isInOverriddenMethodSignature(node)
             && !isInAllowedSyntacticCtx(node)
             && !isAllowedType(node)
             && !isTypeParameter(node)) {
-            asCtx(data).addViolation(node, node.getSimpleName());
+            ctx.addViolation(node, node.getSimpleName());
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Implementation note: this rule currently ignores return types of y.x.z,
@@ -34,9 +35,11 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (!method.getResultTypeNode().getTypeMirror().isArray()
             || method.getVisibility() == Visibility.V_PRIVATE) {
-            return data;
+            return null;
         }
 
         for (ASTReturnStatement returnStmt : method.descendants(ASTReturnStatement.class)) {
@@ -45,20 +48,20 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
                 ASTNamedReferenceExpr reference = (ASTNamedReferenceExpr) expr;
 
                 if (JavaAstUtils.isRefToFieldOfThisInstance(reference)) {
-                    asCtx(data).addViolation(returnStmt, reference.getName());
+                    ctx.addViolation(returnStmt, reference.getName());
                 } else {
                     // considers static, non-final fields
                     JVariableSymbol symbol = reference.getReferencedSym();
                     if (symbol instanceof JFieldSymbol) {
                         JFieldSymbol field = (JFieldSymbol) symbol;
                         if (field.isStatic() && isInternal(field) && !isZeroLengthArrayConstant(field)) {
-                            asCtx(data).addViolation(returnStmt, reference.getName());
+                            ctx.addViolation(returnStmt, reference.getName());
                         }
                     }
                 }
             }
         }
-        return data;
+        return null;
     }
 
     private static boolean isInternal(JFieldSymbol field) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 /**
@@ -23,9 +24,11 @@ public class MissingOverrideRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.isOverride() && !node.isAnnotationPresent(Override.class)) {
-            asCtx(data).addViolation(node, PrettyPrintingUtil.displaySignature(node));
+            ctx.addViolation(node, PrettyPrintingUtil.displaySignature(node));
         }
-        return data;
+        return null;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
     // todo dfa
@@ -57,6 +58,8 @@ public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTCatchClause catchStmt, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTVariableId exceptionParam = catchStmt.getParameter().getVarId();
         if (JavaRuleUtil.isExplicitUnusedVarName(exceptionParam.getName())) {
             // ignore those
@@ -68,7 +71,7 @@ public class PreserveStackTraceRule extends AbstractJavaRulechainRule {
             ASTExpression thrownExpr = throwStatement.getExpr();
 
             if (!exprConsumesException(Collections.singleton(exceptionParam), thrownExpr, true)) {
-                asCtx(data).addViolation(thrownExpr, exceptionParam.getName());
+                ctx.addViolation(thrownExpr, exceptionParam.getName());
             }
         }
         recursingOnVars.clear();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule {
 
@@ -26,6 +27,8 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
 
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTClassType type = node.firstChild(ASTClassType.class);
         if (type == null) {
             return data;
@@ -38,12 +41,12 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
                 || TypeTestUtil.isA(Short.class, type)
                 || TypeTestUtil.isA(Byte.class, type)
                 || TypeTestUtil.isA(Character.class, type)) {
-            asCtx(data).addViolation(node, type.getSimpleName());
+            ctx.addViolation(node, type.getSimpleName());
         } else if (TypeTestUtil.isA(Boolean.class, type)) {
-            checkArguments(node.getArguments(), node, data);
+            checkArguments(node.getArguments(), node, ctx);
         }
 
-        return data;
+        return null;
     }
 
     /**
@@ -51,14 +54,16 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
      */
     @Override
     public Object visit(ASTMethodCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (BOOLEAN_VALUEOF_MATCHER.matchesCall(node)) {
-            checkArguments(node.getArguments(), node, data);
+            checkArguments(node.getArguments(), node, ctx);
         }
 
-        return data;
+        return null;
     }
 
-    private void checkArguments(ASTArgumentList arguments, JavaNode node, Object data) {
+    private void checkArguments(ASTArgumentList arguments, JavaNode node, RuleContext ctx) {
         if (arguments == null || arguments.size() != 1) {
             return;
         }
@@ -70,21 +75,21 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
         ASTBooleanLiteral boolLiteral = getFirstArgBooleanLiteralOrNull(arguments);
         if (stringLiteral != null) {
             if ("\"true\"".equals(stringLiteral.getImage())) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"true\")`, prefer `Boolean.TRUE`");
+                ctx.addViolationWithMessage(node, messagePart + "(\"true\")`, prefer `Boolean.TRUE`");
             } else if ("\"false\"".equals(stringLiteral.getImage())) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"false\")`, prefer `Boolean.FALSE`");
+                ctx.addViolationWithMessage(node, messagePart + "(\"false\")`, prefer `Boolean.FALSE`");
             } else {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(\"...\")`, prefer `Boolean.valueOf`");
+                ctx.addViolationWithMessage(node, messagePart + "(\"...\")`, prefer `Boolean.valueOf`");
             }
         } else if (boolLiteral != null) {
             if (boolLiteral.isTrue()) {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(true)`, prefer `Boolean.TRUE`");
+                ctx.addViolationWithMessage(node, messagePart + "(true)`, prefer `Boolean.TRUE`");
             } else {
-                asCtx(data).addViolationWithMessage(node, messagePart + "(false)`, prefer `Boolean.FALSE`");
+                ctx.addViolationWithMessage(node, messagePart + "(false)`, prefer `Boolean.FALSE`");
             }
         } else if (isNewBoolean) {
             // any argument with "new Boolean", might be a variable access
-            asCtx(data).addViolationWithMessage(node, messagePart + "(...)`, prefer `Boolean.valueOf`");
+            ctx.addViolationWithMessage(node, messagePart + "(...)`, prefer `Boolean.valueOf`");
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/RelianceOnDefaultCharsetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/RelianceOnDefaultCharsetRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detects constructors and methods that use the JVM's default character set
@@ -81,24 +82,28 @@ public class RelianceOnDefaultCharsetRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
-        checkInvocation(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        checkInvocation(node, ctx);
+        return null;
     }
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
-        checkInvocation(node, data);
-        return data;
+        RuleContext ctx = (RuleContext) data;
+
+        checkInvocation(node, ctx);
+        return null;
     }
 
-    private void checkInvocation(net.sourceforge.pmd.lang.java.ast.JavaNode node, Object data) {
+    private void checkInvocation(net.sourceforge.pmd.lang.java.ast.JavaNode node, RuleContext ctx) {
         for (Map.Entry<InvocationMatcher, String> entry : METHOD_TO_MIN_VERSION.entrySet()) {
             InvocationMatcher matcher = entry.getKey();
             String minVersion = entry.getValue();
             
             // Only flag violation if replacement method is available in current Java version
             if (node.getLanguageVersion().compareToVersion(minVersion) >= 0 && matcher.matchesCall(node)) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  *
@@ -37,6 +38,8 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         final boolean isAssertTrue = isAssertionCall(node, "assertTrue");
         final boolean isAssertFalse = isAssertionCall(node, "assertFalse");
 
@@ -58,7 +61,7 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                         suggestion = isPositive ? "assertSame" : "assertNotSame";
                     }
                 }
-                asCtx(data).addViolation(node, suggestion);
+                ctx.addViolation(node, suggestion);
 
             } else {
                 @Nullable ASTExpression negatedExprOperand = getNegatedExprOperand(lastArg);
@@ -66,17 +69,17 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                 if (OBJECT_EQUALS.matchesCall(negatedExprOperand)) {
                     //assertTrue(!a.equals(b))
                     String suggestion = isAssertTrue ? "assertNotEquals" : "assertEquals";
-                    asCtx(data).addViolation(node, suggestion);
+                    ctx.addViolation(node, suggestion);
 
                 } else if (negatedExprOperand != null) {
                     //assertTrue(!something)
                     String suggestion = isAssertTrue ? "assertFalse" : "assertTrue";
-                    asCtx(data).addViolation(node, suggestion);
+                    ctx.addViolation(node, suggestion);
 
                 } else if (OBJECT_EQUALS.matchesCall(lastArg)) {
                     //assertTrue(a.equals(b))
                     String suggestion = isAssertTrue ? "assertEquals" : "assertNotEquals";
-                    asCtx(data).addViolation(node, suggestion);
+                    ctx.addViolation(node, suggestion);
                 }
             }
         }
@@ -99,7 +102,7 @@ public class SimplifiableTestAssertionRule extends AbstractJavaRulechainRule {
                     if (comp1.getTypeMirror().isPrimitive(PrimitiveTypeKind.BOOLEAN)) {
                         ASTBooleanLiteral literal = (ASTBooleanLiteral) comp0;
                         String suggestion = literal.isTrue() == isAssertEquals ? "assertTrue" : "assertFalse";
-                        asCtx(data).addViolation(node, suggestion);
+                        ctx.addViolation(node, suggestion);
                     }
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestAssertionsShouldIncludeMessageRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher.CompoundInvocationMatcher;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestAssertionsShouldIncludeMessageRule extends AbstractJavaRulechainRule {
 
@@ -34,9 +35,11 @@ public class UnitTestAssertionsShouldIncludeMessageRule extends AbstractJavaRule
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (TestFrameworksUtil.isCallOnAssertionContainer(node)) {
             if (checks.anyMatch(node)) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestContainsTooManyAssertsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.properties.NumericConstraints;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRule {
 
@@ -41,6 +42,8 @@ public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRul
 
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTBlock body = method.getBody();
         if (body != null && TestFrameworksUtil.isTestMethod(method)) {
             Set<String> extraAsserts = getProperty(EXTRA_ASSERT_METHOD_NAMES);
@@ -49,9 +52,9 @@ public class UnitTestContainsTooManyAssertsRule extends AbstractJavaRulechainRul
                                   || extraAsserts.contains(call.getMethodName()))
                                   .count();
             if (assertCount > getProperty(MAX_ASSERTS)) {
-                asCtx(data).addViolation(method);
+                ctx.addViolation(method);
             }
         }
-        return data;
+        return null;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnitTestShouldIncludeAssertRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.TestFrameworksUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
 
@@ -39,6 +40,8 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTTypeDeclaration enclosingType = method.getEnclosingType();
         // marks the usage of a SoftAssertionExtension (JUnit 5+) or SoftAssertionRule (JUnit 4)
         // effects are the same -> no explicit call to .assertAll() necessary
@@ -56,7 +59,7 @@ public class UnitTestShouldIncludeAssertRule extends AbstractJavaRulechainRule {
             && getAllMethodCallsFrom(body)
                 .none(isAssertCall
                         .or(call -> extraAsserts.contains(call.getMethodName())))) {
-            asCtx(data).addViolation(method);
+            ctx.addViolation(method);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRule {
 
@@ -24,6 +25,8 @@ public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRu
 
     @Override
     public Object visit(ASTArrayAllocation array, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (array.getArrayInitializer() == null) {
             return null;
         }
@@ -44,7 +47,7 @@ public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRu
             if (array.getTypeMirror().equals(lastFormal)) {
                 // If type not equal, then it would not actually be equivalent to remove the array creation.
                 // That case may be caught by ConfusingArgumentToVarargsMethod
-                asCtx(data).addViolation(array);
+                ctx.addViolation(array);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -104,9 +104,11 @@ public class UnusedAssignmentRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTCompilationUnit node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         DataflowResult result = DataflowPass.getDataflowResult(node);
-        reportFinished(result, (RuleContext) data);
-        return data;
+        reportFinished(result, ctx);
+        return null;
     }
 
     private void reportFinished(DataflowResult result, RuleContext ruleCtx) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 
 public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
@@ -30,32 +31,36 @@ public class UnusedFormalParameterRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.getVisibility() != Visibility.V_PRIVATE && !getProperty(CHECKALL_DESCRIPTOR)) {
-            return data;
+            return null;
         }
-        check(node, data);
-        return data;
+        check(node, ctx);
+        return null;
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node.getVisibility() != Visibility.V_PRIVATE && !getProperty(CHECKALL_DESCRIPTOR)) {
-            return data;
+            return null;
         }
         if (node.getBody() != null
             && !node.hasModifiers(JModifier.DEFAULT)
             && !JavaRuleUtil.isSerializationReadObject(node)
             && !node.isOverride()) {
-            check(node, data);
+            check(node, ctx);
         }
-        return data;
+        return null;
     }
 
-    private void check(ASTExecutableDeclaration node, Object data) {
+    private void check(ASTExecutableDeclaration node, RuleContext ctx) {
         for (ASTFormalParameter formal : node.getFormalParameters()) {
             ASTVariableId varId = formal.getVarId();
             if (JavaAstUtils.isNeverUsed(varId) && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())) {
-                asCtx(data).addViolation(varId, node instanceof ASTMethodDeclaration ? "method" : "constructor", varId.getName());
+                ctx.addViolation(varId, node instanceof ASTMethodDeclaration ? "method" : "constructor", varId.getName());
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedLocalVariableRule extends AbstractJavaRule {
 
@@ -26,24 +27,28 @@ public class UnusedLocalVariableRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTLocalVariableDeclaration decl, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         for (ASTVariableId varId : decl.getVarIds()) {
             if (JavaAstUtils.isNeverUsed(varId)
                 && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())) {
-                asCtx(data).addViolation(varId, varId.getName());
+                ctx.addViolation(varId, varId.getName());
             }
         }
-        return data;
+        return null;
     }
 
     @Override
     public Object visit(ASTTypePattern pattern, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         ASTVariableId varId = pattern.getVarId();
         if (JavaAstUtils.isNeverUsed(varId)
                 && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())
                 && !neededForSwitchOrRecord(pattern)) {
-            asCtx(data).addViolation(varId, varId.getName());
+            ctx.addViolation(varId, varId.getName());
         }
-        return data;
+        return null;
     }
 
     private boolean neededForSwitchOrRecord(ASTTypePattern pattern) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
 
@@ -47,6 +48,8 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visitJavaNode(JavaNode node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if (node instanceof ASTTypeDeclaration) {
             ASTTypeDeclaration type = (ASTTypeDeclaration) node;
             if (hasAnyAnnotation(type)) {
@@ -59,7 +62,7 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
                     for (ASTVariableId varId : field.getVarIds()) {
                         if (!fieldsUsedByAnnotations.contains(varId.getName())
                                 && JavaAstUtils.isNeverUsed(varId)) {
-                            asCtx(data).addViolation(varId, varId.getName());
+                            ctx.addViolation(varId, varId.getName());
                         }
                     }
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects private methods, that are not used and can therefore be
@@ -50,6 +51,8 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTCompilationUnit file, Object param) {
+        RuleContext ctx = (RuleContext) param;
+
         // this does a couple of traversals:
         // - one to find annotations that potentially reference a method
         // - one to collect candidates, that is, potentially unused methods
@@ -78,7 +81,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             });
 
         for (ASTMethodDeclaration unusedMethod : candidates.values()) {
-            asCtx(param).addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
+            ctx.addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detect structures like "foo.size() == 0" and suggest replacing them with
@@ -26,10 +27,12 @@ public class UseCollectionIsEmptyRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         if ((TypeTestUtil.isA(Collection.class, call.getQualifier())
             || TypeTestUtil.isA(Map.class, call.getQualifier()))
             && isSizeZeroCheck(call)) {
-            asCtx(data).addViolation(call);
+            ctx.addViolation(call);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseEnumCollectionsRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * Detect cases where EnumSet and EnumMap can be used.
@@ -30,6 +31,8 @@ public class UseEnumCollectionsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorCall call, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         JTypeMirror builtType = call.getTypeMirror();
 
         if (!builtType.isRaw()) {
@@ -41,7 +44,7 @@ public class UseEnumCollectionsRule extends AbstractJavaRulechainRule {
 
                 if (keySymbol instanceof JClassSymbol && ((JClassSymbol) keySymbol).isEnum()) {
                     String enumCollectionReplacement = isMap ? "EnumMap" : "EnumSet";
-                    asCtx(data).addViolation(call.getTypeNode(), enumCollectionReplacement);
+                    ctx.addViolation(call.getTypeNode(), enumCollectionReplacement);
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
 
@@ -34,6 +35,8 @@ public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTTryStatement node, Object data) {
+        RuleContext ctx = (RuleContext) data;
+
         boolean isJava9OrLater = node.getLanguageVersion().compareToVersion("9") >= 0;
 
         ASTFinallyClause finallyClause = node.getFinallyClause();
@@ -47,12 +50,12 @@ public final class UseTryWithResourcesRule extends AbstractJavaRulechainRule {
                         && TypeTestUtil.isA(AutoCloseable.class, closeTarget)
                         && (isJava9OrLater || JavaAstUtils.isReferenceToLocal(closeTarget))
                         || hasAutoClosableArguments(method)) {
-                    asCtx(data).addViolation(node);
+                    ctx.addViolation(node);
                     break; // only report the first closeable
                 }
             }
         }
-        return data;
+        return null;
     }
 
     private boolean hasAutoClosableArguments(ASTMethodCall method) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryWarningSuppressionTest.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.rule.Rule;
+import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
@@ -34,8 +35,10 @@ class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
 
         @Override
         public Object visit(ASTUnaryExpression node, Object data) {
+            RuleContext ctx = (RuleContext) data;
+
             if (node.getOperator().isIncrement()) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
             return null;
         }
@@ -52,8 +55,10 @@ class UnnecessaryWarningSuppressionTest extends PmdRuleTst {
 
         @Override
         public Object visit(ASTUnaryExpression node, Object data) {
+            RuleContext ctx = (RuleContext) data;
+
             if (node.getOperator().isDecrement()) {
-                asCtx(data).addViolation(node);
+                ctx.addViolation(node);
             }
             return null;
         }


### PR DESCRIPTION
## Describe the PR

Rewrite all rule visitors in java-bestpractices to...
* cast the "Object data" parameter to RuleContext first
* never touch "data" again
* return null instead of data

This removes all calls to asCtx() from java-bestpractices.

If this PR is accepted, I plan on preparing further PRs for the rest of the code.

## Related issues

- Part of #4814

## Ready?

- [n/a] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

