### PR TITLE
[java] Fix #6901: Track internal array escapes through expressions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -90,6 +90,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
     * [#6393](https://github.com/pmd/pmd/issues/6393): \[java] UnusedPrivateMethod: False positive with overloaded private methods called with values returned from methods of an unresolved type
     * [#6611](https://github.com/pmd/pmd/issues/6611): \[java] UnnecessaryVarargsArrayCreation: false positive when removing the array creates overload ambiguity
+    * [#6901](https://github.com/pmd/pmd/issues/6901): \[java] MethodReturnsInternalArray: False negative when the same array escapes through Collections.singletonList(data).get(0)
     * [#6965](https://github.com/pmd/pmd/issues/6965): \[java] AbstractClassWithoutAnyMethod False Positive on derived abstract class
 * java-codestyle
     * [#5441](https://github.com/pmd/pmd/issues/5441): \[java] UseDiamondOperator: False positive with interdependent generic vars

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
@@ -5,27 +5,74 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayDimExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayTypeDim;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
+import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTList;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.AssignmentEntry;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.DataflowResult;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.ReachingDefinitionSet;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JFormalParamSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
+import net.sourceforge.pmd.lang.java.types.JClassType;
+import net.sourceforge.pmd.lang.java.types.JMethodSig;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.JTypeVar;
+import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
- * Implementation note: this rule currently ignores return types of y.x.z,
- * currently it handles only local type fields. Created on Jan 17, 2005
+ * Flags methods that expose an internal array through their return value.
+ *
+ * <p>The rule traces array provenance backwards from each return. Local
+ * aliases are resolved with {@link DataflowPass}. Calls are followed only
+ * when their generic declaration connects an input type variable to the
+ * result, which covers arbitrary container and accessor chains without an API
+ * allowlist. Exact helpers in the current class are summarized from their
+ * return expressions, so a helper that returns a clone is distinguished from
+ * one that returns the field itself.
+ *
+ * <p>The analysis is a may-analysis: if any reaching definition or value
+ * branch carries an internal array, the return is reported. Heap mutation,
+ * dynamically dispatched helpers, and non-generic calls across class
+ * boundaries are not modelled.
  */
 public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
 
@@ -42,31 +89,40 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
             return null;
         }
 
-        for (ASTReturnStatement returnStmt : method.descendants(ASTReturnStatement.class)) {
-            ASTExpression expr = returnStmt.getExpr();
-            if (expr instanceof ASTNamedReferenceExpr) {
-                ASTNamedReferenceExpr reference = (ASTNamedReferenceExpr) expr;
+        DataflowResult dataflow = DataflowPass.getDataflowResult(method.getRoot());
+        InternalArrayEscapeAnalysis analysis = new InternalArrayEscapeAnalysis(
+            dataflow, method.getEnclosingType().getSymbol());
 
-                if (JavaAstUtils.isRefToFieldOfThisInstance(reference)) {
-                    ctx.addViolation(returnStmt, reference.getName());
-                } else {
-                    // considers static, non-final fields
-                    JVariableSymbol symbol = reference.getReferencedSym();
-                    if (symbol instanceof JFieldSymbol) {
-                        JFieldSymbol field = (JFieldSymbol) symbol;
-                        if (field.isStatic() && isInternal(field) && !isZeroLengthArrayConstant(field)) {
-                            ctx.addViolation(returnStmt, reference.getName());
-                        }
-                    }
-                }
+        for (ASTReturnStatement returnStmt : method.descendants(ASTReturnStatement.class)) {
+            if (JavaAstUtils.getReturnTarget(returnStmt) != method) {
+                continue;
+            }
+            ASTNamedReferenceExpr source = analysis.findEscapingField(returnStmt.getExpr());
+            if (source != null) {
+                ctx.addViolation(returnStmt, source.getName());
             }
         }
         return null;
     }
 
+    private static boolean isInternalArrayReference(ASTNamedReferenceExpr reference) {
+        if (!reference.getTypeMirror().isArray()) {
+            return false;
+        }
+        if (JavaAstUtils.isRefToFieldOfThisInstance(reference)) {
+            return true;
+        }
+        JVariableSymbol symbol = reference.getReferencedSym();
+        if (symbol instanceof JFieldSymbol) {
+            JFieldSymbol field = (JFieldSymbol) symbol;
+            return field.isStatic() && isInternal(field) && !isZeroLengthArrayConstant(field);
+        }
+        return false;
+    }
+
     private static boolean isInternal(JFieldSymbol field) {
-        return !Modifier.isPublic(field.getModifiers()) // not public
-            && !field.isUnresolved(); // must be resolved to avoid FPs
+        return !Modifier.isPublic(field.getModifiers())
+            && !field.isUnresolved();
     }
 
     private static boolean isZeroLengthArrayConstant(JFieldSymbol sym) {
@@ -79,21 +135,306 @@ public class MethodReturnsInternalArrayRule extends AbstractJavaRulechainRule {
 
     private static boolean isZeroLengthArrayExpr(ASTExpression expr) {
         if (expr instanceof ASTArrayInitializer) {
-            // {}
             return ((ASTArrayInitializer) expr).length() == 0;
         } else if (expr instanceof ASTArrayAllocation) {
             ASTArrayInitializer init = ((ASTArrayAllocation) expr).getArrayInitializer();
             if (init != null) {
-                // new int[] {}
                 return init.length() == 0;
-            } else {
-                // new int[0]
-                ASTArrayTypeDim lastChild = ((ASTArrayAllocation) expr).getTypeNode().getDimensions().getLastChild();
-                if (lastChild instanceof ASTArrayDimExpr) {
-                    return JavaAstUtils.isLiteralInt(((ASTArrayDimExpr) lastChild).getLengthExpression(), 0);
-                }
+            }
+            ASTArrayTypeDim lastChild = ((ASTArrayAllocation) expr).getTypeNode().getDimensions().getLastChild();
+            if (lastChild instanceof ASTArrayDimExpr) {
+                return JavaAstUtils.isLiteralInt(((ASTArrayDimExpr) lastChild).getLengthExpression(), 0);
             }
         }
         return false;
+    }
+
+    private static boolean isScalar(JTypeMirror type) {
+        return type.isPrimitive()
+            || type.isBoxedPrimitive()
+            || TypeTestUtil.isExactlyA(String.class, type)
+            || TypeTestUtil.isExactlyA(Class.class, type);
+    }
+
+    private static boolean isFreshArrayProducer(ASTMethodCall call) {
+        String name = call.getMethodName();
+        if ("clone".equals(name)) {
+            ASTExpression qualifier = call.getQualifier();
+            return qualifier != null
+                && qualifier.getTypeMirror().isArray()
+                && ASTList.sizeOrZero(call.getArguments()) == 0
+                && call.getTypeMirror().isArray();
+        }
+        return ("copyOf".equals(name) || "copyOfRange".equals(name))
+            && TypeTestUtil.isDeclaredInClass(java.util.Arrays.class, call.getMethodType());
+    }
+
+    private static final class InternalArrayEscapeAnalysis {
+
+        private final DataflowResult dataflow;
+        private final JClassSymbol rootClass;
+
+        private InternalArrayEscapeAnalysis(DataflowResult dataflow, JClassSymbol rootClass) {
+            this.dataflow = dataflow;
+            this.rootClass = rootClass;
+        }
+
+        @Nullable
+        ASTNamedReferenceExpr findEscapingField(@Nullable ASTExpression expression) {
+            return findEscapingField(expression, AnalysisContext.root());
+        }
+
+        private @Nullable ASTNamedReferenceExpr findEscapingField(@Nullable ASTExpression expression,
+                                                                  AnalysisContext context) {
+            if (expression == null || isScalar(expression.getTypeMirror())) {
+                return null;
+            }
+
+            if (expression instanceof ASTNamedReferenceExpr) {
+                return fromNamedReference((ASTNamedReferenceExpr) expression, context);
+            } else if (expression instanceof ASTCastExpression) {
+                return findEscapingField(((ASTCastExpression) expression).getOperand(), context);
+            } else if (expression instanceof ASTConditionalExpression) {
+                ASTConditionalExpression conditional = (ASTConditionalExpression) expression;
+                ASTNamedReferenceExpr source = findEscapingField(conditional.getThenBranch(), context);
+                return source != null ? source : findEscapingField(conditional.getElseBranch(), context);
+            } else if (expression instanceof ASTSwitchExpression) {
+                for (ASTExpression yield : ((ASTSwitchExpression) expression).getYieldExpressions()) {
+                    ASTNamedReferenceExpr source = findEscapingField(yield, context);
+                    if (source != null) {
+                        return source;
+                    }
+                }
+            } else if (expression instanceof ASTAssignmentExpression) {
+                return findEscapingField(((ASTAssignmentExpression) expression).getRightOperand(), context);
+            } else if (expression instanceof ASTArrayAccess) {
+                return findEscapingField(((ASTArrayAccess) expression).getQualifier(), context);
+            } else if (expression instanceof ASTArrayAllocation) {
+                return fromArrayAllocation((ASTArrayAllocation) expression, context);
+            } else if (expression instanceof ASTMethodCall) {
+                return fromMethodCall((ASTMethodCall) expression, context);
+            } else if (expression instanceof ASTConstructorCall) {
+                return fromGenericSignature((ASTConstructorCall) expression, null, context);
+            }
+            return null;
+        }
+
+        private @Nullable ASTNamedReferenceExpr fromNamedReference(ASTNamedReferenceExpr reference,
+                                                                    AnalysisContext context) {
+            if (isInternalArrayReference(reference)) {
+                return reference;
+            }
+
+            JVariableSymbol symbol = reference.getReferencedSym();
+            if (symbol == null || symbol instanceof JFieldSymbol
+                || !context.visitingVariables.add(symbol)) {
+                return null;
+            }
+
+            try {
+                ReachingDefinitionSet reaching = dataflow.getReachingDefinitions(reference);
+                List<AssignmentEntry> definitions = new ArrayList<>(reaching.getReaching());
+                Collections.sort(definitions);
+                for (AssignmentEntry definition : definitions) {
+                    ASTExpression rhs = definition.getRhsAsExpression();
+                    if (definition.isForeachVar()) {
+                        rhs = definition.getVarId()
+                                        .ancestors(ASTForeachStatement.class)
+                                        .firstOrThrow()
+                                        .getIterableExpr();
+                    }
+                    ASTNamedReferenceExpr source = rhs == null
+                                                   ? context.entryValue(symbol)
+                                                   : findEscapingField(rhs, context);
+                    if (source != null) {
+                        return source;
+                    }
+                }
+                return reaching.isNotFullyKnown() ? context.entryValue(symbol) : null;
+            } finally {
+                context.visitingVariables.remove(symbol);
+            }
+        }
+
+        private @Nullable ASTNamedReferenceExpr fromArrayAllocation(ASTArrayAllocation allocation,
+                                                                     AnalysisContext context) {
+            ASTArrayInitializer initializer = allocation.getArrayInitializer();
+            if (initializer != null) {
+                for (ASTExpression element : initializer) {
+                    ASTNamedReferenceExpr source = findEscapingField(element, context);
+                    if (source != null) {
+                        return source;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private @Nullable ASTNamedReferenceExpr fromMethodCall(ASTMethodCall call,
+                                                                AnalysisContext context) {
+            if (isFreshArrayProducer(call)) {
+                return null;
+            }
+
+            ASTMethodDeclaration helper = getSummarizableHelper(call);
+            if (helper != null) {
+                return summarizeHelper(call, helper, context);
+            }
+            return fromGenericSignature(call, call.getQualifier(), context);
+        }
+
+        private @Nullable ASTMethodDeclaration getSummarizableHelper(ASTMethodCall call) {
+            OverloadSelectionResult overload = call.getOverloadSelectionInfo();
+            if (overload.isFailed()) {
+                return null;
+            }
+
+            JExecutableSymbol executable = overload.getMethodType().getSymbol();
+            if (!(executable instanceof JMethodSymbol)
+                || !rootClass.equals(executable.getEnclosingClass())) {
+                return null;
+            }
+
+            int modifiers = executable.getModifiers();
+            boolean exactDispatch = executable.isStatic()
+                || Modifier.isPrivate(modifiers)
+                || Modifier.isFinal(modifiers)
+                || rootClass.isFinal();
+            if (!exactDispatch
+                || !executable.isStatic() && !JavaAstUtils.isCallOnThisInstance(call).isTrue()) {
+                return null;
+            }
+
+            ASTMethodDeclaration declaration = ((JMethodSymbol) executable).tryGetNode();
+            return declaration != null && declaration.getBody() != null ? declaration : null;
+        }
+
+        private @Nullable ASTNamedReferenceExpr summarizeHelper(ASTMethodCall call,
+                                                                 ASTMethodDeclaration helper,
+                                                                 AnalysisContext callerContext) {
+            JExecutableSymbol executable = call.getMethodType().getSymbol();
+            if (!callerContext.visitingExecutables.add(executable)) {
+                return null;
+            }
+
+            try {
+                AnalysisContext helperContext = callerContext.forCall(bindArguments(call, executable,
+                                                                                    callerContext));
+                for (ASTReturnStatement returnStmt : helper.descendants(ASTReturnStatement.class)) {
+                    if (JavaAstUtils.getReturnTarget(returnStmt) == helper) {
+                        ASTNamedReferenceExpr source = findEscapingField(returnStmt.getExpr(), helperContext);
+                        if (source != null) {
+                            return source;
+                        }
+                    }
+                }
+                return null;
+            } finally {
+                callerContext.visitingExecutables.remove(executable);
+            }
+        }
+
+        private Map<JVariableSymbol, ASTNamedReferenceExpr> bindArguments(InvocationNode invocation,
+                                                                          JExecutableSymbol executable,
+                                                                          AnalysisContext context) {
+            Map<JVariableSymbol, ASTNamedReferenceExpr> result = new HashMap<>();
+            List<JFormalParamSymbol> formals = executable.getFormalParameters();
+            int argumentCount = ASTList.sizeOrZero(invocation.getArguments());
+            boolean varargs = invocation.getOverloadSelectionInfo().isVarargsCall() && !formals.isEmpty();
+            int fixedCount = varargs ? formals.size() - 1 : formals.size();
+            for (int i = 0; i < fixedCount && i < argumentCount; i++) {
+                ASTNamedReferenceExpr source = findEscapingField(invocation.getArguments().get(i), context);
+                if (source != null) {
+                    result.put(formals.get(i), source);
+                }
+            }
+            if (varargs) {
+                for (int i = fixedCount; i < argumentCount; i++) {
+                    ASTNamedReferenceExpr source = findEscapingField(invocation.getArguments().get(i), context);
+                    if (source != null) {
+                        result.put(formals.get(formals.size() - 1), source);
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        private @Nullable ASTNamedReferenceExpr fromGenericSignature(InvocationNode invocation,
+                                                                      @Nullable ASTExpression receiver,
+                                                                      AnalysisContext context) {
+            OverloadSelectionResult overload = invocation.getOverloadSelectionInfo();
+            if (overload.isFailed()) {
+                return null;
+            }
+
+            JMethodSig generic = overload.getMethodType().getSymbol().getGenericSignature();
+            Set<JTypeVar> resultVariables = resultTypeVariables(generic);
+            if (resultVariables.isEmpty()) {
+                return null;
+            }
+
+            if (receiver != null && generic.getSymbol().hasReceiver()
+                && TypeOps.mentionsAny(generic.getDeclaringType(), resultVariables)) {
+                ASTNamedReferenceExpr source = findEscapingField(receiver, context);
+                if (source != null) {
+                    return source;
+                }
+            }
+
+            int argumentCount = ASTList.sizeOrZero(invocation.getArguments());
+            boolean varargs = overload.isVarargsCall();
+            for (int i = 0; i < argumentCount && (i < generic.getArity() || varargs); i++) {
+                if (TypeOps.mentionsAny(generic.ithFormalParam(i, varargs), resultVariables)) {
+                    ASTNamedReferenceExpr source = findEscapingField(invocation.getArguments().get(i), context);
+                    if (source != null) {
+                        return source;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private Set<JTypeVar> resultTypeVariables(JMethodSig generic) {
+            Set<JTypeVar> candidates = new LinkedHashSet<>(generic.getTypeParameters());
+            JTypeMirror declaringType = generic.getDeclaringType();
+            while (declaringType instanceof JClassType) {
+                JClassType declaringClass = (JClassType) declaringType;
+                candidates.addAll(declaringClass.getFormalTypeParams());
+                declaringType = declaringClass.getEnclosingType();
+            }
+            candidates.removeIf(typeVar -> !TypeOps.mentionsAny(generic.getReturnType(),
+                                                                 Collections.singleton(typeVar)));
+            return candidates;
+        }
+
+        private static final class AnalysisContext {
+
+            private final Map<JVariableSymbol, ASTNamedReferenceExpr> entryValues;
+            private final Set<JVariableSymbol> visitingVariables;
+            private final Set<JExecutableSymbol> visitingExecutables;
+
+            private AnalysisContext(Map<JVariableSymbol, ASTNamedReferenceExpr> entryValues,
+                                    Set<JVariableSymbol> visitingVariables,
+                                    Set<JExecutableSymbol> visitingExecutables) {
+                this.entryValues = entryValues;
+                this.visitingVariables = visitingVariables;
+                this.visitingExecutables = visitingExecutables;
+            }
+
+            private static AnalysisContext root() {
+                return new AnalysisContext(new HashMap<>(), new HashSet<>(), new HashSet<>());
+            }
+
+            private AnalysisContext forCall(Map<JVariableSymbol, ASTNamedReferenceExpr> parameters) {
+                Map<JVariableSymbol, ASTNamedReferenceExpr> values = new HashMap<>(entryValues);
+                values.putAll(parameters);
+                return new AnalysisContext(values, visitingVariables, visitingExecutables);
+            }
+
+            private @Nullable ASTNamedReferenceExpr entryValue(JVariableSymbol symbol) {
+                return entryValues.get(symbol);
+            }
+        }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayTest.java
@@ -4,8 +4,12 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import org.junit.jupiter.api.Tag;
+
+import net.sourceforge.pmd.lang.java.rule.AllDataflowRuleTestSuite;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
+@Tag(AllDataflowRuleTestSuite.TAG)
 class MethodReturnsInternalArrayTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MethodReturnsInternalArray.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MethodReturnsInternalArray.xml
@@ -497,4 +497,487 @@ public class Outer {
 }
         ]]></code>
     </test-code>
+
+    <!-- The following tests cover #6901: the rule now follows the provenance of
+         array-valued return expressions through local variables, value-producing
+         branches, exact local helpers, and generic call inputs connected to the
+         returned type. See the class Javadoc in MethodReturnsInternalArrayRule. -->
+
+    <test-code>
+        <description>#6901 issue reproducer: array escapes through Collections.singletonList(data).get(0)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Collections;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return Collections.singletonList(data).get(0);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 review: equivalent escape through List.of(data).get(1)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return List.of(data, data).get(1);
+    }
+}
+        ]]></code>
+        <source-type>java 9</source-type>
+    </test-code>
+
+    <test-code>
+        <description>#6901 review: equivalent escape through a generic Tuple.of(data).getLeft()</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return Tuple.of(data, data).getLeft();
+    }
+
+    static class Tuple<L, R> {
+        private final L left;
+        private final R right;
+        Tuple(L left, R right) { this.left = left; this.right = right; }
+        static <L, R> Tuple<L, R> of(L left, R right) { return new Tuple<>(left, right); }
+        L getLeft() { return left; }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 local alias: byte[] result = data; return result;</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        byte[] result = data;
+        return result;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 wrapper stored in a local before access: List values = singletonList(data); return values.get(0)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Collections;
+import java.util.List;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        List<byte[]> values = Collections.singletonList(data);
+        return values.get(0);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 branch merge: any path carrying the internal array escapes</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+    private boolean flag;
+
+    public byte[] getData() {
+        byte[] result;
+        if (flag) {
+            result = data;
+        } else {
+            result = new byte[0];
+        }
+        return result;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 conditional value branch: flag ? data : new byte[0] escapes</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+    private boolean flag;
+
+    public byte[] getData() {
+        return flag ? data : new byte[0];
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 multidimensional array element: return data[0] from byte[][] data</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[][] data;
+
+    public byte[] getData() {
+        return data[0];
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 constructor wrapper: return new Holder&lt;byte[]&gt;(data).get()</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return new Holder<byte[]>(data).get();
+    }
+
+    static class Holder<T> {
+        private final T value;
+        Holder(T value) { this.value = value; }
+        T get() { return value; }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 new outer array stores the internal array: return new Object[] { data }</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public Object[] getData() {
+        return new Object[] { data };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 foreach variable: for (byte[] value : singletonList(data)) { return value; }</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Collections;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        for (byte[] value : Collections.singletonList(data)) {
+            return value;
+        }
+        return null;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 cast chain: return (byte[]) (Object) data</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return (byte[]) (Object) data;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: wrapper holds a local fresh array</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Collections;
+
+public class Foo {
+    public byte[] getData() {
+        byte[] local = new byte[0];
+        return Collections.singletonList(local).get(0);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: all reaching paths are overwritten with a fresh array</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        byte[] result = data;
+        result = new byte[0];
+        return result;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 freshness barrier: array clone()</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return data.clone();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 freshness barrier: Arrays.copyOf</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Arrays;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return Arrays.copyOf(data, data.length);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 freshness barrier: Arrays.copyOfRange</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Arrays;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return Arrays.copyOfRange(data, 0, data.length);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: internal array used only in the condition of a ternary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return data == null ? new byte[0] : new byte[1];
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: internal array used only as the length of a fresh array</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return new byte[data.length];
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape and no recursion: local self-assignment cycle without a source</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public byte[] getData() {
+        byte[] result = null;
+        result = result;
+        return result;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape and no recursion: mutually aliased locals cycle without a source</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public byte[] getData(boolean flag) {
+        byte[] x;
+        byte[] y;
+        if (flag) {
+            x = new byte[0];
+            y = x;
+        } else {
+            y = new byte[0];
+            x = y;
+        }
+        return x;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 may-analysis: a mutually aliased cycle still reports when one path carries the internal array</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>14</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData(boolean flag) {
+        byte[] x;
+        byte[] y;
+        if (flag) {
+            x = data;
+            y = x;
+        } else {
+            y = new byte[0];
+            x = y;
+        }
+        return x;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: a return inside a nested lambda is not attributed to the enclosing method</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.function.Supplier;
+
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        Supplier<byte[]> s = () -> { return data; };
+        return new byte[0];
+    }
+}
+        ]]></code>
+        <source-type>java 8</source-type>
+    </test-code>
+
+    <test-code>
+        <description>#6901 interprocedural flow: a private helper returns its internal array argument</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    private static byte[] identity(byte[] input) {
+        return input;
+    }
+
+    public byte[] getData() {
+        return identity(data);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: a private helper returns a clone of its argument</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    private static byte[] copy(byte[] input) {
+        return input.clone();
+    }
+
+    public byte[] getData() {
+        return copy(data);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 no escape: a non-generic external transformation is not assumed to return its argument</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return ArrayUtil.copy(data);
+    }
+}
+
+class ArrayUtil {
+    static byte[] copy(byte[] input) {
+        return input.clone();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6901 generic identity: a type variable carries the array from argument to result</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private byte[] data;
+
+    public byte[] getData() {
+        return Identity.keep(data);
+    }
+}
+
+class Identity {
+    static <T> T keep(T value) {
+        return value;
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## Describe the PR

`MethodReturnsInternalArray` now detects indirect returns of internal arrays through local aliases and conditional expressions, including local variables assigned in different branches. These common cases are the main improvements:

- Local alias: `byte[] result = data; return result;`
- Conditional return: `return flag ? data : new byte[0];`
- Branch assignments: `if (flag) { result = data; } else { result = new byte[0]; } return result;`

Each can expose the internal array without copying it. Returning a defensive copy such as `data.clone()` remains unreported. These cases are covered by the rule's regression tests.

The rule traces array-valued return expressions backwards, using `DataflowPass` to resolve local aliases and merged control-flow definitions. For calls, provenance crosses a declaration only when the generic return type is connected to the receiver or a formal parameter through the same type variable. The original `Collections.singletonList(data).get(0)` reproducer is an additional case, alongside `List.of(data, data).get(1)` and generic tuple accessors, without an API-specific escape allowlist.

Calls to exact helpers in the current class are summarized from their return expressions with array arguments bound to formal parameters. A helper returning its argument or an internal field therefore propagates the source, while a helper returning a clone does not. Array `clone()`, `Arrays.copyOf`, and `Arrays.copyOfRange` remain freshness barriers.

The analysis is a may-analysis. It does not model heap mutation, dynamically dispatched helper bodies, or non-generic calls across class boundaries. This bounded propagation avoids treating every call argument as a possible return value.

The regression report for `68276c8b95` has 30 new violations versus `main`, down from 43 in the previous revision. All 30 were inspected: 26 are expected internal-array returns, and four are conservative results. Three involve zero-length static arrays whose declarations are unavailable in the current compilation unit, and one comes from a boolean-controlled helper where both return paths are summarized. No API-specific exceptions were added for these cases.

## Related issues

- Fix #6901

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
