### PR TITLE
[java] Fix #6270: CommentSize skips file header comments

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -74,12 +74,12 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6714](https://github.com/pmd/pmd/issues/6714): \[java] Rename UseUtilityClass to InstantiableUtilityClass
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
+* java-documentation
+    * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
-* java-documentation
-    * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -77,6 +77,8 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-errorprone
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
+* java-documentation
+    * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * kotlin
     * [#6795](https://github.com/pmd/pmd/issues/6795): \[kotlin] Add kotlin-type-mapper infrastructure
     * [#6891](https://github.com/pmd/pmd/issues/6891): \[kotlin] AnnotationFqnAnnotator: @<!-- -->TypeName not set on UnescapedAnnotation nodes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -8,8 +8,10 @@ import static net.sourceforge.pmd.properties.NumericConstraints.positive;
 
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.document.TextPos2d;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.JavaComment;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -42,7 +44,17 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTCompilationUnit cUnit, Object data) {
 
+        // Comments that make up the file header (e.g. a license/copyright header)
+        // appear before the first declaration and are not subject to the limits,
+        // see #6270.
+        TextPos2d firstCodePos = firstCodeTokenStart(cUnit);
+
         for (JavaComment comment : cUnit.getComments()) {
+            if (firstCodePos != null
+                && comment.getReportLocation().getEndPos().compareTo(firstCodePos) <= 0) {
+                continue;
+            }
+
             if (hasTooManyLines(comment)) {
                 asCtx(data).addViolationWithPosition(
                     comment.getToken(),
@@ -55,6 +67,19 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
         }
 
         return null;
+    }
+
+    /**
+     * Start position of the first code token of the compilation unit, or {@code null}
+     * if the file has no declaration. Any comment ending before this position is
+     * considered part of the file header.
+     */
+    private static TextPos2d firstCodeTokenStart(ASTCompilationUnit cUnit) {
+        if (cUnit.getNumChildren() == 0) {
+            return null;
+        }
+        JavaNode firstDecl = cUnit.getChild(0);
+        return firstDecl.getFirstToken().getReportLocation().getStartPos();
     }
 
     private static boolean hasRealText(Chars line) {

--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -59,22 +59,17 @@ Determines whether the dimensions of non-header comments found are within the sp
         <priority>3</priority>
         <example>
 <![CDATA[
-/**
-*
-*   too many lines!
-*
-*
-*
-*
-*
-*
-*
-*
-*
-*
-*
-*
-*/
+public class Foo {
+    /*
+     * 1
+     * 2
+     * 3
+     * 4
+     * 5
+     * 6
+     * 7
+     */
+}
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentSize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentSize.xml
@@ -8,8 +8,9 @@
         <description>Too many lines</description>
         <rule-property name="maxLines">5</rule-property>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>1</expected-linenumbers>
+        <expected-linenumbers>2</expected-linenumbers>
         <code><![CDATA[
+package foo;
 /* 1
  * 2
  * 3
@@ -32,8 +33,9 @@ public class Foo {
         <description>#4369 Line too long</description>
         <rule-property name="maxLineLength">5</rule-property>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
+package foo;
 //
 
 
@@ -91,6 +93,26 @@ public class Foo {
         comment
         */
     }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#6270 File header comments are not checked</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/*
+ * This is a long license header comment
+ * that exceeds the default maxLines limit.
+ * It must not be reported since header
+ * comments are ignored by this rule.
+ * line 5
+ * line 6
+ * line 7
+ * line 8
+ */
+package foo;
+
+public class Foo {
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## What
`CommentSize` now skips file header comments — comments that appear before the first declaration (package / import / type / module) of the compilation unit — so that license/copyright headers are no longer flagged.

## Why
The rule documentation states it checks "non-header comments", but the implementation iterated over *every* comment, producing false positives for typical license headers (e.g. ASLv2, which exceeds the default 6-line limit). Closes #6270.

## Root cause
`CommentSizeRule.visit` looped over `cUnit.getComments()` without distinguishing header comments, contradicting its own documented scope.

## How
Determine the start position of the first code token (the first package/import/type/module declaration) and skip any comment whose end position is at or before it. This uses the standard Java-ecosystem meaning of "file header" (the comments preceding the first declaration) and matches the issue's ASLv2-before-package example; it also holds for default-package files (no package — the header sits before the first type). Empty files keep the old behavior (nothing skipped).

## Testing
- New case `#6270 File header comments are not checked`: an 8-line header before `package` (default `maxLines=6`), expected 0 problems.
- Verified it fails on the old code (`CommentSize: Too many lines`) and passes after the fix.
- `./mvnw -pl pmd-java -am test -Dtest=CommentSizeTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false` → `Tests run: 5, Failures: 0, Errors: 0`.
- Two existing cases whose sample comment sat at the top of a default-package file (now correctly a header) were adjusted to add `package foo;` so the comment remains a non-header, with expected line numbers shifted accordingly.
- Also fixed the bad documentation example flagged in the issue (the old example was a 1-non-empty-line header that would never trigger the rule).

## Notes
- Behavior change: comments before the first declaration are no longer checked — this is exactly the correction requested, and it is called out in the release note.

Fixes #6270
