### PR TITLE
[java] Fix #2840: CloseResource: allow Mockito mocks by default

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -59,6 +59,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
     * [#6865](https://github.com/pmd/pmd/issues/6865): \[core] Include the running PMD version in the "Unable to find referenced rule" error
 * java
+    * [#2840](https://github.com/pmd/pmd/issues/2840): \[java] CloseResource: False positive on mocks
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
 * java-bestpractices

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -59,7 +59,6 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#4953](https://github.com/pmd/pmd/issues/4953): \[core] Deprecate PMDConfiguration#setClassloader and #getClassloader
     * [#6865](https://github.com/pmd/pmd/issues/6865): \[core] Include the running PMD version in the "Unable to find referenced rule" error
 * java
-    * [#2840](https://github.com/pmd/pmd/issues/2840): \[java] CloseResource: False positive on mocks
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
 * java-bestpractices
@@ -76,6 +75,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
 * java-errorprone
+    * [#2840](https://github.com/pmd/pmd/issues/2840): \[java] CloseResource: False positive on mocks
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer 
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -125,7 +125,12 @@ public class CloseResourceRule extends AbstractJavaRule {
                 "jakarta.servlet.ServletResponse#getOutputStream()",
                 "jakarta.servlet.http.HttpServletRequest#getReader()",
                 "jakarta.servlet.http.HttpServletResponse#getWriter()",
-                "jakarta.servlet.http.HttpServletResponse#getOutputStream()"
+                "jakarta.servlet.http.HttpServletResponse#getOutputStream()",
+                // org.mockito - a mock or spy is not a real resource, even when the mocked
+                // type implements AutoCloseable. Mockito#mockStatic is deliberately absent:
+                // it returns a MockedStatic, which does have to be closed.
+                "org.mockito.Mockito#mock(_*)",
+                "org.mockito.Mockito#spy(_*)"
             )
             .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -126,11 +126,11 @@ public class CloseResourceRule extends AbstractJavaRule {
                 "jakarta.servlet.http.HttpServletRequest#getReader()",
                 "jakarta.servlet.http.HttpServletResponse#getWriter()",
                 "jakarta.servlet.http.HttpServletResponse#getOutputStream()",
-                // org.mockito - a mock or spy is not a real resource, even when the mocked
-                // type implements AutoCloseable. Mockito#mockStatic is deliberately absent:
-                // it returns a MockedStatic, which does have to be closed.
-                "org.mockito.Mockito#mock(_*)",
-                "org.mockito.Mockito#spy(_*)"
+                // org.mockito - a mock is not a real resource, even when the mocked type
+                // implements AutoCloseable. Mockito#spy and Mockito#mockStatic are deliberately
+                // absent: a spy calls through to a real object, and mockStatic returns a
+                // MockedStatic; both of those do have to be closed.
+                "org.mockito.Mockito#mock(_*)"
             )
             .build();
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1127,8 +1127,16 @@ just remove "AutoCloseable" from the types.
 The property `allowedResourceMethodPatterns` can be used to specify method invocation patterns that return
 resources which are managed externally and don't need to be closed by the caller. This is useful for
 servlet-related streams like `HttpServletRequest.getReader()` or `HttpServletResponse.getWriter()`,
-which are managed by the servlet container. The patterns use InvocationMatcher syntax
-(e.g., `javax.servlet.ServletRequest#getReader()`).
+which are managed by the servlet container, and for mocking frameworks, whose mocks are not real
+resources even when the mocked type implements `java.lang.AutoCloseable`. The patterns use
+InvocationMatcher syntax (e.g., `javax.servlet.ServletRequest#getReader()`).
+
+The defaults cover the servlet API and Mockito's `mock()` and `spy()`. Mocks created by other frameworks
+can be allowed by adding their factory methods, for example `org.easymock.EasyMock#createMock(_*)`,
+`org.jmock.Mockery#mock(_*)` or `mockit.Mocked#new(_*)`.
+
+Note that `Mockito.mockStatic()` is intentionally not among the defaults: it returns a `MockedStatic`,
+which does have to be closed, so a violation there is a true positive.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1131,12 +1131,14 @@ which are managed by the servlet container, and for mocking frameworks, whose mo
 resources even when the mocked type implements `java.lang.AutoCloseable`. The patterns use
 InvocationMatcher syntax (e.g., `javax.servlet.ServletRequest#getReader()`).
 
-The defaults cover the servlet API and Mockito's `mock()` and `spy()`. Mocks created by other frameworks
+The defaults cover the servlet API and Mockito's `mock()`. Mocks created by other frameworks
 can be allowed by adding their factory methods, for example `org.easymock.EasyMock#createMock(_*)`,
 `org.jmock.Mockery#mock(_*)` or `mockit.Mocked#new(_*)`.
 
-Note that `Mockito.mockStatic()` is intentionally not among the defaults: it returns a `MockedStatic`,
-which does have to be closed, so a violation there is a true positive.
+Note that `Mockito.spy()` and `Mockito.mockStatic()` are intentionally not among the defaults.
+A spy calls through to the real object by default, so either the spy or the object it wraps still
+has to be closed; `mockStatic()` returns a `MockedStatic`, which has to be closed as well. A violation
+in either case is a true positive.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2371,4 +2371,59 @@ public class SplitDeclAfter {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#2840 [java] CloseResource: False positive on mocks</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.Closeable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+interface MockRequest extends Closeable {
+    int execute(String request, String body);
+}
+
+class MockTest {
+    @Test
+    void testMock() {
+        MockRequest mock = Mockito.mock(MockRequest.class);
+        Mockito.when(mock.execute("foo", "bar")).thenReturn(200);
+
+        Assertions.assertEquals(200, mock.execute("foo", "bar"));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2840 Mockito spy of a closeable type should not be reported either</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.Closeable;
+import java.io.IOException;
+import org.mockito.Mockito;
+
+class SpyTest {
+    void test(Closeable real) {
+        Closeable spy = Mockito.spy(real);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2840 Mockito.mockStatic returns a MockedStatic and must still be reported</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class StaticMockTest {
+    void test() {
+        MockedStatic<Integer> mocked = Mockito.mockStatic(Integer.class);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2397,22 +2397,6 @@ class MockTest {
     </test-code>
 
     <test-code>
-        <description>#2840 Mockito spy of a closeable type should not be reported either</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-import java.io.Closeable;
-import java.io.IOException;
-import org.mockito.Mockito;
-
-class SpyTest {
-    void test(Closeable real) {
-        Closeable spy = Mockito.spy(real);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
         <description>#2840 Mockito.mockStatic returns a MockedStatic and must still be reported</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
Fixes #2840.

@UncleOwen — both, as you suggested.

**Defaults.** `org.mockito.Mockito#mock(_*)` is added to `allowedResourceMethodPatterns`. `spy` and `mockStatic` are deliberately left out: a spy calls through to the real object by default, so either the spy or the object it wraps still has to be closed, and `mockStatic` returns a `MockedStatic`, which genuinely has to be closed. A violation in either case is a true positive, and there is a test pinning `mockStatic`.

The defaults live in `CloseResourceRule.java` rather than in `errorprone.xml`, so that is where the pattern went; the note for other frameworks went into the rule description in `errorprone.xml`, with `EasyMock`, `JMock` and `JMockit` as examples and an explicit note about `spy` and `mockStatic`.

`mockito-core` is already a test dependency of `pmd-java`, so no new dependency is needed — unlike the servlet patterns in #6436.

**Runs**, on `443f7a6` with temurin-25, for the original three-pattern version of this PR:

```
clean tree                  Tests run: 99,  Failures: 0    BUILD SUCCESS
+ test cases only           Tests run: 102, Failures: 1    "#2840 ... Expected 0 problem(s), 1 problem(s) found."
+ test cases and the fix    Tests run: 102, Failures: 0    BUILD SUCCESS
```

**Update after review (`6b0bfc7`).** @zbynek pointed out that a spy delegates to the real object, so allowing `spy(_*)` would turn a true positive into a false negative. Agreed — `spy` is out of the defaults, and only `mock` remains.

The `spy` test case is removed rather than inverted. With `spy` out of the defaults the rule reports 0 violations for that snippet either way: it took the resource as a method parameter, so the case never discriminated on the allowed-pattern list and was not testing what its description claimed. The `mock` and `mockStatic` cases do discriminate and stay. The release note entry moved from java to java-errorprone (@UncleOwen). I have not re-run the suite locally since that commit — CI on this branch is the check for it.

AI-assisted (LLM used for drafting); the runs above are mine.
