### PR TITLE
[java] Fix #6274: UselessParentheses treats ternary else-branch parentheses as clarifying

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -69,12 +69,12 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
     * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
 * java-codestyle
+    * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.
     * [#6651](https://github.com/pmd/pmd/issues/6651): \[java] UnnecessaryImport false-positive when Javadoc {@link} references an array type
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver
     * [#6737](https://github.com/pmd/pmd/issues/6737): \[java] TooManyStaticImports: @<!-- -->SuppressWarnings("PMD.TooManyStaticImports") has stopped working
     * [#6846](https://github.com/pmd/pmd/issues/6846): \[java] VariableDeclarationUsageDistance: False positive with variables grouped at the top of a block
     * [#6867](https://github.com/pmd/pmd/issues/6867): \[java] UnnecessaryFullyQualifiedName: ContextedAssertionError: This should be unreachable: unknown constant ScopeInfo: MODULE_IMPORT
-    * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.
 * java-design
     * [#6714](https://github.com/pmd/pmd/issues/6714): \[java] Rename UseUtilityClass to InstantiableUtilityClass
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -70,6 +70,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6737](https://github.com/pmd/pmd/issues/6737): \[java] TooManyStaticImports: @<!-- -->SuppressWarnings("PMD.TooManyStaticImports") has stopped working
     * [#6846](https://github.com/pmd/pmd/issues/6846): \[java] VariableDeclarationUsageDistance: False positive with variables grouped at the top of a block
     * [#6867](https://github.com/pmd/pmd/issues/6867): \[java] UnnecessaryFullyQualifiedName: ContextedAssertionError: This should be unreachable: unknown constant ScopeInfo: MODULE_IMPORT
+    * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.
 * java-design
     * [#6714](https://github.com/pmd/pmd/issues/6714): \[java] Rename UseUtilityClass to InstantiableUtilityClass
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesRule.java
@@ -140,10 +140,10 @@ public final class UselessParenthesesRule extends AbstractJavaRulechainRule {
         if (inner instanceof ASTConditionalExpression) {
 
             // a ? (b ? c : d) : e    necessary
-            // a ? b : (c ? d : e)    associative
+            // a ? b : (c ? d : e)    clarifying (parentheses are associative, but clarify the else-branch)
             // (a ? b : c) ? d : e    necessary
             if (outer instanceof ASTConditionalExpression) {
-                return inner.getIndexInParent() == 2 ? NEVER  // last child
+                return inner.getIndexInParent() == 2 ? CLARIFYING  // last child
                                                      : ALWAYS;
             } else {
                 return necessaryIf(!(outer instanceof ASTAssignmentExpression));

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UselessParenthesesTest.java
@@ -93,7 +93,7 @@ class UselessParenthesesTest extends PmdRuleTst {
     @Test
     void testConditionals() {
         assertAll(
-            unnecessary("a ? b : (c ? d : e)"),
+            clarifying("a ? b : (c ? d : e)"),
 
             necessary("a ? (b ? c : d) : e"),
             unnecessary("a ? ((b ? c : d)) : e"),

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UselessParentheses.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UselessParentheses.xml
@@ -780,4 +780,36 @@ public class Test {
             }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#6274 False positive: parentheses around a ternary in the else-branch are clarifying (default config)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    public boolean test(boolean foo, boolean bar, boolean baz, boolean bam, boolean boo) {
+        boolean baa;
+        // Parentheses around the nested ternary in the else-branch are clarifying,
+        // consistent with the then-branch on the last line.
+        baa = foo ? bar : (baz ? bam : boo);
+        baa = foo ? (bar ? baz : bam) : boo;
+        return baa;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#6274 With ignoreClarifying=false, the else-branch ternary parentheses are reported as clarifying</description>
+        <rule-property name="ignoreClarifying">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    public boolean test(boolean foo, boolean bar, boolean baz, boolean bam, boolean boo) {
+        boolean baa;
+        baa = foo ? bar : (baz ? bam : boo); // clarifying, reported
+        baa = foo ? (bar ? baz : bam) : boo; // necessary, not reported
+        return baa;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## What
`UselessParentheses` no longer flags parentheses around a ternary expression in the else-branch of an enclosing ternary (`a ? b : (c ? d : e)`), making it consistent with the then-branch, which was already accepted.

## Why
Both parentheses are technically redundant but act as clarifiers; flagging only the else-branch was an inconsistency. This matches @oowekyala's suggestion on the issue: "maybe we could consider the parentheses in the next to last line to be clarifying too. This would be consistent with how we treat the last line."

## Root cause
`UselessParenthesesRule` classified the else-branch nested ternary as `NEVER` (reported under the default `ignoreClarifying=true`) but the then-branch as `ALWAYS` (not reported).

## How
Classify the else-branch nested ternary as `CLARIFYING` instead of `NEVER`. Under the default config it is no longer reported; with `ignoreClarifying=false` it is still reported. One-line change.

## Testing
- New XML cases: default config asserts 0 violations on both branches; `ignoreClarifying=false` asserts the else-branch is reported (locking the `CLARIFYING` classification).
- Verified the default-config case fails on the old code (`Useless parentheses around 'baz ? bam : boo'`) and passes after the fix.
- `./mvnw -pl pmd-java -am test -Dtest=UselessParenthesesTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false` → `Tests run: 60, Failures: 0, Errors: 0`.
- Updated one unit test that encoded the old `NEVER` behavior.

## Notes
- A residual asymmetry remains under `ignoreClarifying=false` (then-branch `ALWAYS`, else-branch `CLARIFYING`). Fully symmetric would require the then-branch to become `CLARIFYING` too — a larger behavior change, left for the maintainer to decide.

Fixes #6274
