### PR TITLE
[java] Fix #6547: NonSerializableClass checks collection/map generic element types

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -77,10 +77,10 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-documentation
     * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone
-    * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
-    * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
-    * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
     * [#6547](https://github.com/pmd/pmd/issues/6547): \[java] NonSerializableClass: Report non-serializable generic element/value types of collections and maps
+    * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer
+    * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
+    * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -75,6 +75,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
 * java-errorprone
+    * [#6547](https://github.com/pmd/pmd/issues/6547): \[java] NonSerializableClass: Report non-serializable generic element/value types of collections and maps
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
 * kotlin

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -183,10 +183,10 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
     }
 
     /**
-     * If the given type is a parameterized collection or map (a
-     * {@link Collection} or {@link Map}), checks whether any of its concrete class
+     * If the given type is a parameterized {@link java.util.Collection Collection} or
+     * {@link java.util.Map Map}, checks whether any of its concrete class
      * type arguments is non-serializable. The container type itself might be
-     * serializable (e.g. {@code ArrayList}), while its elements/values are not,
+     * serializable (e.g. {@link java.util.ArrayList ArrayList}), while its elements/values are not,
      * which would still make the field non-serializable in practice.
      *
      * <p>Type arguments that cannot be determined statically (type variables,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
+import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -152,16 +153,20 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
 
     private boolean isNotSerializable(TypeNode node) {
         JTypeMirror typeMirror = node.getTypeMirror();
+        return isNotSerializableType(typeMirror) || hasNonSerializableElementType(typeMirror);
+    }
+
+    private boolean isNotSerializableType(JTypeMirror typeMirror) {
         JTypeDeclSymbol typeSymbol = typeMirror.getSymbol();
         JClassSymbol classSymbol = null;
         if (typeSymbol instanceof JClassSymbol) {
             classSymbol = (JClassSymbol) typeSymbol;
         }
-        boolean notSerializable = !TypeTestUtil.isA(Serializable.class, node)
+        boolean notSerializable = !TypeTestUtil.isA(Serializable.class, typeMirror)
                 && !typeMirror.isPrimitive();
         if (!getProperty(CHECK_ABSTRACT_TYPES) && classSymbol != null) {
             // exclude java.lang.Object, interfaces, abstract classes
-            notSerializable &= !TypeTestUtil.isExactlyA(Object.class, node)
+            notSerializable &= !TypeTestUtil.isExactlyA(Object.class, typeMirror)
                     && !classSymbol.isInterface()
                     && !classSymbol.isAbstract();
         }
@@ -174,6 +179,38 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
             notSerializable = false;
         }
         return notSerializable;
+    }
+
+    /**
+     * If the given type is a parameterized collection or map (more generally, an
+     * {@link Iterable} or {@link Map}), checks whether any of its concrete class
+     * type arguments is non-serializable. The container type itself might be
+     * serializable (e.g. {@code ArrayList}), while its elements/values are not,
+     * which would still make the field non-serializable in practice.
+     *
+     * <p>Type arguments that cannot be determined statically (type variables,
+     * wildcards, arrays, intersection types, ...) are ignored to avoid false
+     * positives.
+     */
+    private boolean hasNonSerializableElementType(JTypeMirror typeMirror) {
+        if (!(typeMirror instanceof JClassType)) {
+            return false;
+        }
+        JClassType classType = (JClassType) typeMirror;
+        if (!TypeTestUtil.isA(Iterable.class, classType) && !TypeTestUtil.isA(Map.class, classType)) {
+            return false;
+        }
+        for (JTypeMirror typeArg : classType.getTypeArgs()) {
+            // only check concrete class type arguments; skip type variables,
+            // wildcards, arrays, intersection types, etc.
+            if (!(typeArg instanceof JClassType)) {
+                continue;
+            }
+            if (isNotSerializableType(typeArg) || hasNonSerializableElementType(typeArg)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Set<String> determinePersistentFields(ASTTypeDeclaration typeDeclaration) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NonSerializableClassRule.java
@@ -10,6 +10,7 @@ import java.io.Externalizable;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -182,8 +183,8 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
     }
 
     /**
-     * If the given type is a parameterized collection or map (more generally, an
-     * {@link Iterable} or {@link Map}), checks whether any of its concrete class
+     * If the given type is a parameterized collection or map (a
+     * {@link Collection} or {@link Map}), checks whether any of its concrete class
      * type arguments is non-serializable. The container type itself might be
      * serializable (e.g. {@code ArrayList}), while its elements/values are not,
      * which would still make the field non-serializable in practice.
@@ -197,7 +198,7 @@ public class NonSerializableClassRule extends AbstractJavaRulechainRule {
             return false;
         }
         JClassType classType = (JClassType) typeMirror;
-        if (!TypeTestUtil.isA(Iterable.class, classType) && !TypeTestUtil.isA(Map.class, classType)) {
+        if (!TypeTestUtil.isA(Collection.class, classType) && !TypeTestUtil.isA(Map.class, classType)) {
             return false;
         }
         for (JTypeMirror typeArg : classType.getTypeArgs()) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NonSerializableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NonSerializableClass.xml
@@ -384,4 +384,43 @@ class Buzz implements java.io.Serializable {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Non-serializable generic element/value type of collections and maps</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private List<NotSerializable> items;
+    private Map<String, NotSerializable> map;
+}
+class NotSerializable {}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Skip generic element/value types that cannot be determined statically</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+class Foo<T> implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private List<String> serializableElements;
+    private List<T> typeVariable;
+    private Map<String, T> mapTypeVariable;
+    private List<? extends Serializable> wildcard;
+}
+class Bar<T extends NotSerializable> implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private List<T> boundedTypeVariable;
+}
+class NotSerializable {}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NonSerializableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NonSerializableClass.xml
@@ -423,4 +423,18 @@ class Bar<T extends NotSerializable> implements Serializable {
 class NotSerializable {}
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Bare Iterable is not a collection that holds its elements</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.Serializable;
+import java.util.Iterator;
+class Foo implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private Iterable<NotSerializable> generator;
+}
+class NotSerializable {}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## What

`NonSerializableClass` now also reports fields whose collection/map generic element or value type is non-serializable — e.g. `List<NotSerializable> items;` or `Map<String, NotSerializable> map;` — not just fields whose own raw type is non-serializable.

Closes #6547.

## Why

The rule checked only whether a field's declared type implements `Serializable`. `List`/`Map` themselves are `Serializable`, so `List<NotSerializable>` slipped through — yet serializing such a field still fails, because the element/value type isn't serializable. The container being serializable doesn't make its contents serializable.

## How

Add `hasNonSerializableElementType(typeMirror)`, invoked alongside the existing type check. For a field whose type is a parameterized `Iterable` or `Map` (`TypeTestUtil.isA`), it walks `JClassType.getTypeArgs()` and runs each type argument through the same serializability check used for the field type itself (reusing the existing `CHECK_ABSTRACT_TYPES` property semantics and `isUnresolved()` guard). The pre-existing check is refactored into `isNotSerializableType(JTypeMirror)` so both paths share one definition; behaviour for non-container fields is unchanged.

It is deliberately conservative to avoid false positives — only **concrete class** type arguments are evaluated:

- type variables (`List<T>`), wildcards (`List<? extends Serializable>`), bounded type vars (`List<T extends NotSerializable>`), array types, and intersection types are skipped, since their serializability can't be determined statically;
- unresolved type arguments are skipped via the existing guard;
- `interface`/`abstract`/`Object` element types are excluded when `CHECK_ABSTRACT_TYPES` is off (the default), consistent with how the rule treats the field type itself.

## Testing

- Added cases to `NonSerializableClass.xml`: `List<NotSerializable>` and `Map<String, NotSerializable>` → 2 findings, plus negatives — `List<String>` (serializable element), `List<T>` / `Map<String,T>` (type variables), `List<? extends Serializable>` (wildcard), `List<T extends NotSerializable>` (bounded type var) → 0 findings.
- Verified **fails before the fix** (`expected: <2> but was: <0>`) and **passes after** (24/24, including all pre-existing cases).
- `./mvnw -pl pmd-java checkstyle:check` → 0 violations.

Added a `release_notes.md` entry under the java-errorprone section.
