### PR TITLE
[java] Fix #5441: Resolve interdependent inference variables simultaneously

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -65,6 +65,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
 * java-codestyle
+    * [#5441](https://github.com/pmd/pmd/issues/5441): \[java] UseDiamondOperator reported but Java 21 is unable to infer the type
     * [#6651](https://github.com/pmd/pmd/issues/6651): \[java] UnnecessaryImport false-positive when Javadoc {@link} references an array type
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
     * [#6737](https://github.com/pmd/pmd/issues/6737): \[java] TooManyStaticImports: @<!-- -->SuppressWarnings("PMD.TooManyStaticImports") has stopped working

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -563,20 +564,35 @@ final class InferenceContext {
 
     /**
      * Tries to solve as much of varsToSolve as possible using some reduction steps.
-     * Returns the set of solved variables during this step.
+     * Returns true if at least one variable was instantiated.
      */
     private boolean solveBatchProgressed(Set<InferenceVar> varsToSolve, List<ReductionStep> wave) {
+        // The variables of a batch are interdependent, so the JLS (18.4)
+        // mandates that their instantiations all be *computed* from the same
+        // bound set, and only then incorporated. Solving them one after the
+        // other would be incorrect: instantiating the first variable may turn
+        // an improper bound of the second one (a bound mentioning an inference
+        // variable) into a proper one, and the resolution rules would then use
+        // that bound instead of the one the JLS prescribes.
+        Map<InferenceVar, JTypeMirror> instantiations = new LinkedHashMap<>();
         for (InferenceVar ivar : intersect(varsToSolve, freeVars)) {
             for (ReductionStep step : wave) {
                 if (step.accepts(ivar, this)) {
-                    ivar.setInst(step.solve(ivar, this));
-                    onVarInstantiated(ivar);
-                    return true;
+                    instantiations.put(ivar, step.solve(ivar, this));
+                    break;
                 }
             }
         }
 
-        return false;
+        if (instantiations.isEmpty()) {
+            return false;
+        }
+
+        instantiations.forEach((ivar, inst) -> {
+            ivar.setInst(inst);
+            onVarInstantiated(ivar);
+        });
+        return true;
     }
 
     public boolean isEmpty() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
@@ -125,6 +125,8 @@ enum ReductionStep {
      */
     static final List<List<ReductionStep>> WAVES =
         listOf(
+            listOf(EQ),
+            listOf(EQ, LOWER),
             listOf(EQ, LOWER, UPPER, CAPTURED),
             listOf(EQ, LOWER, FBOUND, UPPER, CAPTURED));
     //                        ^^^^^^

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
@@ -353,4 +353,45 @@ class CtorInferenceTest : ProcessorTestSpec({
             ctorCall.methodType.symbol shouldBe ctorSymbol
         }
     }
+
+    parserTest("Interdependent ivars are resolved simultaneously (#5441)") {
+        // The inference context for `build` ends up with the bounds
+        //     'a { 'a <: String, 'a <: 'b }        ('a is K1)
+        //     'b { 'b <: Object, 'b >: 'a }        ('b is CacheLoader's K)
+        // 'a and 'b are interdependent, so per JLS 18.4 their instantiations
+        // must both be computed from this bound set before either is
+        // incorporated. 'b then has no *proper* lower bound and resolves to
+        // Object, exactly like javac. Resolving 'a first would make `'b >: 'a`
+        // proper and wrongly instantiate 'b to String.
+        val (acu, _) = parser.parseWithTypeInferenceSpy(
+            """
+            class Test {
+                interface CacheLoader<K, V> {}
+
+                interface CacheBuilder<K, V> {
+                    <K1 extends K, V1 extends V> Cache<K1, V1> build(CacheLoader<? super K1, V1> loader);
+                }
+
+                interface Cache<K, V> {}
+
+                static class ConcreteCacheLoader<K, V> implements CacheLoader<K, V> {}
+
+                static <K, V> CacheBuilder<K, V> newCacheBuilder(String id) { return null; }
+
+                static void test() {
+                    var cache = Test.<String, Integer>newCacheBuilder("test")
+                                    .build(new ConcreteCacheLoader<>());
+                }
+            }
+            """
+        )
+
+        val (_, _, _, t_Cache, t_ConcreteCacheLoader) = acu.declaredTypeSignatures()
+        val ctorCall = acu.firstCtorCall()
+
+        ctorCall.withTypeDsl {
+            ctorCall shouldHaveType t_ConcreteCacheLoader[ts.OBJECT, int.box()]
+            acu.varId("cache") shouldHaveType t_Cache[ts.STRING, int.box()]
+        }
+    }
 })

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceTest.kt
@@ -498,4 +498,92 @@ class Main {
             info.methodType shouldBeSomeInstantiationOf ofNullable
         }
     }
+
+    parserTest("Lower bounds of an interdependent batch are used before upper bounds") {
+        // Reduced from spring-framework's JsonPathAssertions#value usages.
+        // The inference context for `value` ends up with the bounds
+        //     'a { 'a <: Object, 'a <: 'd }      ('a is T of value)
+        //     'd { 'd >: Integer, 'd >: 'a }     ('d is T of equalTo)
+        // 'a and 'd are interdependent, so they are instantiated simultaneously.
+        // If UPPER may be applied to 'a in the same pass in which LOWER is
+        // applied to 'd, we get 'a := Object and 'd := Integer, and incorporating
+        // both yields the false bound 'a <: Integer, ie the call does not resolve
+        // at all. Like javac, LOWER must be exhausted over the whole batch first:
+        // 'd := Integer, and only once that is incorporated 'a := glb(Object, Integer).
+        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+            """
+            class Scratch {
+                interface Matcher<T> {}
+                interface Consumer<T> {}
+                interface BodyContentSpec {}
+
+                interface JsonPathAssertions {
+                    <T> BodyContentSpec value(Matcher<? super T> matcher);
+                    <T> BodyContentSpec value(Consumer<T> consumer);
+                }
+
+                static <T> Matcher<T> equalTo(T operand) { return null; }
+
+                static void test(JsonPathAssertions a) {
+                    a.value(equalTo(42));
+                }
+            }
+            """.trimIndent()
+        )
+
+        val (_, t_Matcher, _, t_BodyContentSpec) = acu.declaredTypeSignatures()
+        val valueCall = acu.firstMethodCall("value")
+        val equalToCall = acu.firstMethodCall("equalTo")
+
+        spy.shouldBeOk {
+            valueCall.overloadSelectionInfo::isFailed shouldBe false
+            valueCall shouldHaveType t_BodyContentSpec
+            // javac infers T := Integer here too, not Object.
+            valueCall.methodType.formalParameters[0] shouldBe t_Matcher[`?` `super` int.box()]
+            equalToCall shouldHaveType t_Matcher[int.box()]
+        }
+    }
+
+    parserTest("Interdependent batch in an implicitly typed lambda body") {
+        // Reduced from spring-framework's DefaultPublishedEvents#matchingMapped.
+        // Same root cause as the test above: `of`'s ivar and the ivar of the
+        // flatMap function are interdependent, and applying UPPER too eagerly
+        // makes the whole `of` call unresolvable.
+        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+            """
+            import java.util.List;
+            import java.util.function.Function;
+            import java.util.function.Predicate;
+            import java.util.stream.Stream;
+
+            class Scratch {
+                interface Typed<T> {}
+
+                static class Simple<T> implements Typed<T> {
+                    private final List<T> events = null;
+
+                    static <T> Simple<T> of(Stream<T> stream) { return null; }
+
+                    <S> Typed<T> matchingMapped(Function<T, S> mapper, Predicate<? super S> predicate) {
+                        return Simple.of(this.events.stream().flatMap(it -> {
+                            S mapped = mapper.apply(it);
+                            return predicate.test(mapped) ? Stream.of(it) : Stream.empty();
+                        }));
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+
+        val t_Simple = acu.declaredTypeSignatures()[2]
+        val (of) = acu.declaredMethodSignatures()
+        val ofCall = acu.firstMethodCall("of")
+
+        spy.shouldBeOk {
+            ofCall.overloadSelectionInfo::isFailed shouldBe false
+            ofCall.methodType shouldBeSomeInstantiationOf of
+            // ie Simple<T>, where T is the type param of the enclosing class
+            ofCall shouldHaveType t_Simple
+        }
+    }
 })

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -603,4 +603,47 @@ class TypeReference<T> {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] #5441 False positive when the diamond would be inferred to a different type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+
+class Test {
+    interface CacheLoader<K, V> {
+    }
+
+    interface CacheBuilder<K, V> {
+        <K1 extends K, V1 extends V> AsyncCache<K1, V1> buildAsync(CacheLoader<? super K1, V1> loader);
+    }
+
+    interface Cache<K, V> {
+    }
+
+    interface AsyncCache<K, V> {
+        Cache<K, V> synchronous();
+    }
+
+    abstract static class ConcreteCacheLoader<K, V> implements CacheLoader<K, V> {
+        abstract V fetch(K key);
+    }
+
+    interface Provider {
+        <K, V> CacheBuilder<K, V> newCacheBuilder(String id);
+    }
+
+    void test(Provider provider) {
+        Cache<String, List<Integer>> cache = provider.<String, List<Integer>>newCacheBuilder("test")
+                .buildAsync(new ConcreteCacheLoader<String, List<Integer>>() {
+                    @Override
+                    List<Integer> fetch(String key) {
+                        return List.of(123);
+                    }
+                })
+                .synchronous();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Analyzed and written by Claude Opus 5.

### Describe the PR

`UseDiamondOperator` reported a false positive on code where javac cannot infer
the type arguments, so following the suggestion did not compile:

    Cache<String, List<Integer>> cache =
        provider.<String, List<Integer>>newCacheBuilder("test")
                .buildAsync(new ConcreteCacheLoader<String, List<Integer>>() { ... })
                .synchronous();

The rule itself was fine; the underlying type inference was wrong. PMD inferred
the diamond as `ConcreteCacheLoader<String, List<Integer>>`, identical to the
explicit type arguments, so the rule concluded they were redundant. javac infers
`ConcreteCacheLoader<Object, List<Integer>>`, which is why replacing the type
arguments with a diamond breaks compilation ("does not override abstract method
fetch(Object)").

Two commits, both in `net.sourceforge.pmd.lang.java.types.internal.infer`.

**1. Resolve interdependent inference variables simultaneously**

`VarWalkStrategy` merges strongly connected components of the ivar dependency
graph into a single batch, precisely so that mutually dependent variables are
solved together. But `solveBatchProgressed` instantiated only the first
acceptable variable of the batch and returned, so incorporation ran again before
the rest of the batch was solved. JLS 18.4 requires the instantiations of such a
batch to all be *computed* from the same bound set and only then incorporated,
because the resolution rules may only use *proper* bounds. For the snippet above:

    'a { 'a <: String, 'a <: 'e }     # K1 of buildAsync
    'e { 'e <: Object, 'e >: 'a }     # K of the diamond

Solved sequentially, `'a := String` by UPPER; incorporation turns `'e >: 'a`
into the proper bound `'e >: String`, LOWER applies and `'e := String`. Solved
simultaneously, `'e` has no proper lower bound, so UPPER gives `'e := Object`
while `'a := String` — matching javac.

**2. Exhaust lower bounds before upper bounds within a batch**

The first commit alone caused a regression that the regression tester caught:
5 violations removed from spring-framework (4 `LawOfDemeter`,
1 `UnnecessaryFullyQualifiedName`). Those removals were *not* valid — the
affected calls stopped resolving at all, so the rules bailed out. Reduced from
`JsonPathAssertions#value`:

    <T> BodyContentSpec value(Matcher<? super T> matcher);
    static <T> Matcher<T> equalTo(T operand);

    a.value(equalTo(42));

    'a { 'a <: Object, 'a <: 'd }     # T of value
    'd { 'd >: Integer, 'd >: 'a }    # T of equalTo

Instantiating the batch simultaneously used LOWER for `'d` and UPPER for `'a` in
the same pass: `'a := Object`, `'d := Integer`. Incorporation then produces
`'a <: Integer`, contradicting `'a = Object`, so the bound set becomes false and
the invocation is rejected.

JLS 18.4 prescribes a recovery for exactly this — when the simultaneous
instantiation yields false, a second attempt is made with fresh type variables.
PMD does not implement that fallback. javac has it
(`Infer.instantiateAsUninferredVars`) but never needs it here, because its
`GraphSolver` escalates *step sets* over the whole batch — `{EQ}`, then
`{EQ, LOWER}`, then `{EQ, LOWER, UPPER, THROWS, CAPTURED}` — so LOWER is
exhausted batch-wide before UPPER is applied to any variable. PMD's
`ReductionStep.WAVES` instead offered LOWER and UPPER to the same variable in a
single pass. This commit splits the waves the same way.

`'d := Integer` is then the only instantiation of the first productive wave;
after incorporation `'a <: Integer` is proper and
`'a := glb(Object, Integer) = Integer`. That matches javac, which infers
`T := Integer` here (verified by probing javac with
`<T> List<T> value(Matcher<? super T>)`, which reports `List<Integer>`). This is
also *more* precise than main, which inferred `Matcher<? super Object>`.

Refs the inference trace and initial analysis in oowekyala/pmd@b2bb215.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5441

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
