### PR TITLE
chore: Remove unnecessary casts

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -74,7 +74,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
         }
 
         public int getComplexityAverage() {
-            return (double) methodCount == 0 ? 1 : (int) Math.rint((double) decisionPoints / (double) methodCount);
+            return methodCount == 0 ? 1 : (int) Math.rint((double) decisionPoints / methodCount);
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -168,14 +168,14 @@ public abstract class AbstractPropertySource implements PropertySource {
         Map<String, String> propertiesWithValues = new HashMap<>();
         propertyDescriptors.forEach(propertyDescriptor -> {
             Object value = propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
-            @SuppressWarnings({"unchecked", "rawtypes"})
+            @SuppressWarnings({"unchecked", "rawtypes", "PMD.UnnecessaryCast"})
             String valueString = ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
             propertiesWithValues.put(propertyDescriptor.name(), valueString);
         });
         Map<String, String> thatPropertiesWithValues = new HashMap<>();
         that.propertyDescriptors.forEach(propertyDescriptor -> {
             Object value = that.propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
-            @SuppressWarnings({"unchecked", "rawtypes"})
+            @SuppressWarnings({"unchecked", "rawtypes", "PMD.UnnecessaryCast"})
             String valueString = ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
             thatPropertiesWithValues.put(propertyDescriptor.name(), valueString);
         });

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -159,12 +159,15 @@ public abstract class AbstractPropertySource implements PropertySource {
         }
         AbstractPropertySource that = (AbstractPropertySource) o;
 
-        if (!Objects.equals(propertyDescriptors, that.propertyDescriptors)) {
-            return false;
-        }
+        return Objects.equals(propertyDescriptors, that.propertyDescriptors)
+                && Objects.equals(toStringMap(), that.toStringMap());
+    }
 
-        // Convert the values to strings for comparisons. This is needed at least for RegexProperties,
-        // as java.util.regex.Pattern doesn't implement equals().
+    /*
+     * Convert the values to strings for comparisons. This is needed at least for RegexProperties,
+     * as java.util.regex.Pattern doesn't implement equals().
+     */
+    private Map<String, String> toStringMap() {
         Map<String, String> propertiesWithValues = new HashMap<>();
         propertyDescriptors.forEach(propertyDescriptor -> {
             Object value = propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
@@ -172,14 +175,7 @@ public abstract class AbstractPropertySource implements PropertySource {
             String valueString = ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
             propertiesWithValues.put(propertyDescriptor.name(), valueString);
         });
-        Map<String, String> thatPropertiesWithValues = new HashMap<>();
-        that.propertyDescriptors.forEach(propertyDescriptor -> {
-            Object value = that.propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
-            @SuppressWarnings({"unchecked", "rawtypes", "PMD.UnnecessaryCast"})
-            String valueString = ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
-            thatPropertiesWithValues.put(propertyDescriptor.name(), valueString);
-        });
-        return Objects.equals(propertiesWithValues, thatPropertiesWithValues);
+        return propertiesWithValues;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -79,7 +79,7 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
         if (isIntegral) {
             is64bits = lastChar == 'l' || lastChar == 'L';
             longValue = parseIntegralValue(image);
-            doubleValue = (double) longValue;
+            doubleValue = longValue;
         } else {
             is64bits = !(lastChar == 'f' || lastChar == 'F');
             doubleValue = Double.parseDouble(StringUtils.remove(image.toString(), '_'));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
@@ -521,7 +521,7 @@ public final class JavaResolvers {
             return isAccessibleIn(nestRoot, accessPackageName, sym, isSubtype(access, sym.getEnclosingClass()));
         };
 
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "PMD.UnnecessaryCast"})
         ShadowChainBuilder<S, ?>.ResolverBuilder builder = (ShadowChainBuilder<S, ?>.ResolverBuilder) classes.new ResolverBuilder();
 
         for (JClassType next : DIRECT_STRICT_SUPERTYPES.iterable(c)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -2318,7 +2318,7 @@ public final class TypeOps {
     public static boolean isContextDependent(JExecutableSymbol symbol) {
         if (symbol.isGeneric() || symbol.getEnclosingClass().isGeneric()) {
             if (symbol instanceof JMethodSymbol) {
-                JTypeMirror returnType = ((JMethodSymbol) symbol).getReturnType(EMPTY);
+                JTypeMirror returnType = symbol.getReturnType(EMPTY);
                 return mentionsAny(returnType, symbol.getTypeParameters())
                     || mentionsAny(returnType, symbol.getEnclosingClass().getTypeParameters());
             }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehension.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehension.java
@@ -17,7 +17,7 @@ public final class ASTArrayComprehension extends AbstractEcmascriptNode<ArrayCom
     }
 
     public EcmascriptNode<?> getResult() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public int getNumArrayComprehensionLoops() {
@@ -33,6 +33,6 @@ public final class ASTArrayComprehension extends AbstractEcmascriptNode<ArrayCom
     }
 
     public EcmascriptNode<?> getFilter() {
-        return (EcmascriptNode<?>) getChild(getNumChildren() - 1);
+        return getChild(getNumChildren() - 1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehensionLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehensionLoop.java
@@ -17,10 +17,10 @@ public final class ASTArrayComprehensionLoop extends AbstractEcmascriptNode<Arra
     }
 
     public EcmascriptNode<?> getIterator() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getIteratedObject() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTCatchClause.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTCatchClause.java
@@ -25,7 +25,7 @@ public final class ASTCatchClause extends AbstractEcmascriptNode<CatchClause> {
     }
 
     public EcmascriptNode<?> getCatchCondition() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 
     public ASTBlock getBlock() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTConditionalExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTConditionalExpression.java
@@ -17,14 +17,14 @@ public final class ASTConditionalExpression extends AbstractEcmascriptNode<Condi
     }
 
     public EcmascriptNode<?> getTestExpression() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getTrueExpression() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 
     public EcmascriptNode<?> getFalseExpression() {
-        return (EcmascriptNode<?>) getChild(2);
+        return getChild(2);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTDoLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTDoLoop.java
@@ -17,10 +17,10 @@ public final class ASTDoLoop extends AbstractEcmascriptNode<DoLoop> {
     }
 
     public EcmascriptNode<?> getBody() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getCondition() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTElementGet.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTElementGet.java
@@ -18,14 +18,14 @@ public final class ASTElementGet extends AbstractEcmascriptNode<ElementGet> {
 
     public EcmascriptNode<?> getTarget() {
         if (getNumChildren() > 0) {
-            return (EcmascriptNode<?>) getChild(0);
+            return getChild(0);
         }
         return null;
     }
 
     public EcmascriptNode<?> getElement() {
         if (getNumChildren() > 1) {
-            return (EcmascriptNode<?>) getChild(1);
+            return getChild(1);
         }
         return null;
     }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoop.java
@@ -17,15 +17,15 @@ public final class ASTForInLoop extends AbstractEcmascriptNode<ForInLoop> {
     }
 
     public EcmascriptNode<?> getIterator() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getIteratedObject() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 
     public EcmascriptNode<?> getBody() {
-        return (EcmascriptNode<?>) getChild(2);
+        return getChild(2);
     }
 
     public boolean isForEach() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForLoop.java
@@ -17,18 +17,18 @@ public final class ASTForLoop extends AbstractEcmascriptNode<ForLoop> {
     }
 
     public EcmascriptNode<?> getInitializer() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getCondition() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 
     public EcmascriptNode<?> getIncrement() {
-        return (EcmascriptNode<?>) getChild(2);
+        return getChild(2);
     }
 
     public EcmascriptNode<?> getBody() {
-        return (EcmascriptNode<?>) getChild(3);
+        return getChild(3);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNode.java
@@ -32,11 +32,11 @@ public final class ASTFunctionNode extends AbstractEcmascriptNode<FunctionNode> 
         if (node.getFunctionName() != null) {
             paramIndex = index + 1;
         }
-        return (EcmascriptNode<?>) getChild(paramIndex);
+        return getChild(paramIndex);
     }
 
     public EcmascriptNode<?> getBody() {
-        return (EcmascriptNode<?>) getChild(getNumChildren() - 1);
+        return getChild(getNumChildren() - 1);
     }
 
     public boolean isClosure() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTIfStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTIfStatement.java
@@ -21,14 +21,14 @@ public final class ASTIfStatement extends AbstractEcmascriptNode<IfStatement> {
     }
 
     public EcmascriptNode<?> getCondition() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getThen() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 
     public EcmascriptNode<?> getElse() {
-        return (EcmascriptNode<?>) getChild(2);
+        return getChild(2);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabeledStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabeledStatement.java
@@ -25,6 +25,6 @@ public final class ASTLabeledStatement extends AbstractEcmascriptNode<LabeledSta
     }
 
     public EcmascriptNode<?> getStatement() {
-        return (EcmascriptNode<?>) getChild(getNumChildren() - 1);
+        return getChild(getNumChildren() - 1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLetNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLetNode.java
@@ -26,7 +26,7 @@ public final class ASTLetNode extends AbstractEcmascriptNode<LetNode> {
 
     public EcmascriptNode<?> getBody() {
         if (hasBody()) {
-            return (EcmascriptNode<?>) getChild(getNumChildren() - 1);
+            return getChild(getNumChildren() - 1);
         } else {
             return null;
         }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchCase.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchCase.java
@@ -22,7 +22,7 @@ public final class ASTSwitchCase extends AbstractEcmascriptNode<SwitchCase> {
 
     public EcmascriptNode<?> getExpression() {
         if (!isDefault()) {
-            return (EcmascriptNode<?>) getChild(0);
+            return getChild(0);
         } else {
             return null;
         }
@@ -37,6 +37,6 @@ public final class ASTSwitchCase extends AbstractEcmascriptNode<SwitchCase> {
         if (!isDefault()) {
             statementIndex++;
         }
-        return (EcmascriptNode<?>) getChild(statementIndex);
+        return getChild(statementIndex);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchStatement.java
@@ -17,7 +17,7 @@ public final class ASTSwitchStatement extends AbstractEcmascriptNode<SwitchState
     }
 
     public EcmascriptNode<?> getExpression() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public int getNumCases() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatement.java
@@ -17,7 +17,7 @@ public final class ASTTryStatement extends AbstractEcmascriptNode<TryStatement> 
     }
 
     public EcmascriptNode<?> getTryBlock() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public boolean hasCatch() {
@@ -43,6 +43,6 @@ public final class ASTTryStatement extends AbstractEcmascriptNode<TryStatement> 
         if (!hasFinally()) {
             return null;
         }
-        return (EcmascriptNode<?>) getChild(getNumChildren() - 1);
+        return getChild(getNumChildren() - 1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUnaryExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUnaryExpression.java
@@ -19,7 +19,7 @@ public final class ASTUnaryExpression extends AbstractEcmascriptNode<UnaryExpres
     }
 
     public EcmascriptNode<?> getOperand() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public boolean isPrefix() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableInitializer.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableInitializer.java
@@ -17,12 +17,12 @@ public final class ASTVariableInitializer extends AbstractEcmascriptNode<Variabl
     }
 
     public EcmascriptNode<?> getTarget() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getInitializer() {
         if (getNumChildren() > 0) {
-            return (EcmascriptNode<?>) getChild(1);
+            return getChild(1);
         } else {
             return null;
         }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWhileLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWhileLoop.java
@@ -17,10 +17,10 @@ public final class ASTWhileLoop extends AbstractEcmascriptNode<WhileLoop> {
     }
 
     public EcmascriptNode<?> getCondition() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getBody() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWithStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWithStatement.java
@@ -17,10 +17,10 @@ public final class ASTWithStatement extends AbstractEcmascriptNode<WithStatement
     }
 
     public EcmascriptNode<?> getExpression() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public EcmascriptNode<?> getStatement() {
-        return (EcmascriptNode<?>) getChild(1);
+        return getChild(1);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlExpression.java
@@ -17,7 +17,7 @@ public final class ASTXmlExpression extends AbstractEcmascriptNode<XmlExpression
     }
 
     public EcmascriptNode<?> getExpression() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public boolean isXmlAttribute() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractFunctionCallNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractFunctionCallNode.java
@@ -13,7 +13,7 @@ abstract class AbstractFunctionCallNode<T extends FunctionCall> extends Abstract
     }
 
     public EcmascriptNode<?> getTarget() {
-        return (EcmascriptNode<?>) getChild(0);
+        return getChild(0);
     }
 
     public int getNumArguments() {
@@ -21,7 +21,7 @@ abstract class AbstractFunctionCallNode<T extends FunctionCall> extends Abstract
     }
 
     public EcmascriptNode<?> getArgument(int index) {
-        return (EcmascriptNode<?>) getChild(index + 1);
+        return getChild(index + 1);
     }
 
     public boolean hasArguments() {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -79,7 +79,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
         }
 
         public int getComplexityAverage() {
-            return (double) methodCount == 0 ? 1 : (int) Math.rint((double) decisionPoints / (double) methodCount);
+            return methodCount == 0 ? 1 : (int) Math.rint((double) decisionPoints / methodCount);
         }
     }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityVisitor.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityVisitor.java
@@ -44,7 +44,7 @@ class NPathComplexityVisitor extends PlsqlVisitorBase<Object, Object> {
         PLSQLNode n;
 
         for (int i = 0; i < node.getNumChildren(); i++) {
-            n = (PLSQLNode) node.getChild(i);
+            n = node.getChild(i);
             npath *= (Integer) n.acceptVisitor(this, data);
         }
 
@@ -244,7 +244,7 @@ class NPathComplexityVisitor extends PlsqlVisitorBase<Object, Object> {
         int npath = 1;
         int caseRange = 0;
         for (int i = 0; i < node.getNumChildren(); i++) {
-            PLSQLNode n = (PLSQLNode) node.getChild(i);
+            PLSQLNode n = node.getChild(i);
 
             // Fall-through labels count as 1 for complexity
             Integer complexity = (Integer) n.acceptVisitor(this, data);
@@ -264,7 +264,7 @@ class NPathComplexityVisitor extends PlsqlVisitorBase<Object, Object> {
         int npath = 0;
         int caseRange = 0;
         for (int i = 0; i < node.getNumChildren(); i++) {
-            PLSQLNode n = (PLSQLNode) node.getChild(i);
+            PLSQLNode n = node.getChild(i);
 
             // Fall-through labels count as 1 for complexity
             Integer complexity = (Integer) n.acceptVisitor(this, data);

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ScopeAndDeclarationFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ScopeAndDeclarationFinder.java
@@ -148,7 +148,7 @@ public class ScopeAndDeclarationFinder extends PlsqlVisitorBase<Object, Object> 
     @Override
     public Object visit(ASTPackageSpecification node, Object data) {
         createClassScope(node);
-        Scope s = ((PLSQLNode) node.getParent()).getScope();
+        Scope s = node.getParent().getScope();
         s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;
@@ -157,7 +157,7 @@ public class ScopeAndDeclarationFinder extends PlsqlVisitorBase<Object, Object> 
     @Override
     public Object visit(ASTPackageBody node, Object data) {
         createClassScope(node);
-        Scope s = ((PLSQLNode) node.getParent()).getScope();
+        Scope s = node.getParent().getScope();
         s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;
@@ -166,7 +166,7 @@ public class ScopeAndDeclarationFinder extends PlsqlVisitorBase<Object, Object> 
     @Override
     public Object visit(ASTTypeSpecification node, Object data) {
         createClassScope(node);
-        Scope s = ((PLSQLNode) node.getParent()).getScope();
+        Scope s = node.getParent().getScope();
         s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;
@@ -175,7 +175,7 @@ public class ScopeAndDeclarationFinder extends PlsqlVisitorBase<Object, Object> 
     @Override
     public Object visit(ASTTriggerUnit node, Object data) {
         createClassScope(node);
-        Scope s = ((PLSQLNode) node.getParent()).getScope();
+        Scope s = node.getParent().getScope();
         s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;


### PR DESCRIPTION
## Describe the PR

This PR removes all unnecessary casts from PMD.

In 2 cases, I had to add "PMD.UnnecessaryCast" to an already existing @<!-- -->SuppressWarning(). Currently, this triggers the "UnnecessarySuppression" rule, so we can only merge this at the same time we merge the corresponding build-tools update.

## Related issues

- See #6943 
- See https://github.com/pmd/build-tools/pull/184

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

