### PR TITLE
[java] Fix #6747: NonThreadSafeSingleton flags ternary lazy init

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -77,6 +77,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-errorprone
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
+    * [#6747](https://github.com/pmd/pmd/issues/6747): \[java] NonThreadSafeSingleton: False negative with ternary conditional operator
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -77,6 +77,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-errorprone
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
+* java-multithreading
     * [#6747](https://github.com/pmd/pmd/issues/6747): \[java] NonThreadSafeSingleton: False negative with ternary conditional operator
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -106,6 +107,36 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
             if (violation) {
                 asCtx(data).addViolation(ifStatement);
             }
+        }
+
+        // The same check-then-act race can be written as a ternary assignment:
+        //   field = field == null ? new T() : field;
+        // which is not an ASTIfStatement and was previously missed.
+        for (ASTAssignmentExpression assignment : node.descendants(ASTAssignmentExpression.class).toList()) {
+            if (assignment.ancestors(ASTSynchronizedStatement.class).nonEmpty()) {
+                continue;
+            }
+            ASTAssignableExpr left = assignment.getLeftOperand();
+            if (!(left instanceof ASTNamedReferenceExpr)) {
+                continue;
+            }
+            String fieldName = ((ASTNamedReferenceExpr) left).getName();
+            JVariableSymbol referencedSym = ((ASTNamedReferenceExpr) left).getReferencedSym();
+            if (!(referencedSym instanceof JFieldSymbol) || !fields.contains(fieldName)) {
+                continue;
+            }
+            if (!(assignment.getRightOperand() instanceof ASTConditionalExpression)) {
+                continue;
+            }
+            ASTConditionalExpression ternary = (ASTConditionalExpression) assignment.getRightOperand();
+            if (ternary.getCondition().descendants(ASTNullLiteral.class).isEmpty()) {
+                continue;
+            }
+            ASTNamedReferenceExpr condField = ternary.getCondition().descendants(ASTNamedReferenceExpr.class).first();
+            if (condField == null || !fieldName.equals(condField.getName())) {
+                continue;
+            }
+            asCtx(data).addViolation(assignment);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -23,7 +23,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -89,19 +88,8 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
             List<ASTAssignmentExpression> assignments = ifStatement.descendants(ASTAssignmentExpression.class).toList();
             boolean violation = false;
             for (ASTAssignmentExpression assignment : assignments) {
-                if (assignment.ancestors(ASTSynchronizedStatement.class).nonEmpty()) {
-                    continue;
-                }
-
-                ASTAssignableExpr left = assignment.getLeftOperand();
-                if (left instanceof ASTNamedReferenceExpr) {
-                    JVariableSymbol referencedSym = ((ASTNamedReferenceExpr) left).getReferencedSym();
-                    if (referencedSym instanceof JFieldSymbol) {
-                        String name = ((ASTNamedReferenceExpr) left).getName();
-                        if (fields.contains(name)) {
-                            violation = true;
-                        }
-                    }
+                if (fieldWriteName(assignment) != null) {
+                    violation = true;
                 }
             }
             if (violation) {
@@ -113,16 +101,8 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
         //   field = field == null ? new T() : field;
         // which is not an ASTIfStatement and was previously missed.
         for (ASTAssignmentExpression assignment : node.descendants(ASTAssignmentExpression.class).toList()) {
-            if (assignment.ancestors(ASTSynchronizedStatement.class).nonEmpty()) {
-                continue;
-            }
-            ASTAssignableExpr left = assignment.getLeftOperand();
-            if (!(left instanceof ASTNamedReferenceExpr)) {
-                continue;
-            }
-            String fieldName = ((ASTNamedReferenceExpr) left).getName();
-            JVariableSymbol referencedSym = ((ASTNamedReferenceExpr) left).getReferencedSym();
-            if (!(referencedSym instanceof JFieldSymbol) || !fields.contains(fieldName)) {
+            String fieldName = fieldWriteName(assignment);
+            if (fieldName == null) {
                 continue;
             }
             if (!(assignment.getRightOperand() instanceof ASTConditionalExpression)) {
@@ -139,5 +119,28 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
             asCtx(data).addViolation(assignment);
         }
         return data;
+    }
+
+
+    /**
+     * Returns the name of the monitored field written by {@code assignment}, or {@code null}
+     * if {@code assignment} is not a non-synchronized write to one of the tracked singleton
+     * fields. Shared by the if-statement and ternary check-then-act detection so both cases
+     * apply identical field-write criteria and cannot drift apart.
+     */
+    private String fieldWriteName(ASTAssignmentExpression assignment) {
+        if (assignment.ancestors(ASTSynchronizedStatement.class).nonEmpty()) {
+            return null;
+        }
+        ASTAssignableExpr left = assignment.getLeftOperand();
+        if (!(left instanceof ASTNamedReferenceExpr)) {
+            return null;
+        }
+        ASTNamedReferenceExpr ref = (ASTNamedReferenceExpr) left;
+        if (!(ref.getReferencedSym() instanceof JFieldSymbol)) {
+            return null;
+        }
+        String name = ref.getName();
+        return fields.contains(name) ? name : null;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -78,11 +79,7 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
 
         List<ASTIfStatement> ifStatements = node.descendants(ASTIfStatement.class).toList();
         for (ASTIfStatement ifStatement : ifStatements) {
-            if (ifStatement.getCondition().descendants(ASTNullLiteral.class).isEmpty()) {
-                continue;
-            }
-            ASTNamedReferenceExpr n = ifStatement.getCondition().descendants(ASTNamedReferenceExpr.class).first();
-            if (n == null || !fields.contains(n.getName())) {
+            if (!isNullCheckOnField(ifStatement.getCondition(), null)) {
                 continue;
             }
             List<ASTAssignmentExpression> assignments = ifStatement.descendants(ASTAssignmentExpression.class).toList();
@@ -109,16 +106,30 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRulechainRule {
                 continue;
             }
             ASTConditionalExpression ternary = (ASTConditionalExpression) assignment.getRightOperand();
-            if (ternary.getCondition().descendants(ASTNullLiteral.class).isEmpty()) {
-                continue;
-            }
-            ASTNamedReferenceExpr condField = ternary.getCondition().descendants(ASTNamedReferenceExpr.class).first();
-            if (condField == null || !fieldName.equals(condField.getName())) {
+            if (!isNullCheckOnField(ternary.getCondition(), fieldName)) {
                 continue;
             }
             asCtx(data).addViolation(assignment);
         }
         return data;
+    }
+
+
+    /**
+     * Returns whether {@code condition} is a null-check on a tracked singleton field.
+     * If {@code targetField} is non-null, the checked field must equal it (used by the
+     * ternary case, where the same field is both read in the condition and written);
+     * otherwise any tracked field matches (used by the if case, which keeps pmd's
+     * long-standing conservative behavior). Centralizing this lets the if and ternary
+     * cases share identical condition-check logic.
+     */
+    private boolean isNullCheckOnField(ASTExpression condition, String targetField) {
+        if (condition.descendants(ASTNullLiteral.class).isEmpty()) {
+            return false;
+        }
+        ASTNamedReferenceExpr ref = condition.descendants(ASTNamedReferenceExpr.class).first();
+        return ref != null
+                && (targetField != null ? targetField.equals(ref.getName()) : fields.contains(ref.getName()));
     }
 
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/NonThreadSafeSingleton.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/NonThreadSafeSingleton.xml
@@ -212,4 +212,41 @@ class Tester {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Ternary lazy init is a check-then-act race #6747</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,11</expected-linenumbers>
+        <code><![CDATA[
+class LazyInitTernary {
+    private static Object foo;
+    private static Object bar;
+
+    public static Object getFoo() {
+        foo = foo == null ? new Object() : foo;
+        return foo;
+    }
+
+    public static Object getBar() {
+        bar = bar == null ? new Object() : bar;
+        return bar;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Ternary without null check is OK #6747</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class LazyInitTernaryNoNullCheck {
+    private static Object foo;
+    private static boolean ready;
+    public static Object getFoo() {
+        foo = ready ? new Object() : foo;
+        return foo;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## What

`NonThreadSafeSingleton` now also flags the ternary form of the unsafe lazy-init race:

```java
field = field == null ? new T() : field;
```

which is semantically identical to the already-detected `if (field == null) field = new T();`.

Closes #6747.

## Why

The rewrite exposes the exact same check-then-act data race under concurrent access, yet produced **0 findings** where the `if` form produced 2. The rule only walked `ASTIfStatement`, so the ternary assignment (an `ASTAssignmentExpression` whose right-hand side is an `ASTConditionalExpression`) was invisible to it.

## How

In `visit(ASTMethodDeclaration)`, after the existing `ASTIfStatement` loop, add a second pass over `ASTAssignmentExpression` nodes that reports a violation when:

- the assignment target is a tracked field (not inside a `synchronized` block), and
- the right-hand side is a ternary whose condition null-checks the **same** field.

This mirrors the checks already applied to the `if` form. The `if`-form path is unchanged: a plain `field = new T();` assignment has a non-conditional right-hand side, so the two passes don't double-report.

## Testing

- Added two XML cases to `NonThreadSafeSingleton.xml`:
  - the ternary form from the issue (2 expected findings, lines 6 and 11), and
  - a ternary without a null check (`field = ready ? new T() : field;`) → 0 findings.
- Verified the test **fails before the fix** (`expected: <2> but was: <0>`) and **passes after** (13/13).
- `./mvnw -pl pmd-java checkstyle:check` → 0 violations.

Added a `release_notes.md` entry under the java notes.
