### PR TITLE
[core] Fix #6913: Use the configured class loader in RuleSetLoader#loadFromString

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -58,6 +58,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
     * [#6865](https://github.com/pmd/pmd/issues/6865): \[core] Include the running PMD version in the "Unable to find referenced rule" error
+    * [#6913](https://github.com/pmd/pmd/issues/6913): \[core] RuleSetLoader#loadFromString ignores previously configured Resource/ClassLoader
 * java
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
@@ -154,7 +154,7 @@ public final class RuleSetLoader {
 
         ResourceLoader oldLoader = this.resourceLoader;
         try {
-            loadResourcesWith(new ResourceLoader() {
+            loadResourcesWith(new ResourceLoader(oldLoader.getClassLoader()) {
                 @Override
                 public @NonNull InputStream loadResourceAsStream(String name) throws IOException {
                     if (Objects.equals(name, filename)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/ResourceLoader.java
@@ -55,6 +55,14 @@ public class ResourceLoader {
     }
 
     /**
+     * Returns the classloader this instance uses to resolve classpath
+     * resources and rule classes.
+     */
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    /**
      * Attempts to load the resource from file, a URL or the classpath.
      *
      * <p>Caller is responsible for closing the {@link InputStream}.

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,6 +43,31 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
 
         rs = new RuleSetLoader().loadFromResource(TEST_RULESET_1);
         assertEquals(rs.getFileName(), TEST_RULESET_1, "wrong RuleSet file name");
+    }
+
+    @Test
+    void testLoadFromStringUsesConfiguredClassLoader() {
+        String ruleClass = "net.sourceforge.pmd.lang.rule.RuleOnlyVisibleToCustomClassLoader";
+        AtomicBoolean askedForRuleClass = new AtomicBoolean();
+        ClassLoader customClassLoader = new ClassLoader(RuleSetFactoryTest.class.getClassLoader()) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (ruleClass.equals(name)) {
+                    askedForRuleClass.set(true);
+                    return MockRuleWithNoProperties.class;
+                }
+                return super.loadClass(name);
+            }
+        };
+
+        RuleSet rs = new RuleSetLoader().loadResourcesWith(customClassLoader)
+                                        .withReporter(mockReporter)
+                                        .loadFromString("ruleset.xml", rulesetXml(
+                                            dummyRule(attrs -> attrs.put(SchemaConstants.CLASS, ruleClass))));
+
+        assertTrue(askedForRuleClass.get(), "the configured class loader was not used to load the rule class");
+        assertEquals(1, rs.size());
+        assertEquals(MockRuleWithNoProperties.class, rs.getRules().iterator().next().getClass());
     }
 
     @Test


### PR DESCRIPTION
## Describe the PR

`RuleSetLoader#loadFromString` temporarily replaces the configured `ResourceLoader` with an anonymous wrapper that serves the XML content for the symbolic file name. That wrapper was built with the no-arg `ResourceLoader()` constructor, so it silently fell back to PMD's own class loader.

Resource lookups still behaved correctly, because the wrapper's `loadResourceAsStream` delegates to the previous loader for every other name. Everything that goes through the class loader did not:

* `ResourceLoader#loadRuleFromClassPath` could not find rule classes that are only visible to the class loader passed to `loadResourcesWith(ClassLoader)`, so loading the ruleset failed with `Reflection error while instantiating rule (ClassNotFoundException)`.
* `loadClassPathResourceAsStream` used the wrong class loader for the same reason.

```java
new RuleSetLoader()
  .loadResourcesWith(customClassLoader)
  .loadFromString(location, rulesetXmlContent); // customClassLoader was ignored
```

The fix constructs the wrapper with the previous loader's class loader, so class and classpath resource resolution keep using what the caller configured. Passing the class loader (rather than overriding the individual class-loading methods) also keeps any future `ResourceLoader` method that uses the class loader correct by construction.

`ResourceLoader#getClassLoader()` is added for that. `ResourceLoader` lives in `net.sourceforge.pmd.util.internal` and is marked `@internalApi`, and japicmp reports no API change for this PR.

## Related issues

- Fix #6913

## Ready?

- [x] Added unit tests for fixed bug/feature

  `RuleSetFactoryTest#testLoadFromStringUsesConfiguredClassLoader` loads a ruleset whose `class` attribute is only resolvable through the configured class loader. On `main` it fails with `Reflection error while instantiating rule (ClassNotFoundException)`; the other 59 tests of that class stay green, so the new test is not covered by the existing ones.
- [x] Passing all unit tests

  `./mvnw -pl pmd-core verify` on this branch: `Tests run: 6441, Failures: 0, Errors: 0, Skipped: 7`, with checkstyle, pmd, cpd-check and japicmp all passing.
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)

  GitHub Actions has not run on this PR yet, so I ran the complete build locally on `b141dac`, with Temurin 21.0.9 on macOS aarch64:

  ```
  ./mvnw --show-version --errors --batch-mode clean verify
  BUILD SUCCESS -- Total time: 12:33 min
  ```

  All 44 modules pass. `19188` unit tests (`Failures: 0, Errors: 0, Skipped: 39`) plus `31` integration tests, `checkstyle:check` reporting `0` violations in each of the 44 modules, and `pmd:check`, `pmd:cpd-check`, `javadoc:jar` and `source:jar` green everywhere. `japicmp:cmp` also runs in all 44 modules and is configured with `breakBuildBasedOnSemanticVersioning`, so the green build covers the API compatibility claim above. `RuleSetFactoryTest` itself runs `Tests run: 60, Failures: 0, Errors: 0, Skipped: 0`, that is the 59 existing tests plus the new one.
- [x] Added (in-code) documentation (if needed)

