### PR TITLE
[java] Fix #6882: New Rule: Enforce that local variables are declared at the start of their scope without initialization

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
@@ -1,0 +1,36 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
+public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJavaRulechainRule {
+
+    private static final PropertyDescriptor<Boolean> REQUIRE_BEFORE_THIS_SUPER =
+            PropertyFactory.booleanProperty("requireBeforeThisSuper")
+                    .desc("Require that variable declaration comes before super(...) and this(...) calls. Must be set to false in Java24 and below.")
+                    .defaultValue(true)
+                    .build();
+
+    public LocalVariableDeclarationShouldBeAtStartOfBlock() {
+        super(ASTLocalVariableDeclaration.class);
+        definePropertyDescriptor(REQUIRE_BEFORE_THIS_SUPER);
+    }
+
+    @Override
+    public Object visit(ASTLocalVariableDeclaration declaration, Object data) {
+        // rule does not apply to variables declared and initialised inside for loop initialisers
+        if (declaration.getParent() instanceof ASTForStatement || declaration.getParent() instanceof ASTForeachStatement) {
+            asCtx(data).addViolation(declaration, "This was a for loop");
+            return data;
+        }
+        return data;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
@@ -4,9 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -26,11 +31,55 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
 
     @Override
     public Object visit(ASTLocalVariableDeclaration declaration, Object data) {
-        // rule does not apply to variables declared and initialised inside for loop initialisers
-        if (declaration.getParent() instanceof ASTForStatement || declaration.getParent() instanceof ASTForeachStatement) {
-            asCtx(data).addViolation(declaration, "This was a for loop");
+        JavaNode parent = declaration.getParent(); // parent cannot be null here
+
+        // rule does not apply to variables declared and initialized inside for loop initializers
+        if (parent.getParent() instanceof ASTForStatement || parent.getParent() instanceof ASTForeachStatement) {
             return data;
         }
+
+        // rule does not apply to variables declared with var keyword
+        if (declaration.isTypeInferred()) {
+            return data;
+        }
+
+        if (parent instanceof ASTBlock) {
+
+            if (!isAtStartOfBlock(declaration)) {
+                ASTVariableId firstVarID = declaration.getVarIds().first();
+                if (firstVarID == null) { // should never be null but just in case
+                    return data;
+                }
+                asCtx(data).addViolation(declaration, firstVarID.getName());
+            }
+        }
+
         return data;
+    }
+
+    private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration) {
+        JavaNode sibling = declaration;
+        while (sibling != null) {
+
+            if (sibling instanceof ASTLocalVariableDeclaration) {
+                ASTLocalVariableDeclaration siblingDecl = (ASTLocalVariableDeclaration) sibling;
+                // declaration cannot not have a declarator so there should be no risk of NPE
+                ASTVariableDeclarator declarator = (ASTVariableDeclarator) siblingDecl.getLastChild();
+                // if declarator includes more than just variable name (also includes expression)
+                if (declarator.getNumChildren() != 1) {
+                    return false;
+                }
+            } else if (sibling instanceof ASTExplicitConstructorInvocation) {
+                // super or this
+                if (getProperty(REQUIRE_BEFORE_THIS_SUPER)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+
+            sibling = sibling.getPreviousSibling();
+        }
+        return true;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
@@ -81,7 +82,8 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
                 if (getProperty(REQUIRE_BEFORE_THIS_SUPER)) {
                     return false;
                 }
-            } else if (!(sibling instanceof ASTLocalVariableDeclaration)) {
+            } else if (!(sibling instanceof ASTLocalVariableDeclaration
+                    || sibling instanceof ASTSwitchLabel)) {
                 return false;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
-import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
@@ -43,38 +42,46 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
             return data;
         }
 
-        if (parent instanceof ASTBlock) {
-
-            if (!isAtStartOfBlock(declaration)) {
-                ASTVariableId firstVarID = declaration.getVarIds().first();
-                if (firstVarID == null) { // should never be null but just in case
-                    return data;
-                }
-                asCtx(data).addViolation(declaration, firstVarID.getName());
+        if (!isAtStartOfBlock(declaration) || containsInitialization(declaration)) {
+            ASTVariableId firstVarID = declaration.getVarIds().first();
+            if (firstVarID == null) { // should never be null but just in case
+                return data;
             }
+            asCtx(data).addViolation(declaration, firstVarID.getName());
         }
 
         return data;
     }
 
+    /*
+    Whether any variables in the declaration are initialized
+     */
+    private boolean containsInitialization(ASTLocalVariableDeclaration declaration) {
+        for (int childNum = 0; childNum < declaration.getNumChildren(); childNum++) {
+            JavaNode nthChild = declaration.getChild(childNum);
+
+            if (nthChild instanceof ASTVariableDeclarator) {
+                ASTVariableDeclarator declarator = (ASTVariableDeclarator) nthChild;
+
+                if (declarator.getInitializer() != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration) {
-        JavaNode sibling = declaration;
+
+        JavaNode sibling = declaration.getPreviousSibling();
         while (sibling != null) {
 
-            if (sibling instanceof ASTLocalVariableDeclaration) {
-                ASTLocalVariableDeclaration siblingDecl = (ASTLocalVariableDeclaration) sibling;
-                // declaration cannot not have a declarator so there should be no risk of NPE
-                ASTVariableDeclarator declarator = (ASTVariableDeclarator) siblingDecl.getLastChild();
-                // if declarator includes more than just variable name (also includes expression)
-                if (declarator.getNumChildren() != 1) {
-                    return false;
-                }
-            } else if (sibling instanceof ASTExplicitConstructorInvocation) {
+            if (sibling instanceof ASTExplicitConstructorInvocation) {
                 // super or this
                 if (getProperty(REQUIRE_BEFORE_THIS_SUPER)) {
                     return false;
                 }
-            } else {
+            } else if (!(sibling instanceof ASTLocalVariableDeclaration)) {
                 return false;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlock.java
@@ -4,10 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
-import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
-import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
@@ -31,10 +31,9 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
 
     @Override
     public Object visit(ASTLocalVariableDeclaration declaration, Object data) {
-        JavaNode parent = declaration.getParent(); // parent cannot be null here
-
         // rule does not apply to variables declared and initialized inside for loop initializers
-        if (parent.getParent() instanceof ASTForStatement || parent.getParent() instanceof ASTForeachStatement) {
+        // it also does not apply to try-with-resources blocks
+        if (isInStatementInitializer(declaration)) {
             return data;
         }
 
@@ -43,24 +42,44 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
             return data;
         }
 
-        if (!isAtStartOfBlock(declaration) || containsInitialization(declaration)) {
-            ASTVariableId firstVarID = declaration.getVarIds().first();
-            if (firstVarID == null) { // should never be null but just in case
+        boolean declarationContainsInitialization = containsInitialization(declaration);
+
+        if (!isAtStartOfBlock(declaration) || declarationContainsInitialization) {
+            JavaNode child = declaration.getFirstChild();
+            ASTVariableId firstFlaggedVarID = null;
+
+            while (child != null) {
+                if (child instanceof ASTVariableDeclarator) {
+                    ASTVariableDeclarator castedChild = (ASTVariableDeclarator) child;
+                    if (!declarationContainsInitialization || castedChild.hasInitializer()) {
+                        firstFlaggedVarID = castedChild.getVarId();
+                        break;
+                    }
+                }
+                child = child.getNextSibling();
+            }
+
+            if (firstFlaggedVarID == null) { // should never be null but just in case
+                asCtx(data).addViolation(declaration, "THIS IS NOT SUPPOSED TO HAPPEN");
                 return data;
             }
-            asCtx(data).addViolation(declaration, firstVarID.getName());
+            asCtx(data).addViolation(declaration, firstFlaggedVarID.getName());
         }
 
         return data;
+    }
+
+    private boolean isInStatementInitializer(ASTLocalVariableDeclaration declaration) {
+        // this will stop working if a distinct scope can exist inside a new type of statement (not braces or case of switch)
+        return !(declaration.getParent() instanceof ASTBlock
+                || declaration.getParent() instanceof ASTSwitchFallthroughBranch);
     }
 
     /*
     Whether any variables in the declaration are initialized
      */
     private boolean containsInitialization(ASTLocalVariableDeclaration declaration) {
-        for (int childNum = 0; childNum < declaration.getNumChildren(); childNum++) {
-            JavaNode nthChild = declaration.getChild(childNum);
-
+        for (JavaNode nthChild: declaration.children()) {
             if (nthChild instanceof ASTVariableDeclarator) {
                 ASTVariableDeclarator declarator = (ASTVariableDeclarator) nthChild;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -10,7 +10,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -4,6 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.conventionalEnumProperty;
+
+import java.util.Locale;
+
 import net.sourceforge.pmd.lang.ast.internal.StreamImpl;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
@@ -11,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -19,13 +24,33 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
 
     private static final PropertyDescriptor<Boolean> REQUIRE_BEFORE_THIS_SUPER =
             PropertyFactory.booleanProperty("requireBeforeThisSuper")
-                    .desc("Require that variable declaration comes before super(...) and this(...) calls. Must be set to false in Java24 and below.")
+                    .desc("Require that variable declaration comes before super(...) and this(...) calls. Always behaves as false in Java24 and below.")
                     .defaultValue(true)
                     .build();
+
+
+    private static final PropertyDescriptor<SortBy> SORT_BY =
+            conventionalEnumProperty("sortBy", SortBy.class)
+                    .desc("Enforce lexicographic sorting of variable declarations. When sorting by type declarations of the same type will be ordered by name.")
+                    .defaultValue(SortBy.NONE)
+                    .build();
+
+    private static final PropertyDescriptor<Boolean> CASE_SENSITIVE_SORTING =
+            PropertyFactory.booleanProperty("caseSensitiveSorting")
+                    .desc("Use case sensitive sorting")
+                    .defaultValue(false)
+                    .build();
+
+
+    private enum SortBy {
+        NAME, TYPE, NONE
+    }
 
     public LocalVariableDeclarationShouldBeAtStartOfBlockRule() {
         super(ASTLocalVariableDeclaration.class);
         definePropertyDescriptor(REQUIRE_BEFORE_THIS_SUPER);
+        definePropertyDescriptor(SORT_BY);
+        definePropertyDescriptor(CASE_SENSITIVE_SORTING);
     }
 
     @Override
@@ -36,27 +61,31 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
             return data;
         }
 
-        // rule does not apply to variables declared with var keyword
-        if (declaration.isTypeInferred()) {
-            return data;
+        String version = declaration.getLanguageVersion().getName().replace("Java ", "");
+        String numericPart = version.replace("-preview", "");
+        double versionNum = Double.parseDouble(numericPart);
+
+        boolean declarationIsAtStartOfBlock = isAtStartOfBlock(declaration, versionNum < 25);
+
+        // initialisation and start of block enforcement does not apply to variables declared with var keyword
+        if (!declaration.isTypeInferred()) {
+            declaration.children(ASTVariableDeclarator.class).forEach(child -> {
+                if (child.hasInitializer()) {
+                    String childName = child.getVarId().getName();
+                    asCtx(data).addViolationWithMessage(child,
+                            "Local variable `" + childName + "` is declared with initialization");
+                }
+                if (!declarationIsAtStartOfBlock) {
+                    String childName = child.getVarId().getName();
+                    asCtx(data).addViolationWithMessage(child,
+                            "Local variable `" + childName + "` is not declared at start of block");
+                }
+            });
         }
 
-        boolean declarationIsAtStartOfBlock = isAtStartOfBlock(declaration);
-
-        declaration.children(ASTVariableDeclarator.class).forEach(
-                child -> {
-                    if (child.hasInitializer()) {
-                        String childName = child.getVarId().getName();
-                        asCtx(data).addViolationWithMessage(child,
-                                "Local variable `" + childName + "` is declared with initialization");
-                    }
-                    if (!declarationIsAtStartOfBlock) {
-                        String childName = child.getVarId().getName();
-                        asCtx(data).addViolationWithMessage(child,
-                                "Local variable `" + childName + "` is not declared at start of block");
-                    }
-                });
-
+        if (declarationIsAtStartOfBlock) {
+            return flagSorting(declaration, data, getPreviousDeclaration(declaration));
+        }
         return data;
     }
 
@@ -66,16 +95,100 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
                 || declaration.getParent() instanceof ASTSwitchFallthroughBranch);
     }
 
-    private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration) {
+    private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration, boolean ignoreThisSuper) {
 
         return StreamImpl.precedingSiblings(declaration).all(
             sibling -> {
                 if (sibling instanceof ASTExplicitConstructorInvocation) {
                     // super or this
-                    return !getProperty(REQUIRE_BEFORE_THIS_SUPER);
+                    return !getProperty(REQUIRE_BEFORE_THIS_SUPER) || ignoreThisSuper;
                 }
                 return sibling instanceof ASTLocalVariableDeclaration || sibling instanceof ASTSwitchLabel;
             }
         );
+    }
+
+    /*
+    Takes a declaration and raises a violation if it is out of order with the previous declaration
+     */
+    private Object flagSorting(ASTLocalVariableDeclaration node,
+                                                Object data,
+                                                ASTLocalVariableDeclaration previousDeclaration) {
+
+        if (getProperty(SORT_BY) == SortBy.NONE) {
+            return data;
+        }
+
+        // it is the first declaration in the scope
+        if (previousDeclaration == null) {
+            return data;
+        }
+
+        String prevName = previousDeclaration.getVarIds().get(0).getName();
+        String nodeName = node.getVarIds().get(0).getName();
+        TypeNode prevType = previousDeclaration.getTypeNode();
+        TypeNode nodeType = node.getTypeNode();
+
+        if (isDeclarationOrderCorrect(prevType, prevName, nodeType, nodeName)) {
+            return data;
+        }
+
+        asCtx(data).addViolation(node, nodeName, prevName,
+                getProperty(SORT_BY).toString().toLowerCase(Locale.ENGLISH));
+
+        return data;
+    }
+
+    /*
+    It takes the properties of two variables, 1 comes before 2 in the code and returns whether they are in the correct order
+     */
+    private boolean isDeclarationOrderCorrect(TypeNode type1, String name1, TypeNode type2, String name2) {
+        if (getProperty(SORT_BY) == SortBy.TYPE) {
+            String t1;
+            String t2;
+
+            if (type1 == null) {
+                t1 = "var";
+            } else {
+                t1 = type1.getOriginalText().toString().replace(" ", "");
+            }
+
+            if (type2 == null) {
+                t2 = "var";
+            } else {
+                t2 = type2.getOriginalText().toString().replace(" ", "");
+            }
+
+            if (!getProperty(CASE_SENSITIVE_SORTING)) {
+                t1 = t1.toLowerCase(Locale.ENGLISH);
+                t2 = t2.toLowerCase(Locale.ENGLISH);
+            }
+
+            // if they are the same then continue to name sorting
+            if (!t2.equals(t1)) {
+                // if either is var then the result is decided otherwise compare directly
+                if ("var".equals(t1)) {
+                    return false;
+                }
+                return "var".equals(t2) || t1.compareTo(t2) < 0;
+            }
+        }
+
+        // either sort by is set to name or their types are the same and it has defaulted to name
+        if (!getProperty(CASE_SENSITIVE_SORTING)) {
+            name1 = name1.toLowerCase(Locale.ENGLISH);
+            name2 = name2.toLowerCase(Locale.ENGLISH);
+        }
+        // non-strict inequality because variables with the same name but different capitalization are equal
+        // but should not be flagged when caseSensitiveSorting is false
+        return name1.compareTo(name2) <= 0;
+
+    }
+
+    private ASTLocalVariableDeclaration getPreviousDeclaration(ASTLocalVariableDeclaration node) {
+        return (ASTLocalVariableDeclaration) StreamImpl
+                .precedingSiblings(node)
+                .filter(n -> n instanceof ASTLocalVariableDeclaration)
+                .last();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -4,13 +4,13 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import net.sourceforge.pmd.lang.ast.internal.StreamImpl;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -43,22 +43,19 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
 
         boolean declarationIsAtStartOfBlock = isAtStartOfBlock(declaration);
 
-        JavaNode child = declaration.getFirstChild();
-
-        while (child != null) {
-            if (child instanceof ASTVariableDeclarator) {
-                ASTVariableDeclarator castedChild = (ASTVariableDeclarator) child;
-                if (castedChild.hasInitializer()) {
-                    String childName = castedChild.getVarId().getName();
-                    asCtx(data).addViolationWithMessage(castedChild, "Local variable `" + childName + "` is declared with initialization");
-                }
-                if (!declarationIsAtStartOfBlock) {
-                    String childName = castedChild.getVarId().getName();
-                    asCtx(data).addViolationWithMessage(castedChild, "Local variable `" + childName + "` is not declared at start of block");
-                }
-            }
-            child = child.getNextSibling();
-        }
+        declaration.children(ASTVariableDeclarator.class).forEach(
+                child -> {
+                    if (child.hasInitializer()) {
+                        String childName = child.getVarId().getName();
+                        asCtx(data).addViolationWithMessage(child,
+                                "Local variable `" + childName + "` is declared with initialization");
+                    }
+                    if (!declarationIsAtStartOfBlock) {
+                        String childName = child.getVarId().getName();
+                        asCtx(data).addViolationWithMessage(child,
+                                "Local variable `" + childName + "` is not declared at start of block");
+                    }
+                });
 
         return data;
     }
@@ -71,21 +68,14 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
 
     private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration) {
 
-        JavaNode sibling = declaration.getPreviousSibling();
-        while (sibling != null) {
-
-            if (sibling instanceof ASTExplicitConstructorInvocation) {
-                // super or this
-                if (getProperty(REQUIRE_BEFORE_THIS_SUPER)) {
-                    return false;
+        return StreamImpl.precedingSiblings(declaration).all(
+            sibling -> {
+                if (sibling instanceof ASTExplicitConstructorInvocation) {
+                    // super or this
+                    return !getProperty(REQUIRE_BEFORE_THIS_SUPER);
                 }
-            } else if (!(sibling instanceof ASTLocalVariableDeclaration
-                    || sibling instanceof ASTSwitchLabel)) {
-                return false;
+                return sibling instanceof ASTLocalVariableDeclaration || sibling instanceof ASTSwitchLabel;
             }
-
-            sibling = sibling.getPreviousSibling();
-        }
-        return true;
+        );
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -16,7 +16,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
-public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJavaRulechainRule {
+public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends AbstractJavaRulechainRule {
 
     private static final PropertyDescriptor<Boolean> REQUIRE_BEFORE_THIS_SUPER =
             PropertyFactory.booleanProperty("requireBeforeThisSuper")
@@ -24,7 +24,7 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlock extends AbstractJava
                     .defaultValue(true)
                     .build();
 
-    public LocalVariableDeclarationShouldBeAtStartOfBlock() {
+    public LocalVariableDeclarationShouldBeAtStartOfBlockRule() {
         super(ASTLocalVariableDeclaration.class);
         definePropertyDescriptor(REQUIRE_BEFORE_THIS_SUPER);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -42,27 +42,23 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
             return data;
         }
 
-        boolean declarationContainsInitialization = containsInitialization(declaration);
+        boolean declarationIsAtStartOfBlock = isAtStartOfBlock(declaration);
 
-        if (!isAtStartOfBlock(declaration) || declarationContainsInitialization) {
-            JavaNode child = declaration.getFirstChild();
-            ASTVariableId firstFlaggedVarID = null;
+        JavaNode child = declaration.getFirstChild();
 
-            while (child != null) {
-                if (child instanceof ASTVariableDeclarator) {
-                    ASTVariableDeclarator castedChild = (ASTVariableDeclarator) child;
-                    if (!declarationContainsInitialization || castedChild.hasInitializer()) {
-                        firstFlaggedVarID = castedChild.getVarId();
-                        break;
-                    }
+        while (child != null) {
+            if (child instanceof ASTVariableDeclarator) {
+                ASTVariableDeclarator castedChild = (ASTVariableDeclarator) child;
+                if (castedChild.hasInitializer()) {
+                    String childName = castedChild.getVarId().getName();
+                    asCtx(data).addViolationWithMessage(castedChild, "Local variable `" + childName + "` is declared with initialization");
                 }
-                child = child.getNextSibling();
+                if (!declarationIsAtStartOfBlock) {
+                    String childName = castedChild.getVarId().getName();
+                    asCtx(data).addViolationWithMessage(castedChild, "Local variable `" + childName + "` is not declared at start of block");
+                }
             }
-
-            if (firstFlaggedVarID == null) { // should never be null but just in case
-                return data;
-            }
-            asCtx(data).addViolation(declaration, firstFlaggedVarID.getName());
+            child = child.getNextSibling();
         }
 
         return data;
@@ -72,22 +68,6 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
         // this will stop working if a distinct scope can exist inside a new type of statement (not braces or case of switch)
         return !(declaration.getParent() instanceof ASTBlock
                 || declaration.getParent() instanceof ASTSwitchFallthroughBranch);
-    }
-
-    /*
-    Whether any variables in the declaration are initialized
-     */
-    private boolean containsInitialization(ASTLocalVariableDeclaration declaration) {
-        for (JavaNode nthChild: declaration.children()) {
-            if (nthChild instanceof ASTVariableDeclarator) {
-                ASTVariableDeclarator declarator = (ASTVariableDeclarator) nthChild;
-
-                if (declarator.getInitializer() != null) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     private boolean isAtStartOfBlock(ASTLocalVariableDeclaration declaration) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -60,7 +60,6 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
             }
 
             if (firstFlaggedVarID == null) { // should never be null but just in case
-                asCtx(data).addViolation(declaration, "THIS IS NOT SUPPOSED TO HAPPEN");
                 return data;
             }
             asCtx(data).addViolation(declaration, firstFlaggedVarID.getName());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockRule.java
@@ -20,6 +20,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
+
+/**
+ * @since 7.27.0
+ */
 public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends AbstractJavaRulechainRule {
 
     private static final PropertyDescriptor<Boolean> REQUIRE_BEFORE_THIS_SUPER =
@@ -108,8 +112,8 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
         );
     }
 
-    /*
-    Takes a declaration and raises a violation if it is out of order with the previous declaration
+    /**
+     * Takes a declaration and raises a violation if it is out of order with the previous declaration
      */
     private Object flagSorting(ASTLocalVariableDeclaration node,
                                                 Object data,
@@ -139,8 +143,8 @@ public class LocalVariableDeclarationShouldBeAtStartOfBlockRule extends Abstract
         return data;
     }
 
-    /*
-    It takes the properties of two variables, 1 comes before 2 in the code and returns whether they are in the correct order
+    /**
+     * Takes the properties of two variables, 1 comes before 2 in the code and returns whether they are in the correct order
      */
     private boolean isDeclarationOrderCorrect(TypeNode type1, String name1, TypeNode type2, String name2) {
         if (getProperty(SORT_BY) == SortBy.TYPE) {

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -979,6 +979,51 @@ public class Bar {
         </example>
     </rule>
 
+    <rule name="LocalVariableDeclarationShouldBeAtStartOfBlock"
+          language="java"
+          since="7.27"
+          message="Local variable `{0}` should be declared without initialization at start of block"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlock"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
+        <description>
+            Variables should be declared at the start of the block and then initialized later.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+public class Bar {
+    public void foo1 () {
+        int localVariable1; // correct, variables are declared at the start of the block and not initialized
+        int localVariable2;
+
+
+        localVariable1 = 1; // correct, once all variables are declared they can be initialized and used
+        localVariable2 = 2;
+    }
+
+    public void foo2 () {
+        int localVariable1;
+        localVariable1 = 1;
+
+        int localVariable2; // incorrect, variable2 is declared after others are initialized
+        localVariable2 = 2;
+    }
+
+    public void foo3 () {
+        int localVariable1 = 1; // incorrect, variables should be declared first and initialized later
+    }
+
+    // requireBeforeThisSuper set to true
+    public Bar () {
+        super()
+        int localVariable1; // incorrect, super has been called above the variable declarations
+        localVariable1 = 1;
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="LocalVariableNamingConventions"
           language="java"
           since="6.6.0"

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -986,10 +986,11 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
+**Note**: This rule goes against virtually all Java style guidelines. See {% rule VariableDeclarationUsageDistance %} for an alternative.
+
 This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
 This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden
 in amongst other code or long initialization assignments.
-**Note**: This rule goes against virtually all Java style guidelines. See {% rule VariableDeclarationUsageDistance %} for an alternative.
 
 It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
 For the purposes of this rule a case in a `switch` statement counts as block.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -981,7 +981,7 @@ public class Bar {
 
     <rule name="LocalVariableDeclarationShouldBeAtStartOfBlock"
           language="java"
-          since="7.27"
+          since="7.27.0"
           message="The variable `{0}` comes before `{1}` when ordered by {2}"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -989,7 +989,7 @@ public class Bar {
 This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
 This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden
 in amongst other code or long initialization assignments.
-**Note**: This rule goes against virtually all Java style. See {% rule VariableDeclarationUsageDistance %} for an alternative.
+**Note**: This rule goes against virtually all Java style guidelines. See {% rule VariableDeclarationUsageDistance %} for an alternative.
 
 It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
 For the purposes of this rule a case in a `switch` statement counts as block.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -982,13 +982,14 @@ public class Bar {
     <rule name="LocalVariableDeclarationShouldBeAtStartOfBlock"
           language="java"
           since="7.27"
-          message="Local variable `{0}` is not declared without initialization at start of block"
+          message="This local variable is not declared at start of block/is initialized when declared"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
 This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
 This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden
 in amongst other code or long initialization assignments.
+**Note**: This rule goes against virtually all Java style. See {% rule VariableDeclarationUsageDistance %} for an alternative.
 
 It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
 For the purposes of this rule a case in a `switch` statement counts as block.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -982,7 +982,7 @@ public class Bar {
     <rule name="LocalVariableDeclarationShouldBeAtStartOfBlock"
           language="java"
           since="7.27"
-          message="Local variable `{0}` should be declared without initialization at start of block"
+          message="Local variable `{0}` is not declared without initialization at start of block"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
@@ -991,11 +991,11 @@ This rule exists in order to make it easy to see the type of any given variable 
 in amongst other code or long initialization assignments.
 
 It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
-For the purposes of this rule a case in a switch statement counts as block.
-By default super(...) and this(...) must be placed below the declarations.
+For the purposes of this rule a case in a `switch` statement counts as block.
+By default `super(...)` and `this(...)` must be placed below the declarations.
 
 requireBeforeThisSuper can be set to false (required in older versions of Java which do not allow flexible constructor bodies).
-This will allow super(...) and this(...) calls to be placed before declarations.
+This will allow `super(...)` and `this(...)` calls to be placed before declarations.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1010,6 +1010,9 @@ public class Bar {
 
     public void foo3 () {
         int localVariable1 = 1; // incorrect, variables should be declared first and initialized later
+
+        int localVariable2; // correct, because 1 is initialized in its declaration the fault lies in that line, not here
+        localVariable2 = 2;
     }
 
     // requireBeforeThisSuper set to true

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -983,7 +983,7 @@ public class Bar {
           language="java"
           since="7.27"
           message="Local variable `{0}` should be declared without initialization at start of block"
-          class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlock"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
             All local variables should be declared together at the start of the block and then initialized later.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -986,7 +986,7 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
-**Note**: This rule goes against virtually all Java style guidelines. See {% rule VariableDeclarationUsageDistance %} for an alternative.
+**Note**: This rule goes against virtually all Java style guidelines. For an alternative see {% rule VariableDeclarationUsageDistance %}.
 
 This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
 This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -986,7 +986,16 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
-            All local variables should be declared together at the start of the block and then initialized later.
+This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
+This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden
+in amongst other code or long initialization assignments.
+
+It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
+For the purposes of this rule a case in a switch statement counts as block.
+By default super(...) and this(...) must be placed below the declarations.
+
+requireBeforeThisSuper can be set to false (required in older versions of Java which do not allow flexible constructor bodies).
+This will allow super(...) and this(...) calls to be placed before declarations.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -982,22 +982,29 @@ public class Bar {
     <rule name="LocalVariableDeclarationShouldBeAtStartOfBlock"
           language="java"
           since="7.27"
-          message="This local variable is not declared at start of block/is initialized when declared"
+          message="The variable `{0}` comes before `{1}` when ordered by {2}"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlockRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
 **Note**: This rule goes against virtually all Java style guidelines. For an alternative see {% rule VariableDeclarationUsageDistance %}.
 
 This rule reports variables that are declared and initialized on the same line or that are not declared at the start of their block.
+It is also able to report variables which are out of order based on the sortBy property.
 This rule exists in order to make it easy to see the type of any given variable at a glance and not have declarations hidden
 in amongst other code or long initialization assignments.
 
 It ignores initializations that exist within statement initializers such as for loop, foreach loop and try-with-resources initializers.
 For the purposes of this rule a case in a `switch` statement counts as block.
-By default `super(...)` and `this(...)` must be placed below the declarations.
+By default `super(...)` and `this(...)` must be placed below the declarations in java versions which support it.
+Sorting by type places inferred declarations with `var` last.
+Variables of the same type are then sorted by name.
+In all cases when sorting by type the only consideration is the initial type of the line (`int a[]` is `int` whereas `int[] a` is `int[]`).
+Sorted order is determined by the first declaration on each line.
 
 requireBeforeThisSuper can be set to false (required in older versions of Java which do not allow flexible constructor bodies).
 This will allow `super(...)` and `this(...)` calls to be placed before declarations.
+sortBy allows you to enforce that the local variable declarations are ordered by either type or name.
+caseSensitiveSorting places uppercase values before their lowercase counterparts when true.
         </description>
         <priority>3</priority>
         <example>
@@ -1037,7 +1044,14 @@ public class Bar {
         int localVariable1;
         localVariable1 = 1;
 
-        var localVariable2 = 2; // correct, rule does not apply to inferred types
+        var localVariable2 = 2; // correct, inferred types must be initialized when declared so are not flagged
+    }
+
+    // sortBy set to TYPE
+    public void foo5() {
+        String x;
+        int b; // incorrect, int comes before String when case-insensitive
+        int a; // incorrect, variables of the same type are sorted by name and a comes before b
     }
 }
 ]]>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -986,7 +986,7 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableDeclarationShouldBeAtStartOfBlock"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariabledeclarationshouldbeatstartofblock">
         <description>
-            Variables should be declared at the start of the block and then initialized later.
+            All local variables should be declared together at the start of the block and then initialized later.
         </description>
         <priority>3</priority>
         <example>
@@ -995,7 +995,6 @@ public class Bar {
     public void foo1 () {
         int localVariable1; // correct, variables are declared at the start of the block and not initialized
         int localVariable2;
-
 
         localVariable1 = 1; // correct, once all variables are declared they can be initialized and used
         localVariable2 = 2;
@@ -1018,6 +1017,13 @@ public class Bar {
         super()
         int localVariable1; // incorrect, super has been called above the variable declarations
         localVariable1 = 1;
+    }
+
+    public void foo4 () {
+        int localVariable1;
+        localVariable1 = 1;
+
+        var localVariable2 = 2; // correct, rule does not apply to inferred types
     }
 }
 ]]>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableDeclarationShouldBeAtStartOfBlockTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class LocalVariableDeclarationShouldBeAtStartOfBlockTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -27,7 +27,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable2` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -48,7 +48,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -65,7 +65,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -85,7 +85,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable4` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable4` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -105,7 +105,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -172,7 +172,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>17</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable3` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable3` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -203,9 +203,9 @@
         <expected-problems>3</expected-problems>
         <expected-linenumbers>14,18,23</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `b` should be declared without initialization at start of block</message>
-            <message>Local variable `b` should be declared without initialization at start of block</message>
-            <message>Local variable `b` should be declared without initialization at start of block</message>
+            <message>Local variable `b` is not declared without initialization at start of block</message>
+            <message>Local variable `b` is not declared without initialization at start of block</message>
+            <message>Local variable `b` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -243,8 +243,8 @@
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,10</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `encoded` should be declared without initialization at start of block</message>
-            <message>Local variable `decoded` should be declared without initialization at start of block</message>
+            <message>Local variable `encoded` is not declared without initialization at start of block</message>
+            <message>Local variable `decoded` is not declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -27,7 +27,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable2` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable2` is not declared at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -48,7 +48,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is declared with initialization</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -59,13 +59,49 @@
             ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Multiple variables declared and initialized on the same line should all cause violations</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,3</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `b` is declared with initialization</message>
+            <message>Local variable `c` is declared with initialization</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int a, b = 1, c = 2; // incorrect, only b and c
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>When a declaration has multiple violations they should all be flagged</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,6</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `b` is declared with initialization</message>
+            <message>Local variable `b` is not declared at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int a;
+                        a = 1;
+
+                        int b = 1; // incorrect, declared with initialization and not at start of block
+                    }
+                }
+            ]]></code>
+    </test-code>
 
     <test-code>
         <description>Variable declaration and initialization should be separated and all declarations should happen before initialization</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is declared with initialization</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -85,7 +121,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable4` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable4` is declared with initialization</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -105,7 +141,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable1` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` is not declared at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -172,7 +208,7 @@
         <expected-problems>1</expected-problems>
         <expected-linenumbers>17</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `localVariable3` is not declared without initialization at start of block</message>
+            <message>Local variable `localVariable3` is not declared at start of block</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -200,12 +236,13 @@
 
     <test-code>
         <description>Switch statements should allow variables to be declared at start of case scope</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>14,18,23</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>14,18,18,23</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `b` is not declared without initialization at start of block</message>
-            <message>Local variable `b` is not declared without initialization at start of block</message>
-            <message>Local variable `b` is not declared without initialization at start of block</message>
+            <message>Local variable `b` is not declared at start of block</message>
+            <message>Local variable `b` is declared with initialization</message>
+            <message>Local variable `b` is not declared at start of block</message>
+            <message>Local variable `b` is not declared at start of block</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -225,7 +262,7 @@
                         case 3: {
                             int a; // correct
                             a = 3;
-                            int b; // incorrect
+                            int b = 3; // incorrect
                         }
                         default:
                             int a; // correct
@@ -243,8 +280,8 @@
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,10</expected-linenumbers>
         <expected-messages>
-            <message>Local variable `encoded` is not declared without initialization at start of block</message>
-            <message>Local variable `decoded` is not declared without initialization at start of block</message>
+            <message>Local variable `encoded` is declared with initialization</message>
+            <message>Local variable `decoded` is declared with initialization</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -121,7 +121,7 @@
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             public class Bar {
-                public void foo1 () {
+                public void foo () {
                     int localVariable1;
                     localVariable1 = 1;
 
@@ -140,7 +140,7 @@
 
                 public int field1 = 1; // should not trigger
 
-                public void foo1 () {}
+                public void foo () {}
 
                 public int field2 = 2; // should not trigger
             }
@@ -158,7 +158,7 @@
         <code><![CDATA[
             public class Bar {
 
-                public void foo1 () {
+                public void foo () {
                     int localVariable1;
                     localVariable1 = 1;
 
@@ -169,6 +169,46 @@
                     
                     int localVariable3; // incorrect, should be at top
                 }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Switch statements should allow variables to be declared at start of case scope</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>14,18,23</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `b` should be declared without initialization at start of block</message>
+            <message>Local variable `b` should be declared without initialization at start of block</message>
+            <message>Local variable `b` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+               private void foo()
+               {
+                    int localVariable1;
+                    localVariable1 = 1;
+
+                    switch (localVariable1) {
+                        case 1:
+                            int a; // correct
+                            a = 1;
+                        case 2:
+                            int a; // correct
+                            a = 2;
+                            int b; // incorrect
+                        case 3: {
+                            int a; // correct
+                            a = 3;
+                            int b; // incorrect
+                        }
+                        default:
+                            int a; // correct
+                            a = 4;
+                            int b; // incorrect
+                    }
+               }
             }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -62,18 +62,17 @@
 
     <test-code>
         <description>Variable declaration and initialization should be separated and all declarations should happen before initialization</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
-            <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
                     public void foo () {
                         int localVariable1 = 1; // incorrect, variable1 is initialized on the same line as it is declared
 
-                        int localVariable2; // incorrect, variable2 is declared after others are initialized
+                        int localVariable2; // correct, the issue here lies only with variable1, once that initialization is separated the method is correct
                         localVariable2 = 2;
                     }
                 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+
+    <test-code>
+        <description>Standard correct case</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+                public void foo1 () {
+                    int localVariable1;
+                    int localVariable2;
+
+                    localVariable1 = 1;
+                    localVariable2 = 2;
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>All variables should be declared before any initialisation</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The local variable `localVariable2` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable1;
+                        localVariable1 = 1;
+
+                        int localVariable2; // incorrect, variable2 is declared after others are initialized
+                        localVariable2 = 2;
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Variables should not be declared and initialized on the same line</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable1 = 1; // incorrect, variables should be declared first and initialized later
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Variable declaration and initialization should be separated and all declarations should happen before initialization</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>The local variable `localVariable2` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable1 = 1; // incorrect, variable1 is initialized on the same line as it is declared
+
+                        int localVariable2; // incorrect, variable2 is declared after others are initialized
+                        localVariable2 = 2;
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>When requireBeforeThisSuper is true declarations should come before super(...) and this(...) calls</description>
+        <rule-property name="requireBeforeThisSuper">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public Bar () {
+                        super()
+                        int localVariable1; // incorrect, super has been called above the variable declarations
+                        localVariable1 = 1;
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>When requireBeforeThisSuper is false declarations can come after super(...) and this(...) calls</description>
+        <rule-property name="requireBeforeThisSuper">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+                public class Bar {
+                    public Bar () {
+                        this()
+                        int localVariable1;
+                        localVariable1 = 1;
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Rule should not be enforced on declarations with var</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+                public void foo1 () {
+                    int localVariable1;
+                    localVariable1 = 1;
+
+                    var localVariable2 = 2; // correct, var declarations must happen with initialization
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -25,6 +25,7 @@
     <test-code>
         <description>All variables should be declared before any initialisation</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
         </expected-messages>
@@ -45,6 +46,7 @@
     <test-code>
         <description>Variables should not be declared and initialized on the same line</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
         </expected-messages>
@@ -61,6 +63,7 @@
     <test-code>
         <description>Variable declaration and initialization should be separated and all declarations should happen before initialization</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
             <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
@@ -82,6 +85,7 @@
         <description>When requireBeforeThisSuper is true declarations should come before super(...) and this(...) calls</description>
         <rule-property name="requireBeforeThisSuper">true</rule-property>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
         </expected-messages>
@@ -148,6 +152,7 @@
     <test-code>
         <description>Rule should not be triggered on for-loop initialisers</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable3` should be declared without initialization at start of block</message>
         </expected-messages>
@@ -165,6 +170,62 @@
                     
                     int localVariable3; // incorrect, should be at top
                 }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Issue #6882: Provided failure case</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,10</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `encoded` should be declared without initialization at start of block</message>
+            <message>Local variable `decoded` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+               private String getPassword()
+               {
+                  byte[] encoded = GlobalConfigMap.
+                     getInstance().
+                     getVault().
+                     secret("database.password").
+                     getValue();
+
+                  byte[] decoded = Base64.
+                     getDecoder().
+                     decode(encoded);
+
+                  return new String(decoded, StandardCharsets.UTF_8);
+               }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Issue #6882: Provided success case</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+               private String getPassword()
+               {
+                  byte[] decoded;
+                  byte[] encoded;
+
+                  encoded = GlobalConfigMap.
+                     getInstance().
+                     getVault().
+                     secret("database.password").
+                     getValue();
+
+                  decoded = Base64.
+                     getDecoder().
+                     decode(encoded);
+
+                  return new String(decoded, StandardCharsets.UTF_8);
+               }
             }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -152,6 +152,43 @@
                     }
                 }
             ]]></code>
+        <source-type>java 25</source-type>
+    </test-code>
+
+    <test-code>
+        <description>When requireBeforeThisSuper is true but java version is wrong it should not trigger</description>
+        <rule-property name="requireBeforeThisSuper">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+                public class Bar {
+                    public Bar () {
+                        super();
+                        int localVariable1; // incorrect, super has been called above the variable declarations
+                        localVariable1 = 1;
+                    }
+                }
+            ]]></code>
+        <source-type>java 24</source-type>
+    </test-code>
+
+    <test-code>
+        <description>When requireBeforeThisSuper is true it should be able to deal with preview versions of java</description>
+        <rule-property name="requireBeforeThisSuper">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `localVariable1` is not declared at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public Bar () {
+                        super();
+                        int localVariable1; // incorrect, super has been called above the variable declarations
+                        localVariable1 = 1;
+                    }
+                }
+            ]]></code>
+        <source-type>java 25-preview</source-type>
     </test-code>
 
 
@@ -326,6 +363,366 @@
 
                   return new String(decoded, StandardCharsets.UTF_8);
                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations should be ordered lexicographically when sortBy is set to name</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariableA` comes before `localVariableB` when ordered by name</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariableB;
+                        int localVariableA; // incorrect, variable A comes before variable B lexicographically
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations should be ordered lexicographically when sortBy is set to name and is case sensitive</description>
+        <rule-property name="sortBy">name</rule-property>
+        <rule-property name="caseSensitiveSorting">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable_B` comes before `localVariable_a` when ordered by name</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable_a;
+                        int localVariable_B; // incorrect, B comes before a with a case-sensitive sort
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations should ignore casing when caseSensitiveSorting is false</description>
+        <rule-property name="sortBy">name</rule-property>
+        <rule-property name="caseSensitiveSorting">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `a_var` comes before `B_var` when ordered by name</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo () {
+                    int B_var;
+                    int a_var; // incorrect, 'a' comes before 'B' in a case-insensitive sort
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations should be ordered lexicographically when sortBy is set to type</description>
+        <rule-property name="sortBy">type</rule-property>
+        <rule-property name="caseSensitiveSorting">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable2` comes before `localVariable1` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        String localVariable1;
+                        int localVariable2; // incorrect, int comes before String with a case-insensitive sort
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations should be ordered lexicographically when sortBy is set to type and is case sensitive</description>
+        <rule-property name="sortBy">type</rule-property>
+        <rule-property name="caseSensitiveSorting">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable2` comes before `localVariable1` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable1;
+                        String localVariable2; // incorrect, String comes before int with a case-sensitive sort
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations of the same type should be ordered by name</description>
+        <rule-property name="sortBy">type</rule-property>
+        <rule-property name="caseSensitiveSorting">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable1` comes before `localVariable2` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        String localVariable2;
+                        String localVariable1; // incorrect, variables of the same type should be ordered by name
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Variables should be sorted by type and then by name</description>
+        <rule-property name="sortBy">type</rule-property>
+        <rule-property name="caseSensitiveSorting">true</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,5</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable1` comes before `localVariable2` when ordered by type</message>
+            <message>The variable `localVariable3` comes before `localVariable1` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable2;
+                        int localVariable1; // incorrect, variables of the same type should be sorted according to name
+                        String localVariable3; // incorrect, String comes before int with a case-sensitive sort
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Type inference with var should come last</description>
+        <rule-property name="sortBy">type</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable3` comes before `localVariable1` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable2;
+                        var localVariable1 = 1;
+                        XCustomType localVariable3; // incorrect, X comes after v but var should always come last
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Explicit constructor calls should not affect ordering</description>
+        <rule-property name="sortBy">type</rule-property>
+        <rule-property name="requireBeforeThisSuper">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>10</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `localVariable2` comes before `localVariable1` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public Bar () {
+                        super();
+                        int localVariable1;
+                    }
+
+                    public Bar(int a) {
+                        String localVariable1;
+                        this();
+                        int localVariable2; // incorrect, int should be before string
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>With multiple declarations on one line only the first variable name should be considered</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>3,4,5,5,7,8,8,8</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `d` is declared with initialization</message>
+            <message>Local variable `e` is declared with initialization</message>
+            <message>Local variable `b` is declared with initialization</message>
+            <message>The variable `b` comes before `c` when ordered by name</message>
+            <message>Local variable `p` is declared with initialization</message>
+            <message>Local variable `l` is declared with initialization</message>
+            <message>The variable `l` comes before `p` when ordered by name</message>
+            <message>Local variable `z` is declared with initialization</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () { // all initializations are incorrect as well as sorting issues
+                        int a, d = 2;
+                        int c, e = 1;
+                        int b = 3, f; // incorrect, b comes before c
+
+                        int p = 2, y;
+                        int l = 3, z = 4; // incorrect, l comes before p
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>With multiple declarations on one line only the first variable type should be considered</description>
+        <rule-property name="sortBy">type</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `b` comes before `a` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int[] a;
+                        int b, c[]; // incorrect, int comes before int[]
+                    }
+
+                    public void foo2 () {
+                        int a[], b;
+                        int c; // correct, only the overall type is considered
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations at the start of nested blocks should be ordered</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `a` comes before `b` when ordered by name</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo (boolean flag) {
+                    if (flag) {
+                        int b;
+                        int a; // incorrect, a should come before b in this block
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations inside switch statement blocks should be ordered</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `first` comes before `second` when ordered by name</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo (int value) {
+                    switch (value) {
+                        case 1:
+                            int second;
+                            int first; // incorrect, first comes before second
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Declarations after statements are not at the top of the block and should be ignored by sorter</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `a` is not declared at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo () {
+                    int z;
+                    System.out.println("Doing some work");
+                    int a; // incorrect placement flags but not sorting
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Fields declared after a method are not considered at the top of the block</description>
+        <rule-property name="sortBy">name</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+                int z = 1;
+
+                public void doSomething() {
+                }
+
+                int a = 2; // correct, field is declared after a method so it is ignored
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Modifiers like final should not affect type sorting</description>
+        <rule-property name="sortBy">type</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `a` comes before `b` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo () {
+                    final String b;
+                    final int a; // incorrect, 'int' comes before 'String' despite 'final'
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Multiple var declarations should be sorted by name when sorting by type</description>
+        <rule-property name="sortBy">type</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The variable `a` comes before `b` when ordered by type</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+                public void foo () {
+                    int x;
+                    var b = "hello";
+                    var a = 123; // incorrect, both are 'var', so 'a' must come before 'b'
+                }
             }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -26,7 +26,7 @@
         <description>All variables should be declared before any initialisation</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The local variable `localVariable2` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -46,7 +46,7 @@
         <description>Variables should not be declared and initialized on the same line</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -62,8 +62,8 @@
         <description>Variable declaration and initialization should be separated and all declarations should happen before initialization</description>
         <expected-problems>2</expected-problems>
         <expected-messages>
-            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
-            <message>The local variable `localVariable2` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable2` should be declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
@@ -83,12 +83,12 @@
         <rule-property name="requireBeforeThisSuper">true</rule-property>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The local variable `localVariable1` should be declared without initialization at start of block</message>
+            <message>Local variable `localVariable1` should be declared without initialization at start of block</message>
         </expected-messages>
         <code><![CDATA[
                 public class Bar {
                     public Bar () {
-                        super()
+                        super();
                         int localVariable1; // incorrect, super has been called above the variable declarations
                         localVariable1 = 1;
                     }
@@ -104,7 +104,7 @@
         <code><![CDATA[
                 public class Bar {
                     public Bar () {
-                        this()
+                        this();
                         int localVariable1;
                         localVariable1 = 1;
                     }
@@ -114,7 +114,7 @@
 
 
     <test-code>
-        <description>Rule should not be enforced on declarations with var</description>
+        <description>Rule should not be triggered on declarations with var</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             public class Bar {
@@ -128,5 +128,45 @@
         ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>Rule should not be triggered on fields</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Bar {
+
+                public int field1 = 1; // should not trigger
+
+                public void foo1 () {}
+
+                public int field2 = 2; // should not trigger
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Rule should not be triggered on for-loop initialisers</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Local variable `localVariable3` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                public void foo1 () {
+                    int localVariable1;
+                    localVariable1 = 1;
+
+                    for (int i = 0; i < 10; i++) {
+                        int localVariable2;
+                        localVariable2 = 2;
+                    }
+                    
+                    int localVariable3; // incorrect, should be at top
+                }
+            }
+        ]]></code>
+    </test-code>
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableDeclarationShouldBeAtStartOfBlock.xml
@@ -81,6 +81,25 @@
 
 
     <test-code>
+        <description>Multiple variables declared on the same line should trigger only with the initialized variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Local variable `localVariable4` should be declared without initialization at start of block</message>
+        </expected-messages>
+        <code><![CDATA[
+                public class Bar {
+                    public void foo () {
+                        int localVariable1, localVariable2; // correct
+
+                        int localVariable3, localVariable4 = 2; // incorrect, should flag 4
+                    }
+                }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
         <description>When requireBeforeThisSuper is true declarations should come before super(...) and this(...) calls</description>
         <rule-property name="requireBeforeThisSuper">true</rule-property>
         <expected-problems>1</expected-problems>
@@ -149,9 +168,9 @@
 
 
     <test-code>
-        <description>Rule should not be triggered on for-loop initialisers</description>
+        <description>Rule should not be triggered in statement initialisers</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>12</expected-linenumbers>
+        <expected-linenumbers>17</expected-linenumbers>
         <expected-messages>
             <message>Local variable `localVariable3` should be declared without initialization at start of block</message>
         </expected-messages>
@@ -166,6 +185,11 @@
                         int localVariable2;
                         localVariable2 = 2;
                     }
+
+                    for (int i: new int[5]) {}
+
+                    try (int a = 1) {}
+                    catch (FileNotFoundException e) {}
                     
                     int localVariable3; // incorrect, should be at top
                 }


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Creates a new rule `LocalVariableDeclarationShouldBeAtStartOfBlock` which enforces a two things:
1. Local variables are not declared on the same line that they are initialised - this avoids clutter in the declarations which if allowed would defeat the purpose of the rule
2. All local variables are declared together at the start of their scope, not interleaved throughout

This does not include variables declared and initialised at once inside for loop, foreach loop and try-with-resources initialisers.

This rule does not enforce sorting of the declarations as suggested in the issue, I will implement that as a separate rule with a separate PR as it is too distinct from the core functionality of this rule.

The current message is "Local variable `variableName` is not declared without initialisation at start of block" though this is very much open to suggestions.

I have tried to use the American "initialized" throughout as opposed to "initialised" however some may have slipped through the cracks.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6882 
- Refs #6924 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

