### PR TITLE
[java] Fix #6744: ReturnEmptyCollectionRatherThanNull: Analyze possible null return values

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -109,10 +109,13 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone
     * [#2840](https://github.com/pmd/pmd/issues/2840): \[java] CloseResource: False positive on mocks
+    * [#3880](https://github.com/pmd/pmd/issues/3880): \[java] ReturnEmptyCollectionRatherThanNull: False negative when a null value is assigned to a local that is later returned
     * [#4623](https://github.com/pmd/pmd/issues/4623): \[java] CloseResource: False positive with resource being closed in method
     * [#6435](https://github.com/pmd/pmd/issues/6435): \[java] UnconditionalIfStatement: False negative for negated boolean constant
     * [#6547](https://github.com/pmd/pmd/issues/6547): \[java] NonSerializableClass: Report non-serializable generic element/value types of collections and maps
+    * [#6695](https://github.com/pmd/pmd/issues/6695): \[java] ReturnEmptyCollectionRatherThanNull: False negative when null is returned through a local variable
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer
+    * [#6744](https://github.com/pmd/pmd/issues/6744): \[java] ReturnEmptyCollectionRatherThanNull: False negatives when a returned expression can evaluate to null
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
 * java-multithreading

--- a/pmd-java/pmd-java-exclude-pmd.properties
+++ b/pmd-java/pmd-java-exclude-pmd.properties
@@ -1,0 +1,4 @@
+# The @SuppressWarnings for ReturnEmptyCollectionRatherThanNull in NonSerializableClassRule
+# is only necessary once 7.27.0 analyzes this code. The pmd-main check uses the released PMD,
+# for which it is an UnnecessaryWarningSuppression. Remove this after the 7.27.0 release, see #6941
+net.sourceforge.pmd.lang.java.rule.errorprone.NonSerializableClassRule=UnnecessaryWarningSuppression

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
@@ -214,7 +216,8 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
         return false;
     }
 
-    private Set<String> determinePersistentFields(ASTTypeDeclaration typeDeclaration) {
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull") // null means no serialPersistentFields declaration
+    private @Nullable Set<String> determinePersistentFields(ASTTypeDeclaration typeDeclaration) {
         if (cachedPersistentFieldNames.containsKey(typeDeclaration)) {
             return cachedPersistentFieldNames.get(typeDeclaration);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullRule.java
@@ -1,0 +1,133 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import java.util.Collection;
+import java.util.Map;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ReturnScopeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.AssignmentEntry;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.DataflowResult;
+import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.ReachingDefinitionSet;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+
+/**
+ * For methods that return an array, a {@link Collection} or a {@link Map}, this rule reports
+ * a {@code return} statement when the value it produces has an explicit {@code null} source.
+ *
+ * <p>The analysis is conservative about values it cannot trace: method calls, field reads and
+ * parameters are not treated as {@code null} without an explicit {@code null} source, and the
+ * {@code null} literal is ignored when it appears only in a condition, a switch selector or an array
+ * element rather than in the produced value.
+ *
+ * @since 7.27.0
+ */
+public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulechainRule {
+
+    public ReturnEmptyCollectionRatherThanNullRule() {
+        super(ASTReturnStatement.class);
+    }
+
+    @Override
+    public Object visit(ASTReturnStatement returnStmt, Object data) {
+        ReturnScopeNode target = JavaAstUtils.getReturnTarget(returnStmt);
+        if (!(target instanceof ASTMethodDeclaration)) {
+            return data;
+        }
+
+        ASTMethodDeclaration method = (ASTMethodDeclaration) target;
+        if (!returnsArrayOrCollection(method)) {
+            return data;
+        }
+
+        ASTExpression expression = returnStmt.getExpr();
+        if (expression == null) {
+            return data;
+        }
+
+        if (mayYieldExplicitNull(expression) || reachesExplicitNullThroughLocal(expression)) {
+            asCtx(data).addViolation(returnStmt);
+        }
+        return data;
+    }
+
+    private static boolean returnsArrayOrCollection(ASTMethodDeclaration method) {
+        JTypeMirror returnType = method.getResultTypeNode().getTypeMirror();
+        return returnType.isArray()
+            || TypeTestUtil.isA(Collection.class, returnType)
+            || TypeTestUtil.isA(Map.class, returnType);
+    }
+
+    /**
+     * Returns true when {@code expression} can produce the value {@code null} through an explicit
+     * null source. The condition of a conditional and the selector of a switch are value-selecting
+     * expressions, not produced values, so they are not examined. Local variables are not traced
+     * here; {@link #reachesExplicitNullThroughLocal(ASTExpression)} handles a bare returned local.
+     */
+    private static boolean mayYieldExplicitNull(ASTExpression expression) {
+        if (expression instanceof ASTNullLiteral) {
+            return true;
+        } else if (expression instanceof ASTConditionalExpression) {
+            ASTConditionalExpression conditional = (ASTConditionalExpression) expression;
+            return mayYieldExplicitNull(conditional.getThenBranch())
+                || mayYieldExplicitNull(conditional.getElseBranch());
+        } else if (expression instanceof ASTCastExpression) {
+            return mayYieldExplicitNull(((ASTCastExpression) expression).getOperand());
+        } else if (expression instanceof ASTSwitchExpression) {
+            for (ASTExpression yielded : ((ASTSwitchExpression) expression).getYieldExpressions()) {
+                if (mayYieldExplicitNull(yielded)) {
+                    return true;
+                }
+            }
+            return false;
+        } else if (expression instanceof ASTAssignmentExpression) {
+            ASTAssignmentExpression assignment = (ASTAssignmentExpression) expression;
+            // Only a plain assignment can carry an explicit null reference as its value;
+            // compound assignments are not a direct null source.
+            return !assignment.isCompound()
+                && mayYieldExplicitNull(assignment.getRightOperand());
+        }
+        return false;
+    }
+
+    /**
+     * For a bare {@code return localVar;}, follows the reaching definitions of the local variable
+     * and returns true when any of them has an explicit {@code null} source. This is only applied
+     * to a variable returned directly, never to one nested in a conditional or switch branch, so a
+     * null guard around the value is not reinterpreted. Reaching definitions that the dataflow
+     * analysis cannot fully determine are treated as non-null.
+     */
+    private static boolean reachesExplicitNullThroughLocal(ASTExpression expression) {
+        if (!JavaAstUtils.isReferenceToLocal(expression)) {
+            return false;
+        }
+        ASTVariableAccess access = (ASTVariableAccess) expression;
+        DataflowResult dataflow = DataflowPass.getDataflowResult(access.getRoot());
+        ReachingDefinitionSet reaching = dataflow.getReachingDefinitions(access);
+        if (reaching.isNotFullyKnown()) {
+            return false;
+        }
+        for (AssignmentEntry def : reaching.getReaching()) {
+            ASTExpression rhs = def.getRhsAsExpression();
+            if (rhs != null && mayYieldExplicitNull(rhs)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullRule.java
@@ -35,7 +35,7 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
  * {@code null} literal is ignored when it appears only in a condition, a switch selector or an array
  * element rather than in the produced value.
  *
- * @since 7.27.0
+ * @since 6.37.0 (as XPath) / 7.27.0 (as Java)
  */
 public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulechainRule {
 
@@ -60,7 +60,7 @@ public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulecha
             return data;
         }
 
-        if (mayYieldExplicitNull(expression) || reachesExplicitNullThroughLocal(expression)) {
+        if (mayReturnExplicitNull(expression) || reachesExplicitNullThroughLocal(expression)) {
             asCtx(data).addViolation(returnStmt);
         }
         return data;
@@ -79,18 +79,18 @@ public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulecha
      * expressions, not produced values, so they are not examined. Local variables are not traced
      * here; {@link #reachesExplicitNullThroughLocal(ASTExpression)} handles a bare returned local.
      */
-    private static boolean mayYieldExplicitNull(ASTExpression expression) {
+    private static boolean mayReturnExplicitNull(ASTExpression expression) {
         if (expression instanceof ASTNullLiteral) {
             return true;
         } else if (expression instanceof ASTConditionalExpression) {
             ASTConditionalExpression conditional = (ASTConditionalExpression) expression;
-            return mayYieldExplicitNull(conditional.getThenBranch())
-                || mayYieldExplicitNull(conditional.getElseBranch());
+            return mayReturnExplicitNull(conditional.getThenBranch())
+                || mayReturnExplicitNull(conditional.getElseBranch());
         } else if (expression instanceof ASTCastExpression) {
-            return mayYieldExplicitNull(((ASTCastExpression) expression).getOperand());
+            return mayReturnExplicitNull(((ASTCastExpression) expression).getOperand());
         } else if (expression instanceof ASTSwitchExpression) {
             for (ASTExpression yielded : ((ASTSwitchExpression) expression).getYieldExpressions()) {
-                if (mayYieldExplicitNull(yielded)) {
+                if (mayReturnExplicitNull(yielded)) {
                     return true;
                 }
             }
@@ -100,7 +100,7 @@ public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulecha
             // Only a plain assignment can carry an explicit null reference as its value;
             // compound assignments are not a direct null source.
             return !assignment.isCompound()
-                && mayYieldExplicitNull(assignment.getRightOperand());
+                && mayReturnExplicitNull(assignment.getRightOperand());
         }
         return false;
     }
@@ -124,7 +124,7 @@ public class ReturnEmptyCollectionRatherThanNullRule extends AbstractJavaRulecha
         }
         for (AssignmentEntry def : reaching.getReaching()) {
             ASTExpression rhs = def.getRhsAsExpression();
-            if (rhs != null && mayYieldExplicitNull(rhs)) {
+            if (rhs != null && mayReturnExplicitNull(rhs)) {
                 return true;
             }
         }

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2910,7 +2910,7 @@ public class Foo {
     <rule name="ReturnEmptyCollectionRatherThanNull"
           language="java"
           since="6.37.0"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.ReturnEmptyCollectionRatherThanNullRule"
           message="Return an empty collection rather than 'null'."
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#returnemptycollectionratherthannull">
         <description>
@@ -2921,21 +2921,6 @@ inadvertent NullPointerExceptions.
 See Effective Java, 3rd Edition, Item 54: Return empty collections or arrays instead of null
         </description>
         <priority>1</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//ReturnStatement/NullLiteral
-[ancestor::MethodDeclaration[1]
-    [ArrayType
-     or ClassType[pmd-java:typeIs('java.util.Collection')
-        or pmd-java:typeIs('java.util.Map')]]
-]
-[not(./ancestor::LambdaExpression)]
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 public class Example {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
@@ -271,4 +271,409 @@ public class Example {
 ]]></code>
     </test-code>
 
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: False negative when returning ternary-wrapped null #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+public class ReturnNullAfter {
+    public List<String> getList() {
+        return (true ? null : null);   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Either branch of a conditional may evaluate to null #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+public class ReturnNullAfter {
+    public List<String> getList(boolean cond) {
+        return cond ? null : new ArrayList<>();   // violation: then-branch evaluates to null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null in the else-branch of a conditional #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+public class Foo {
+    public List<String> getList(boolean cond) {
+        return cond ? new ArrayList<>() : null;   // violation: else-branch evaluates to null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null value leaf in a nested conditional #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+public class Foo {
+    public List<String> getList(boolean a, boolean b) {
+        return a ? (b ? null : new ArrayList<>()) : new ArrayList<>();   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null only in the condition of a conditional is not returned #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+import java.util.Collections;
+public class Foo {
+    public List<String> getList(String x, List<String> list) {
+        return x == null ? Collections.emptyList() : list;   // no violation: null is only in the condition
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Conditional with no null value branch #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedList;
+public class Foo {
+    public List<String> getList(boolean cond) {
+        return cond ? new ArrayList<>() : new LinkedList<>();   // no violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Cast of a null literal #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+public class Foo {
+    public List<String> getList() {
+        return (List<String>) null;   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Parentheses around a null literal #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+public class Foo {
+    public List<String> getList() {
+        return ((null));   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null produced by a switch expression arrow branch #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+public class Foo {
+    public List<String> getList(int x) {
+        return switch (x) {
+            case 1 -> null;
+            default -> new ArrayList<>();
+        };
+    }
+}
+]]></code>
+        <source-type>java 17</source-type>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null produced by a switch expression yield statement #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+public class Foo {
+    public List<String> getList(int x) {
+        return switch (x) {
+            case 1 -> {
+                yield null;
+            }
+            default -> new ArrayList<>();
+        };
+    }
+}
+]]></code>
+        <source-type>java 17</source-type>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Switch expression whose value branches are all non-null #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedList;
+public class Foo {
+    public List<String> getList() {
+        Integer selector = null;
+        return switch (selector) {
+            case 1 -> new ArrayList<>();
+            default -> new LinkedList<>();
+        };
+    }
+}
+]]></code>
+        <source-type>java 17</source-type>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Parameter, field and method call results are not null sources #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.*;
+public class Foo {
+    private List<String> field;
+    public List<String> fromParam(List<String> p) {
+        return p;   // no violation: parameter has no explicit null source
+    }
+    public List<String> fromField() {
+        return field;   // no violation: field has no explicit null source
+    }
+    public Map<String, String> fromUnknown() {
+        return Collections.emptyMap();   // no violation: method call result is unknown
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null array element is not a null array reference #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public String[] getArray() {
+        return new String[] { null };   // no violation: the array reference is non-null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null returned from a lambda is not attributed to the enclosing method #3721</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.*;
+import java.util.function.Supplier;
+public class Foo {
+    public List<String> outer() {
+        Supplier<List<String>> s = () -> {
+            return null;   // no violation: this returns from the lambda, not from outer()
+        };
+        return s.get();   // no violation: method call result is unknown
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null returned from an anonymous class method that returns a collection #3721</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.*;
+import java.util.concurrent.Callable;
+public class Foo {
+    public void outer() {
+        Callable<List<String>> c = new Callable<List<String>>() {
+            public List<String> call() {
+                return null;   // violation: call() returns List
+            }
+        };
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Each violating return is reported independently #6744</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.*;
+public class Foo {
+    public List<String> getList(boolean a, boolean b) {
+        if (a) {
+            return a ? null : null;   // violation
+        }
+        return b ? new ArrayList<>() : null;   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Assignment expression whose value is null #6744</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.*;
+public class Foo {
+    public List<String> getList() {
+        List<String> result;
+        return result = null;   // violation: the assigned value is null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null returned from a method whose type is not array, Collection or Map #6744</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public String getString() {
+        return null;   // no violation: String is not array, Collection or Map
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null assigned to a local that is later returned #3880</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>11</expected-linenumbers>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+public class Foo {
+    public boolean flag;
+    public List<String> get() {
+        List<String> res = null;
+        if (flag) {
+            res = new ArrayList<>();
+            res.add("");
+        }
+        return res;   // violation: res can be null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Null array assigned to a local that is returned #6695</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public int[] getNumbers(boolean empty) {
+        if (empty) {
+            int[] result = null;
+            return result;   // violation: result is null
+        }
+        return new int[] { 1, 2, 3 };
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Local initialized to null and returned directly #6695</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.List;
+public class Foo {
+    public List<String> get() {
+        List<String> result = null;
+        return result;   // violation
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Local assigned a null value branch then returned #3880</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+public class Foo {
+    public List<String> get(boolean cond) {
+        List<String> result = cond ? null : new ArrayList<>();
+        return result;   // violation: a reaching definition has a null value branch
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: A local that can be null is returned through a null guard #6695</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+public class Foo {
+    public List<String> get(boolean cond) {
+        List<String> result = null;
+        if (cond) {
+            result = new ArrayList<>();
+        }
+        return result != null ? result : new ArrayList<>();   // no violation: the returned value is guarded
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Local initialized to a non-null value and returned #3880</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
+public class Foo {
+    public List<String> get() {
+        List<String> result = new ArrayList<>();
+        return result;   // no violation: result is non-null
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] ReturnEmptyCollectionRatherThanNull: Local initialized from a method call is an unknown value #3880</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Collections;
+import java.util.List;
+public class Foo {
+    public List<String> get() {
+        List<String> result = Collections.emptyList();
+        return result;   // no violation: the method call result is unknown
+    }
+}
+]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Replaces the syntax-specific XPath change with a Java rule that analyzes the value reaching each return statement.

The rule reports one violation when an array, Collection, or Map return value has an explicit null source through a null literal, a conditional value branch, cast, switch yield, or plain assignment. A bare returned local variable is followed through its reaching definitions and reported when any of them assigns an explicit null source. The null literal is ignored when it appears only in a condition, a switch selector, or an array element. Unknown values (method calls, field reads and parameters) are not treated as null without an explicit null source.

Following local variables also reports `determinePersistentFields` in PMD's own source (NonSerializableClassRule), so that method is converted to return `Optional` to keep the dogfood build clean.

The analysis reports on the return statement and preserves method, lambda, and nested executable scope boundaries.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6744
- Fix #3880
- Fix #6695

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
