### PR TITLE
[java] Fix #6435: UnconditionalIfStatement flags arbitrarily negated boolean literals

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -99,6 +99,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone
     * [#2840](https://github.com/pmd/pmd/issues/2840): \[java] CloseResource: False positive on mocks
+    * [#6435](https://github.com/pmd/pmd/issues/6435): \[java] UnconditionalIfStatement: False negative for negated boolean constant
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3333,7 +3333,11 @@ Do not use "if" statements whose conditionals are always true or always false.
             <property name="xpath">
                 <value>
  <![CDATA[
-//IfStatement[BooleanLiteral[1]]
+//IfStatement[
+    every $node in *[1]/descendant-or-self::*
+    satisfies $node/self::BooleanLiteral
+              or $node/self::UnaryExpression[@Operator = '!']
+]
 union
 //IfStatement/(VariableAccess|UnaryExpression[@Operator = '!']/VariableAccess)/self::VariableAccess[@CompileTimeConstant = false()]
 [@Name = ancestor::IfStatement

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnconditionalIfStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnconditionalIfStatement.xml
@@ -143,4 +143,62 @@ class UnconditionalIfStatementBug {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6435 false-negative if (!false)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        if (!false) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6435 false-negative if (!true)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        if (!true) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6435 boolean literal with multiple logical negations</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>3,4,5,6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        if (!!true) {}
+        if (!!!false) {}
+        if (!!!!!!!!true) {}
+        if (!((!!false))) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6435 no false-positive for negated non-constant boolean</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(boolean b) {
+        if (!b) {}
+        if (!!b) {}
+        if (b) {
+            boolean nested = !!!true;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

`UnconditionalIfStatement` now reports an `if` condition when a boolean literal is wrapped in any number of logical `!` operators. The previous XPath handled a direct literal and the initial fix handled exactly one `UnaryExpression`, so `!!true` and longer chains still escaped the rule.

The XPath now inspects only the if-condition (`*[1]`) and accepts it when every node in that expression subtree is either a `BooleanLiteral` or a `UnaryExpression` whose operator is `!`. This expresses the complete `UnaryExpression(!)* -> BooleanLiteral` shape without a fixed maximum depth. Conditions ending in a variable, such as `!b` and `!!b`, remain excluded, as do conditions containing other expression node types.

Regression coverage now spans zero, one, two, three, and eight logical negations, a parenthesized chain, non-literal chains, and an if-body scoping guard. The new repeated-negation test fails against the previous PR head with `expected: <4> but was: <0>` and passes with the structural XPath.

Local verification:

- `./mvnw -o -pl pmd-java -am test -Dtest=UnconditionalIfStatementTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false`: 13 tests, 0 failures, 0 errors.
- `./mvnw clean verify`: BUILD SUCCESS.

Regression tester: compared to main, the changeset introduces 0 new violations, 0 new errors, and 0 new configuration errors. `UnconditionalIfStatement` itself reports the same violations on every project in the corpus (no added, removed, or changed, e.g. 949 to 949 on checkstyle and 4 to 4 on spring-framework), so the broader matcher does not flag any new site in openjdk-11, spring-framework, checkstyle, or the other projects. The remaining deltas are 8 changed `UnusedReturnValue` violations, a rule this PR does not touch, plus baseline errors and configuration errors that are removed on this base; none of these are introduced by this XPath-only change to one rule.

## Related issues

- Fix #6435

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
