### PR TITLE
[java] Fix #6932: Handle conflicting inner class visibility modifiers

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -79,6 +79,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
+    * [#6932](https://github.com/pmd/pmd/issues/6932): \[java] AssertionError when outer class is parsed before inner class with conflicting visibility
 * java-bestpractices
     * [#2033](https://github.com/pmd/pmd/issues/2033): \[jsp] NoClassAttribute rule is generating a false positive
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -48,6 +48,8 @@ import net.sourceforge.pmd.util.OptionalBool;
 final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
 
     static final int UNKNOWN_ARITY = 0;
+    private static final int VISIBILITY_MASK = Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED | Opcodes.ACC_PRIVATE;
+    private static final int NO_INNER_CLASS_VISIBILITY = -1;
 
     private final AsmSymbolResolver resolver;
 
@@ -56,6 +58,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
     // all the following are lazy and depend on the parse lock
 
     private int accessFlags;
+    private int innerClassVisibility = NO_INNER_CLASS_VISIBILITY;
 
     private EnclosingInfo enclosingInfo;
     private LazyClassSignature signature;
@@ -197,23 +200,34 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
             Also ACC_SUPER conflicts with ACC_SYNCHRONIZED, which
             Modifier.toString would reflect.
 
-            Since the differences are disjoint we can just OR the two
-            sets of flags.
+            The non-visibility differences are disjoint, so they can be
+            combined with OR. Visibility needs to be merged separately:
+            bytecode processors may produce conflicting InnerClasses
+            entries, and class stubs can be populated in different orders.
          */
-        final int visibilityMask = Opcodes.ACC_PUBLIC | Opcodes.ACC_PROTECTED | Opcodes.ACC_PRIVATE;
-        int myAccess = this.accessFlags;
         if (fromClassInfo) {
             // we don't care about ACC_SUPER and it conflicts
             // with ACC_SYNCHRONIZED
             accessFlags = accessFlags & ~Opcodes.ACC_SUPER;
-        } else if ((myAccess & Opcodes.ACC_PUBLIC) != 0
-            && (accessFlags & visibilityMask) != Opcodes.ACC_PUBLIC) {
-            // ClassInfo mentions ACC_PUBLIC even if the real
-            // visibility is protected or private
-            // We remove the public to avoid a "public protected" or "public private" combination
-            myAccess = myAccess & ~Opcodes.ACC_PUBLIC;
+            if (innerClassVisibility != NO_INNER_CLASS_VISIBILITY) {
+                // InnerClasses contains the source-level visibility, even
+                // when it arrived before the ClassInfo for this class.
+                accessFlags = accessFlags & ~VISIBILITY_MASK;
+            }
+        } else {
+            int newVisibility = normalizeVisibility(accessFlags);
+            if (innerClassVisibility == NO_INNER_CLASS_VISIBILITY) {
+                innerClassVisibility = newVisibility;
+            } else {
+                innerClassVisibility = mostRestrictiveVisibility(innerClassVisibility, newVisibility);
+            }
+
+            // Replace any visibility read from ClassInfo or another
+            // InnerClasses entry, instead of accumulating incompatible flags.
+            this.accessFlags = this.accessFlags & ~VISIBILITY_MASK;
+            accessFlags = (accessFlags & ~VISIBILITY_MASK) | innerClassVisibility;
         }
-        this.accessFlags = myAccess | accessFlags;
+        this.accessFlags = this.accessFlags | accessFlags;
 
         // setModifiers is called multiple times: once from ClassFile structure (fromClassInfo==true)
         // and additionally from InnerClasses attribute (fromClassInfo==false)
@@ -227,6 +241,29 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
                 this.recordComponents = new ArrayList<>();
             }
         }
+    }
+
+    private static int normalizeVisibility(int accessFlags) {
+        int visibility = accessFlags & VISIBILITY_MASK;
+        if ((visibility & Opcodes.ACC_PRIVATE) != 0) {
+            return Opcodes.ACC_PRIVATE;
+        } else if (visibility == 0) {
+            return 0; // package-private
+        } else if ((visibility & Opcodes.ACC_PROTECTED) != 0) {
+            return Opcodes.ACC_PROTECTED;
+        }
+        return Opcodes.ACC_PUBLIC;
+    }
+
+    private static int mostRestrictiveVisibility(int first, int second) {
+        if (first == Opcodes.ACC_PRIVATE || second == Opcodes.ACC_PRIVATE) {
+            return Opcodes.ACC_PRIVATE;
+        } else if (first == 0 || second == 0) {
+            return 0; // package-private
+        } else if (first == Opcodes.ACC_PROTECTED || second == Opcodes.ACC_PROTECTED) {
+            return Opcodes.ACC_PROTECTED;
+        }
+        return Opcodes.ACC_PUBLIC;
     }
 
     void setEnclosingInfo(ClassStub outer, boolean localOrAnon, @Nullable String methodName, @Nullable String methodDescriptor) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -202,8 +202,10 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
 
             The non-visibility differences are disjoint, so they can be
             combined with OR. Visibility needs to be merged separately:
-            bytecode processors may produce conflicting InnerClasses
-            entries, and class stubs can be populated in different orders.
+            Bytecode processors (e.g. Android Proguard/R8) may produce
+            conflicting InnerClasses entries (widening access modifiers to
+            allow easier optimizations), and class stubs can be
+            populated in different orders.
          */
         if (fromClassInfo) {
             // we don't care about ACC_SUPER and it conflicts

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
@@ -16,12 +16,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 import org.pcollections.PSet;
 
 import net.sourceforge.pmd.lang.java.JavaParsingHelper;
@@ -37,6 +40,9 @@ import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 class ClassStubTest {
+    private static final String R8_OUTER_INTERNAL_NAME = "testdata/R8Outer";
+    private static final String R8_INNER_INTERNAL_NAME = R8_OUTER_INTERNAL_NAME + "$Inner";
+
     // while parsing the annotation type, ClassStub's parseLock.ensureParsed()
     // is called multiple times, reentering the parselock while the status is
     // still BEING_PARSED.
@@ -140,6 +146,22 @@ class ClassStubTest {
         assertThat(innerOfObj, hasProperty("modifiers", equalTo(Modifier.PRIVATE | Modifier.STATIC)));
     }
 
+    @Test
+    void testLoadR8InnerClassWithConflictingVisibility() {
+        TypeSystem ts = TypeSystem.usingClassLoaderClasspath(JavaParsingHelper.class.getClassLoader());
+        AsmSymbolResolver resolver = (AsmSymbolResolver) ts.bootstrapResolver();
+        Loader loader = new Loader.StreamLoader(R8_INNER_INTERNAL_NAME,
+                                                new ByteArrayInputStream(r8InnerClass()));
+        ClassStub inner = new ClassStub(resolver, R8_INNER_INTERNAL_NAME, loader,
+                                        ClassStub.UNKNOWN_ARITY);
+
+        // Simulate the outer class being parsed first. Parsing the inner stub then adds
+        // public from both its ClassInfo and its own InnerClasses entry.
+        inner.setModifiers(Opcodes.ACC_PRIVATE, false);
+
+        assertEquals(Modifier.PRIVATE, inner.getModifiers());
+    }
+
 
     @Test
     void testLoadAnonClassFromEnum() {
@@ -195,6 +217,15 @@ class ClassStubTest {
 
     private static @NonNull JClassSymbol loadScalaClass(TypeSystem typeSystem, String simpleName) {
         return loadClassInPackage("net.sourceforge.pmd.lang.java.symbols.scalaclasses", simpleName, typeSystem);
+    }
+
+    private static byte[] r8InnerClass() {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER,
+                     R8_INNER_INTERNAL_NAME, null, "java/lang/Object", null);
+        writer.visitInnerClass(R8_INNER_INTERNAL_NAME, R8_OUTER_INTERNAL_NAME, "Inner", Opcodes.ACC_PUBLIC);
+        writer.visitEnd();
+        return writer.toByteArray();
     }
 
     private static @NonNull JClassSymbol loadTestDataClass(TypeSystem typeSystem, String simpleName) {


### PR DESCRIPTION
## Describe the PR

`ClassStub#setModifiers` combines access flags from the class header (`ClassInfo`) and one or more `InnerClasses` entries. The normalization added by #5310 assumed that the class header was parsed before the non-public `InnerClasses` entry.

PMD's ASM symbols are loaded lazily, so the opposite order is also possible. If the enclosing class is parsed first, a nested class may receive `private` before its own public class header is parsed. With bytecode observed after Android R8 processing, the nested class also contains a contradictory public self-entry. The old merge accumulated these values into `public private`; `JavaResolvers` later treats that state as unreachable and throws an `AssertionError`.

This PR makes the merge independent of class parsing order:

- Track the source-level visibility from `InnerClasses` separately, including package-private (`0`).
- Do not let a later class header overwrite visibility that already came from `InnerClasses`.
- Replace visibility bits instead of OR-ing mutually exclusive values.
- If duplicate `InnerClasses` entries disagree, retain the most restrictive visibility. This preserves the non-public precedence established by #5310 and avoids resolving members as more accessible than their metadata allows.

The regression test generates the conflicting inner-class bytecode with ASM, then simulates the enclosing class being parsed first. It contains no third-party binary fixture.

### Verification

- Before the fix, the regression fails with `expected: <2> but was: <3>` (`private` vs `public private`).
- `mvn -pl pmd-java -am "-Dtest=ClassStubTest" "-Dsurefire.failIfNoSpecifiedTests=false" test` — 9 tests passed.
- `mvn -pl pmd-java -am verify` — BUILD SUCCESS for all 7 reactor modules, including the complete `pmd-core` and `pmd-java` test suites and quality checks.

## Related issues

- Fix #6932
- Follow-up to #5283 and #5310

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

