### PR TITLE
[java] Fix #1287: GuardLogStatement false positive with a guard clause

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -82,6 +82,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
     * [#6932](https://github.com/pmd/pmd/issues/6932): \[java] AssertionError when outer class is parsed before inner class with conflicting visibility
 * java-bestpractices
+    * [#1287](https://github.com/pmd/pmd/issues/1287): \[java] GuardLogStatement: False positive when using negative guard conditions
     * [#2033](https://github.com/pmd/pmd/issues/2033): \[jsp] NoClassAttribute rule is generating a false positive
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -162,13 +162,34 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
      * }
      * log.debug("..." + expensive());
      * }</pre>
+     *
+     * <p>The guard also covers log statements nested deeper than the guard itself,
+     * as the early exit applies to everything that follows it in the block:
+     *
+     * <pre>{@code
+     * if (!log.isDebugEnabled()) {
+     *     return;
+     * }
+     * for (Object o : os) {
+     *     log.debug("..." + o);
+     * }
+     * }</pre>
      */
     private boolean hasEarlyExitGuard(ASTMethodCall node, String logLevel) {
-        ASTStatement statement = node.ancestors(ASTStatement.class).first();
-        if (statement == null || !(statement.getParent() instanceof ASTBlock)) {
-            return false;
+        for (ASTStatement statement : node.ancestors(ASTStatement.class)) {
+            if (statement.getParent() instanceof ASTBlock
+                    && isGuardedBefore(statement, logLevel)) {
+                return true;
+            }
         }
+        return false;
+    }
 
+    /**
+     * Whether a statement preceding {@code statement} in its enclosing block is a
+     * guard clause for {@code logLevel}.
+     */
+    private boolean isGuardedBefore(ASTStatement statement, String logLevel) {
         for (ASTStatement sibling : statement.getParent().children(ASTStatement.class)) {
             if (sibling == statement) {
                 return false;
@@ -191,13 +212,9 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
                 && ((ASTUnaryExpression) condition).getOperator() == UnaryOp.NEGATION;
     }
 
-    private boolean alwaysExits(ASTStatement statement) {
+    private boolean alwaysExits(@Nullable ASTStatement statement) {
         if (statement instanceof ASTBlock) {
-            ASTStatement last = null;
-            for (ASTStatement child : ((ASTBlock) statement).children(ASTStatement.class)) {
-                last = child;
-            }
-            return last != null && alwaysExits(last);
+            return alwaysExits(statement.children(ASTStatement.class).last());
         }
         return statement instanceof ASTReturnStatement
                 || statement instanceof ASTThrowStatement

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -16,6 +16,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTBreakStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTContinueStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
@@ -24,10 +27,15 @@ import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.QualifiableExpression;
+import net.sourceforge.pmd.lang.java.ast.UnaryOp;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -141,7 +149,60 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
                 return true;
             }
         }
+        return hasEarlyExitGuard(node, logLevel);
+    }
+
+    /**
+     * Recognizes the guard clause style, where the guard is not an ancestor of the log
+     * statement but a preceding sibling that leaves the block:
+     *
+     * <pre>{@code
+     * if (!log.isDebugEnabled()) {
+     *     return;
+     * }
+     * log.debug("..." + expensive());
+     * }</pre>
+     */
+    private boolean hasEarlyExitGuard(ASTMethodCall node, String logLevel) {
+        ASTStatement statement = node.ancestors(ASTStatement.class).first();
+        if (statement == null || !(statement.getParent() instanceof ASTBlock)) {
+            return false;
+        }
+
+        for (ASTStatement sibling : statement.getParent().children(ASTStatement.class)) {
+            if (sibling == statement) {
+                return false;
+            }
+            if (sibling instanceof ASTIfStatement) {
+                ASTIfStatement ifStatement = (ASTIfStatement) sibling;
+                if (ifStatement.getElseBranch() == null
+                        && isNegation(ifStatement.getCondition())
+                        && containsGuardMethod(ifStatement, logLevel)
+                        && alwaysExits(ifStatement.getThenBranch())) {
+                    return true;
+                }
+            }
+        }
         return false;
+    }
+
+    private boolean isNegation(ASTExpression condition) {
+        return condition instanceof ASTUnaryExpression
+                && ((ASTUnaryExpression) condition).getOperator() == UnaryOp.NEGATION;
+    }
+
+    private boolean alwaysExits(ASTStatement statement) {
+        if (statement instanceof ASTBlock) {
+            ASTStatement last = null;
+            for (ASTStatement child : ((ASTBlock) statement).children(ASTStatement.class)) {
+                last = child;
+            }
+            return last != null && alwaysExits(last);
+        }
+        return statement instanceof ASTReturnStatement
+                || statement instanceof ASTThrowStatement
+                || statement instanceof ASTContinueStatement
+                || statement instanceof ASTBreakStatement;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -32,10 +32,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.QualifiableExpression;
-import net.sourceforge.pmd.lang.java.ast.UnaryOp;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -156,26 +155,8 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
 
     /**
      * Recognizes the guard clause style, where the guard is not an ancestor of the log
-     * statement but a preceding sibling that leaves the block:
-     *
-     * <pre>{@code
-     * if (!log.isDebugEnabled()) {
-     *     return;
-     * }
-     * log.debug("..." + expensive());
-     * }</pre>
-     *
-     * <p>The guard also covers log statements nested deeper than the guard itself,
-     * as the early exit applies to everything that follows it in the block:
-     *
-     * <pre>{@code
-     * if (!log.isDebugEnabled()) {
-     *     return;
-     * }
-     * for (Object o : os) {
-     *     log.debug("..." + o);
-     * }
-     * }</pre>
+     * statement, but an earlier statement of an enclosing block that exits that block.
+     * Such a guard covers everything following it, however deeply nested.
      */
     private boolean hasEarlyExitGuard(ASTMethodCall node, String logLevel) {
         for (ASTStatement statement : node.ancestors(ASTStatement.class)) {
@@ -199,7 +180,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
             if (sibling instanceof ASTIfStatement) {
                 ASTIfStatement ifStatement = (ASTIfStatement) sibling;
                 if (ifStatement.getElseBranch() == null
-                        && isNegation(ifStatement.getCondition())
+                        && JavaAstUtils.isBooleanNegation(ifStatement.getCondition())
                         && containsGuardMethod(ifStatement, logLevel)
                         && alwaysExits(ifStatement.getThenBranch())) {
                     return true;
@@ -207,11 +188,6 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
             }
         }
         return false;
-    }
-
-    private boolean isNegation(ASTExpression condition) {
-        return condition instanceof ASTUnaryExpression
-                && ((ASTUnaryExpression) condition).getOperator() == UnaryOp.NEGATION;
     }
 
     private boolean alwaysExits(@Nullable ASTStatement statement) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -890,4 +890,94 @@ public class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>[java] guard clause covers a log statement nested in a loop (#1287)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object[] os) {
+        if (!LOG.isDebugEnabled()) {
+            return;
+        }
+        for (Object o : os) {
+            LOG.debug("logging from " + o);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] guard clause covers a log statement nested several blocks deep (#1287)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object[] os, boolean flag) {
+        if (!LOG.isDebugEnabled()) {
+            return;
+        }
+        for (Object o : os) {
+            if (flag) {
+                try {
+                    LOG.debug("logging from " + o);
+                } finally {
+                    System.out.println("done");
+                }
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] continue guard inside a loop does not guard a log after the loop (#1287)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object[] os) {
+        for (Object o : os) {
+            if (!LOG.isDebugEnabled()) {
+                continue;
+            }
+        }
+        LOG.debug("logging from " + os.length);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] guard in a sibling block does not guard a later log statement (#1287)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object o, boolean flag) {
+        if (flag) {
+            if (!LOG.isDebugEnabled()) {
+                return;
+            }
+        }
+        LOG.debug("logging from " + o);
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -833,4 +833,61 @@ public class Foo {
 }
     ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] guard clause with early return, slf4j (#1287)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object o) {
+        if (!LOG.isDebugEnabled()) {
+            return;
+        }
+        LOG.debug("logging from " + o);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] guard clause without braces, early return (#1287)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object o) {
+        if (!LOG.isDebugEnabled())
+            return;
+        LOG.debug("logging from " + o);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] positive guard clause that does not exit is still unguarded (#1287)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+
+public class Foo {
+    private static final Logger LOG = null;
+
+    private void log(Object o) {
+        if (!LOG.isDebugEnabled()) {
+            System.out.println("still here");
+        }
+        LOG.debug("logging from " + o);
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
Fixes #1287

`GuardLogStatement` only recognizes the wrapping style of guard, so the guard-clause style is reported
even though the log call is unreachable when the level is disabled:

```java
private void log(Object o) {
    if (!LOG.isDebugEnabled()) {
        return;
    }
    LOG.debug("logging from " + o);   // reported
}
```

`hasGuard()` looks for the guard among the *ancestors* of the log call:

```java
for (ASTIfStatement ifStatement : node.ancestors(ASTIfStatement.class).take(2)) {
    if (containsGuardMethod(ifStatement, logLevel)) {
        return true;
    }
}
return false;
```

With an early return the guard is not an ancestor — it is a preceding sibling in the same block, so it
is never seen.

This adds a second lookup for that shape. To avoid weakening the rule it is deliberately narrow: the
preceding `if` counts as a guard only when it has no `else` branch, its condition is a negation
containing the guard method for the same log level, and its then-branch always leaves the block
(`return` / `throw` / `continue` / `break`, or a block ending in one of those).

### Before / after

Three cases added to `GuardLogStatement.xml` — the reported shape, the same without braces, and a
negative control where the `if` body does *not* exit and the call therefore stays unguarded:

```
before:  Test Failure: guard clause with early return, slf4j (#1287)
           -> Expected 0 problem(s), 1 problem(s) found.
         Test Failure: guard clause without braces, early return (#1287)
           -> Expected 0 problem(s), 1 problem(s) found.

after:   Tests run: 41, Failures: 0, Errors: 0, Skipped: 0
```

The control case passes both before and after, so the change narrows the rule only for guards that
really do skip the statement. Run with `mvn -pl pmd-java test -Dtest=GuardLogStatementTest` on
temurin-25.

AI-assisted (LLM used for drafting); the change and both runs above are mine.
