### PR TITLE
[java] Fix #6611: UnnecessaryVarargsArrayCreation ignores overload ambiguity

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -84,6 +84,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
     * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
+    * [#6611](https://github.com/pmd/pmd/issues/6611): \[java] UnnecessaryVarargsArrayCreation: false positive when removing the array creates overload ambiguity
 * java-codestyle
     * [#6958](https://github.com/pmd/pmd/issues/6958): \[java] BooleanGetMethodName should have the option to treat boolean wrapper type differently
     * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
@@ -4,15 +4,25 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
 import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
+import net.sourceforge.pmd.lang.java.types.JArrayType;
+import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+import net.sourceforge.pmd.lang.java.types.Substitution;
+import net.sourceforge.pmd.lang.java.types.TypeOps;
 
 public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRule {
 
@@ -44,10 +54,152 @@ public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRu
             if (array.getTypeMirror().equals(lastFormal)) {
                 // If type not equal, then it would not actually be equivalent to remove the array creation.
                 // That case may be caught by ConfusingArgumentToVarargsMethod
+                if (isRequiredForOverloadResolution(info, (ASTArgumentList) parent, array)) {
+                    // Removing the explicit array would make another overload applicable,
+                    // i.e. the call would become ambiguous or select a different overload.
+                    // The explicit array is required, do not report. See #6611.
+                    return null;
+                }
                 asCtx(data).addViolation(array);
             }
         }
 
         return null;
+    }
+
+    /**
+     * Returns true if removing the explicit array creation (i.e. expanding its
+     * initializer elements into the varargs parameter) would make another
+     * overload of the called executable applicable. In that case the explicit
+     * array is required for overload resolution: removing it would either
+     * change the selected overload or make the call ambiguous (compile error),
+     * so the rule must not flag it.
+     *
+     * <p>Competing constructors come from the selected executable's own class
+     * (exhaustive, since constructors are not inherited). Competing methods are
+     * streamed from the declaring type, which includes overloads inherited from
+     * supertypes, so any same-named overload in the class hierarchy is considered.
+     *
+     * <p>The applicability check is a conservative approximation of
+     * JLS &sect;15.12.2.2-15.12.2.4: it is based on subtyping (reference and
+     * primitive widening) and treats a generic parameter type by its upper
+     * bound, which may consider a generic overload applicable that would
+     * otherwise need inference to confirm. This may cause a few false-negatives,
+     * but no false-positives.
+     */
+    private static boolean isRequiredForOverloadResolution(OverloadSelectionResult info,
+                                                           ASTArgumentList argList,
+                                                           ASTArrayAllocation array) {
+        JExecutableSymbol selected = info.getMethodType().getSymbol();
+        if (selected == null) {
+            return false;
+        }
+        JClassSymbol owner = selected.getEnclosingClass();
+
+        JTypeMirror componentType = ((JArrayType) array.getTypeMirror()).getComponentType();
+        if (TypeOps.isUnresolved(componentType)) {
+            // Cannot reason reliably about the expanded argument types.
+            return false;
+        }
+
+        List<JTypeMirror> expandedArgTypes = expandedArgumentTypes(argList, componentType, array);
+
+        List<? extends JExecutableSymbol> siblings =
+                selected instanceof JConstructorSymbol
+                        ? owner.getConstructors()
+                        : methodsNamed(info.getMethodType().getDeclaringType(), selected.getSimpleName());
+
+        for (JExecutableSymbol sibling : siblings) {
+            if (sibling == selected) { // NOPMD CompareObjectsWithEquals - skip the candidate itself by identity
+                continue;
+            }
+            if (isApplicableTo(sibling, expandedArgTypes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<JTypeMirror> expandedArgumentTypes(ASTArgumentList argList,
+                                                           JTypeMirror componentType,
+                                                           ASTArrayAllocation array) {
+        // The array allocation is the last argument; leading arguments are unchanged.
+        int leadingCount = argList.getNumChildren() - 1;
+        int elementCount = array.getArrayInitializer().getNumChildren();
+        List<JTypeMirror> types = new ArrayList<>(leadingCount + elementCount);
+        for (int i = 0; i < leadingCount; i++) {
+            types.add(argList.get(i).getTypeMirror());
+        }
+        for (int i = 0; i < elementCount; i++) {
+            types.add(componentType);
+        }
+        return types;
+    }
+
+    /**
+     * Returns the symbols of all methods named {@code name} that are declared
+     * in, or inherited by, {@code ownerType}. Inherited overloads are included
+     * so that a competing overload declared in a supertype is considered.
+     */
+    private static List<JExecutableSymbol> methodsNamed(JTypeMirror ownerType, String name) {
+        return ownerType.streamMethods(m -> name.equals(m.getSimpleName()))
+                        .map(JMethodSig::getSymbol)
+                        .collect(Collectors.toList());
+    }
+
+    /**
+     * Checks whether the given executable is applicable to the expanded argument
+     * list in either fixed-arity or variable-arity invocation mode.
+     */
+    private static boolean isApplicableTo(JExecutableSymbol exec, List<JTypeMirror> argTypes) {
+        List<JTypeMirror> formals = exec.getFormalParameterTypes(Substitution.EMPTY);
+        int paramCount = formals.size();
+        int argCount = argTypes.size();
+
+        // Fixed-arity applicability.
+        if (argCount == paramCount && allConvertible(argTypes, formals, paramCount)) {
+            return true;
+        }
+
+        // Variable-arity applicability.
+        if (exec.isVarargs() && paramCount > 0 && argCount >= paramCount - 1) {
+            JTypeMirror lastFormal = formals.get(paramCount - 1);
+            if (!(lastFormal instanceof JArrayType)) {
+                return false; // defensive: a varargs parameter has an array type
+            }
+            JTypeMirror varargsComponent = ((JArrayType) lastFormal).getComponentType();
+            if (!allConvertible(argTypes, formals, paramCount - 1)) {
+                return false;
+            }
+            for (int i = paramCount - 1; i < argCount; i++) {
+                if (!convertible(argTypes.get(i), varargsComponent)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean allConvertible(List<JTypeMirror> argTypes, List<JTypeMirror> paramTypes, int count) {
+        for (int i = 0; i < count; i++) {
+            if (!convertible(argTypes.get(i), paramTypes.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean convertible(JTypeMirror argType, JTypeMirror paramType) {
+        // Treat a generic parameter type by its upper bound, so a generic overload
+        // is considered applicable whenever the argument matches the bound.
+        while (paramType instanceof JTypeVar) {
+            JTypeMirror bound = ((JTypeVar) paramType).getUpperBound();
+            if (bound == paramType) { // NOPMD CompareObjectsWithEquals - self-referential type var guard
+                break;
+            }
+            paramType = bound;
+        }
+        return TypeOps.isConvertible(argType, paramType).somehow();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
@@ -21,9 +21,9 @@ import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
-import net.sourceforge.pmd.reporting.RuleContext;
 import net.sourceforge.pmd.lang.java.types.Substitution;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 public class UnnecessaryVarargsArrayCreationRule extends AbstractJavaRulechainRule {
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnnecessaryVarargsArrayCreation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnnecessaryVarargsArrayCreation.xml
@@ -71,4 +71,76 @@
             ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Array is required: removing it creates constructor overload ambiguity</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Demo {
+                Demo(String file, String... lines) {}
+                Demo(String... args) {}
+
+                {
+                    // Removing the explicit array would yield new Demo("x", "a", "b"),
+                    // which is ambiguous between the two constructors.
+                    new Demo("x", new String[]{"a", "b"});
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Array is required: removing it creates method overload ambiguity</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                static void foo(String first, String... more) {}
+                static void foo(String... all) {}
+
+                static {
+                    // Removing the explicit array would yield foo("x", "a", "b"),
+                    // which is ambiguous between the two overloads.
+                    foo("x", new String[]{"a", "b"});
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Array is required: competing method overload is inherited from a supertype</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Base {
+                void foo(String... all) {}
+            }
+
+            public class Sub extends Base {
+                void foo(String first, String... more) {}
+
+                {
+                    Sub s = new Sub();
+                    // Removing the explicit array would yield s.foo("x", "a", "b"),
+                    // which is ambiguous between Sub.foo(String, String...) and the inherited Base.foo(String...).
+                    s.foo("x", new String[]{"a", "b"});
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No competing overload applicable to expanded args: still unnecessary</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo(String... args) {}
+                void foo(int x, String... args) {}
+
+                {
+                    // Expanded call foo("a", "b") does not match foo(int, String...),
+                    // so removing the array is unambiguous and still a violation.
+                    foo(new String[]{"a", "b"});
+                }
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## What
`UnnecessaryVarargsArrayCreation` no longer suggests removing an explicit array creation passed to a varargs parameter when removing it would make the call ambiguous between overloads.

## Why
For overloads like `Demo(String...)` and `Demo(String, String...)`, the call `new Demo(x, new String[]{...})` is unambiguous, but removing the array creation (`new Demo(x, ...)`) lets the second overload match as well. The rule nonetheless told the user to remove the array, producing non-compiling code. Closes #6611.

## Root cause
After matching `array.getTypeMirror().equals(lastFormal)`, the rule fired `addViolation` without checking whether the "un-arrayed" actual-parameter list could be satisfied by more than one overload of the same name in scope.

## How
Before reporting, enumerate the sibling overloads of the selected executable and test whether any of them is applicable to the expanded actual-parameter list (leading actuals + the array element type):
- Constructors: `JExecutableSymbol.getEnclosingClass().getConstructors()` (exhaustive, since constructors are not inherited).
- Methods: `JTypeMirror.streamMethods(name)` from the selected executable's declaring type, which includes overloads inherited from supertypes.

Applicability uses `TypeOps.isConvertible` in both fixed-arity and variable-arity modes (JLS 15.12.2.2-4); type variables are approximated by their upper bound. If a competing overload is applicable, the suggestion is suppressed.

## Testing
- 4 new cases: constructor ambiguity, method ambiguity in the same class, method ambiguity where the competing overload is inherited from a supertype, and a no-competing-overload control (still reported).
- Verified the ambiguity cases fail on the old code (1 violation each) and pass after the fix; the control case stays at 1 violation. The inherited-overload case specifically reports with `getDeclaredMethods` and is suppressed with `streamMethods`.
- `./mvnw -pl pmd-java -am test -Dtest=UnnecessaryVarargsArrayCreationTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false` -> `Tests run: 8, Failures: 0, Errors: 0`.
- `ConfusingArgumentToVarargsMethodTest` (the adjacent varargs rule) also passes: no collateral regression.
- checkstyle: 0 violations; dogfood (pmd on pmd-java source): 0 violations.

## Notes
- Constructors are fully covered (not inherited, all overloads live in one class); this is the issue's reproducer.
- Methods consider the whole hierarchy of the selected executable's declaring type, so a competing overload declared in a supertype is now covered.
- Generics: type variables are approximated by their upper bound (conservative: leans towards applicable -> suppress); exact for non-generic cases (the issue scenario).

Fixes #6611
