### PR TITLE
[java] Fix #6926: skip file on unresolved generic arity mismatch

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -46,6 +46,8 @@ This is a {{ site.pmd.release_type }} release.
     ```
 
 ### 🐛️ Fixed Issues
+* java
+    * [#6926](https://github.com/pmd/pmd/issues/6926): \[java] IllegalArgumentException (Mismatched list sizes) with inconsistent unresolved generic arity
 * java-bestpractices
     * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignment is in conditional statement
 * java-codestyle
@@ -73,4 +75,3 @@ This is a {{ site.pmd.release_type }} release.
 <!-- content will be automatically generated, see /do-release.sh -->
 
 {% endtocmaker %}
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
@@ -227,6 +227,9 @@ final class AstDisambiguationPass {
             int actualArity = ASTList.sizeOrZero(type.getTypeArguments());
             int expectedArity = sym instanceof JClassSymbol ? ((JClassSymbol) sym).getTypeParameterCount() : 0;
             if (actualArity != 0 && actualArity != expectedArity) {
+                if (sym.isUnresolved()) {
+                    throw ctx.getLogger().error(type, JavaSemanticErrors.UNRESOLVED_GENERIC_ARITY, type.getSimpleName());
+                }
                 ctx.getLogger().warning(type, JavaSemanticErrors.MALFORMED_GENERIC_TYPE, expectedArity, actualArity);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaSemanticErrors.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaSemanticErrors.java
@@ -58,6 +58,13 @@ public final class JavaSemanticErrors {
      * TODO Should be an error.
      */
     public static final String MALFORMED_GENERIC_TYPE = "Malformed generic type: expected {0} type arguments, got {1}";
+    /**
+     * Unresolved types freeze arity on first use. A later use with a
+     * different count cannot be substituted safely, so analysis of the
+     * file is skipped.
+     */
+    public static final String UNRESOLVED_GENERIC_ARITY =
+        "Mismatched generic count on unresolved type \"{0}\" (missing aux-classpath?)";
     // this is an error
     public static final String EXPECTED_ANNOTATION_TYPE = "Expected an annotation type";
     /**

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/UnresolvedGenericArityMismatchTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/UnresolvedGenericArityMismatchTest.java
@@ -1,0 +1,60 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.types;
+
+import static net.sourceforge.pmd.lang.java.symbols.table.internal.JavaSemanticErrors.UNRESOLVED_GENERIC_ARITY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.ast.SemanticException;
+import net.sourceforge.pmd.lang.java.BaseParserTest;
+import net.sourceforge.pmd.lang.java.JavaParsingHelper.TestCheckLogger;
+
+/**
+ * Regression for inconsistent arity of the same unresolved type name
+ * (e.g. Builder used once with 2 type args and later with 3). Analysis
+ * must report a semantic error and skip the file instead of crashing
+ * in Substitution.mapping.
+ */
+class UnresolvedGenericArityMismatchTest extends BaseParserTest {
+
+    @Test
+    void mismatchedUnresolvedArityIsSemanticError() {
+        String source = ""
+            + "public class ComboBox2Test {\n"
+            + "  public class ComboBoxIntStringItem extends ComboBox1<Integer, String> {\n"
+            + "    public ComboBoxIntStringItem() {\n"
+            + "      super(new Builder<Integer, String>() {});\n"
+            + "    }\n"
+            + "    public static class Item extends Item1<Integer, String> {\n"
+            + "      public Item(Integer key, String displayValue) { super(key, displayValue); }\n"
+            + "    }\n"
+            + "  }\n"
+            + "\n"
+            + "  public class ComboBoxIntStringLongItem extends ComboBox2<Integer, String, Long> {\n"
+            + "    public ComboBoxIntStringLongItem() {\n"
+            + "      super(new Builder<Integer, String, Long>() {});\n"
+            + "    }\n"
+            + "    public static class Item extends Item2<Integer, String, Long> {\n"
+            + "      public Item(Integer key, String displayValue, Long displayValue2) {\n"
+            + "        super(key, displayValue);\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+
+        TestCheckLogger logger = new TestCheckLogger(false);
+        SemanticException ex = assertThrows(SemanticException.class, () -> java.withLogger(logger).parse(source));
+
+        assertEquals(1, logger.errors.get(UNRESOLVED_GENERIC_ARITY).size());
+        assertEquals("Builder", logger.errors.get(UNRESOLVED_GENERIC_ARITY).get(0).getSecond()[0]);
+        assertThat(ex.getMessage(), containsString("Mismatched generic count on unresolved type \"Builder\""));
+        assertThat(ex.getMessage(), containsString("missing aux-classpath"));
+    }
+}


### PR DESCRIPTION
## Describe the PR

Unresolved types keep the type-parameter arity of the first use (`UnresolvedClassStore`). A later use of the same unresolved name with a different argument count used to crash in `Substitution.mapping` / `CollectionUtil.zip` with:

`IllegalArgumentException: Mismatched list sizes [T0, T1] to [...]`

This reports a semantic error (type name + file, missing aux-classpath hint) and skips that file so the rest of the analysis can continue. It does not erase generics.

## Related issues

- Fix #6926

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

### Test plan (executed)

```text
./mvnw -pl pmd-java test -Dtest=UnresolvedGenericArityMismatchTest -Dsurefire.failIfNoSpecifiedTests=false
./mvnw -pl pmd-java test -Dtest=TypeDisambiguationTest,TypeTestUtilTest -Dsurefire.failIfNoSpecifiedTests=false
```

GREEN locally (Java 25 / release 8 bytecode as configured by the project). TypeDisambiguationTest 14/0 skip 1.