### PR TITLE
[core] Make RuleSetLoader#withReporter public

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -58,6 +58,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#4952](https://github.com/pmd/pmd/issues/4952): \[doc] Improve doc around PMDConfiguration#prependAuxclasspath #setClassloader
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
     * [#6865](https://github.com/pmd/pmd/issues/6865): \[core] Include the running PMD version in the "Unable to find referenced rule" error
+    * [#6912](https://github.com/pmd/pmd/issues/6912): \[core] RuleSetLoader#withReporter is not publicly accessible
 * java
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
@@ -82,6 +83,12 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes
 
 ### 🚨️ API Changes
+
+* core
+    * {%jdoc core::lang.rule.RuleSetLoader#withReporter(net.sourceforge.pmd.util.log.PmdReporter) %} is now public.
+      This allows configuring a custom {%jdoc core::util.log.PmdReporter %} when loading rulesets outside of
+      {%jdoc core::PmdAnalysis %}, so that detailed validation and loading messages can be observed.
+      See [#6912](https://github.com/pmd/pmd/issues/6912).
 
 #### Deprecations
 * core

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
@@ -52,7 +52,21 @@ public final class RuleSetLoader {
         // default
     }
 
-    RuleSetLoader withReporter(@NonNull PmdReporter reporter) {
+    /**
+     * Replace the reporter used to handle non-fatal issues while loading
+     * rulesets (for example XML validation messages or deprecation warnings).
+     * The default is {@link PmdReporter#quiet()}, which still counts errors
+     * but does not print them.
+     *
+     * <p>A custom reporter is useful when callers need the detailed message
+     * behind a {@link RuleSetLoadException} (the exception message itself is
+     * often only a summary).
+     *
+     * @param reporter Reporter to use; must not be null
+     *
+     * @return This instance, modified
+     */
+    public RuleSetLoader withReporter(@NonNull PmdReporter reporter) {
         this.reporter = Objects.requireNonNull(reporter);
         return this;
     }


### PR DESCRIPTION
## Describe the PR

`RuleSetLoader#withReporter` was package-private, so external callers could not configure a custom `PmdReporter` when loading rulesets outside of `PmdAnalysis`. The default quiet reporter (or the opaque summary on `RuleSetLoadException`) made it hard to see the underlying validation detail.

This change makes `withReporter` part of the public fluent API (with javadoc) and documents it under API Changes / Fixed Issues.

`InternalApiBridge.withReporter` remains for existing internal callers.

## Related issues

- Fixes #6912

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

### Notes

- Existing `RuleSetFactoryTest` (via `RulesetFactoryTestBase`) already exercises `withReporter` for error/warning capture — **59/59** pass on Temurin 21.
- Related issues #6913 / #6914 are **not** addressed here (separate scope: `loadFromString` ResourceLoader, class extensibility).