### PR TITLE
[java] Fix #6925: ImmutableField: false positive on picocli @Option/@Parameters fields

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -74,6 +74,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6714](https://github.com/pmd/pmd/issues/6714): \[java] Rename UseUtilityClass to InstantiableUtilityClass
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
+    * [#6925](https://github.com/pmd/pmd/issues/6925): \[java] ImmutableField: false positive on picocli annotated fields with default
 * java-errorprone
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -39,7 +39,10 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
 
     private static final Set<String> INVALIDATING_FIELD_ANNOT =
         setOf(
-            "lombok.Setter"
+            "lombok.Setter",
+            // picocli injects values into option/parameter fields at runtime
+            "picocli.CommandLine.Option",
+            "picocli.CommandLine.Parameters"
         );
     private static final Function<Object, JavaNode> INTERESTING_ANCESTOR =
         NodeStream.asInstanceOf(ASTLambdaExpression.class,

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -978,4 +978,57 @@ public class NotSoImmutableField {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6925 [java] ImmutableField: false positive on picocli @Option with default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.LocalDate;
+import picocli.CommandLine.Option;
+
+public class Demo {
+    @Option(
+            names = "--ref-date",
+            description = "Reference date (yyyy-MM-dd) for calculating"
+    )
+    private LocalDate refDate = LocalDate.now().withDayOfMonth(1);
+
+    public void something() {
+        System.out.println(refDate);
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6925 [java] ImmutableField: false positive on picocli @Parameters with default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import picocli.CommandLine.Parameters;
+
+public class Demo {
+    @Parameters(index = "0", description = "Input file", defaultValue = "input.txt")
+    private String inputFile = "input.txt";
+
+    public String getInputFile() {
+        return inputFile;
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6925 [java] ImmutableField still reports plain private fields without picocli</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+public class Demo {
+    private String inputFile = "input.txt";
+
+    public String getInputFile() {
+        return inputFile;
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Ignore private fields annotated with picocli `CommandLine.Option` or `CommandLine.Parameters` in the ImmutableField rule.

picocli injects option/parameter values into those fields at runtime (including when a Java initializer provides a default). Treating them as candidates for `final` is a false positive, same pattern as the existing `lombok.Setter` field exclusion.

## Related issues

- Fixes #6925

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

### Tests

`./mvnw -pl pmd-java -am test -Dtest=ImmutableFieldTest -Dsurefire.failIfNoSpecifiedTests=false` — **54 tests, 0 failures** (Java 21).