### PR TITLE
[java] Fix #6393: UnusedPrivateMethod FP on overloaded methods when overload resolution fails

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -64,6 +64,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-bestpractices
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
+    * [#6393](https://github.com/pmd/pmd/issues/6393): \[java] UnusedPrivateMethod: False positive with overloaded private methods called with values returned from methods of an unresolved type
 * java-codestyle
     * [#6651](https://github.com/pmd/pmd/issues/6651): \[java] UnnecessaryImport false-positive when Javadoc {@link} references an array type
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -64,7 +64,11 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             .forEach(ref -> {
                 OverloadSelectionResult selectionInfo = ref.getOverloadSelectionInfo();
                 JExecutableSymbol calledMethod = selectionInfo.getMethodType().getSymbol();
-                if (calledMethod.isUnresolved()) {
+                if (calledMethod.isUnresolved() || selectionInfo.isFailed()) {
+                    // When overload resolution failed, the selected symbol is an
+                    // arbitrary fallback and we cannot trust which overload was
+                    // actually called. Treat it like an unresolved call to avoid
+                    // false positives on the other overloads.
                     handleUnresolvedCall(ref, selectionInfo, candidates);
                     return;
                 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -2813,4 +2813,29 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6393 FP with overloaded private method called with value returned from a method of an unresolved type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface UnusedPrivateMethodFalsePositivePrivateMethod {
+
+    default String publicMethod(final Thing l) {
+        return transform(l.getLong());
+    }
+
+    default String publicMethod2(final Thing l) {
+        return transform(l.getString());
+    }
+
+    private String transform(final String l) {
+        return l;
+    }
+
+    private String transform(final Long l) {
+        return l.toString();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## What
Suppress the `UnusedPrivateMethod` false positive on an overloaded private method when overload resolution for a call to it fails (e.g. when an argument type is not on the auxclasspath).

## Why
When overload resolution fails, PMD falls back to an arbitrary candidate symbol. The rule treated that fallback as the real selection and marked the other overloads as unused. Closes #6393.

## Root cause
`UnusedPrivateMethodRule` only special-cased `calledMethod.isUnresolved()`. On a failed overload resolution (`selectionInfo.isFailed()`, with `calledSymbol.isUnresolved() == false`) the rule kept the fallback symbol as the chosen overload, so the real overload(s) were reported as unused.

## How
Treat a failed selection like an unresolved call:

```java
if (calledMethod.isUnresolved() || selectionInfo.isFailed()) {
    handleUnresolvedCall(ref, selectionInfo, candidates);
    return;
}
```

This reuses the existing whitelist path — `handleUnresolvedCall` already guards cross-class receivers via `receiverMayBeInstanceOfThisClass` — so no new abstraction or framework-level change is needed.

## Testing
- New case in `UnusedPrivateMethod.xml` reproducing the issue (expected 0 problems).
- Verified it fails on the old code (`UnusedPrivateMethod: 'transform(Long)'`) and passes after the fix.
- `./mvnw -pl pmd-java -am test -Dtest=UnusedPrivateMethodTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false` → `Tests run: 111, Failures: 0, Errors: 0` (no regression; 2 pre-existing skipped).

## Notes
- This trades a possible false negative for the existing false positive, matching the rule's existing stance for `isUnresolved()` calls: when in doubt, do not report. As @oowekyala noted on the issue, the cleanest user-side fix is a correct auxclasspath; this change keeps the rule safe when that configuration is incomplete.

Fixes #6393
