### PR TITLE
[apex] Fix ApexUnitTestShouldNotUseSeeAllDataTrue violation location

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,8 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * apex
     * [#6478](https://github.com/pmd/pmd/issues/6478): \[apex] Parser error when using CALENDAR_YEAR() in SOQL
     * [#6887](https://github.com/pmd/pmd/issues/6887): \[apex] ParseException on Summer '26 multiline string literals ('''...''')
+* apex-bestpractices
+    * [#5904](https://github.com/pmd/pmd/issues/5904): \[apex] ApexUnitTestShouldNotUseSeeAllDataTrue violation range should only be the annotation and not the entire test method
 * chore
     * [#6837](https://github.com/pmd/pmd/issues/6837): chore: Input 'app-id' has been deprecated with message: Use 'client-id' instead
 * core

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -47,7 +47,7 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
             for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
                 if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA)
                         && (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue()))) {
-                    asCtx(data).addViolation(node);
+                    asCtx(data).addViolation(parameter);
                     return data;
                 }
             }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestShouldNotUseSeeAllDataTrue.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestShouldNotUseSeeAllDataTrue.xml
@@ -38,7 +38,7 @@ public class Foo {
     <test-code>
         <description>[apex] ApexUnitTestShouldNotUseSeeAllDataTrue false negative due to casing (regression in PMD 7) #5095</description>
         <expected-problems>9</expected-problems>
-        <expected-linenumbers>2,5,10,15,20,25,30,35,40</expected-linenumbers>
+        <expected-linenumbers>1,4,9,14,19,24,29,34,39</expected-linenumbers>
         <code><![CDATA[
 @isTest(SeeAllData = true)
 public class SomeTest {
@@ -89,7 +89,7 @@ public class SomeTest {
     <test-code>
         <description>[apex] ApexUnitTestShouldNotUseSeeAllDataTrue seeAllData boolean enclosed in quote #5667</description>
         <expected-problems>2</expected-problems>
-        <expected-linenumbers>2,5</expected-linenumbers>
+        <expected-linenumbers>1,4</expected-linenumbers>
         <code><![CDATA[
 @isTest(SeeAllData = 'true')
 public class SomeTest {
@@ -97,6 +97,24 @@ public class SomeTest {
     @IsTest(SeeAllData=true)
     public static void testMethod1() {
         System.assertEquals(1 + 2, 3);
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[apex] ApexUnitTestShouldNotUseSeeAllDataTrue violation should be reported on the seeAllData parameter, not the whole method #5904</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3-3</expected-linenumbers>
+        <code><![CDATA[
+@isTest(
+    isParallel = true,
+    seeAllData = true
+)
+public class Foo {
+    public static testMethod void testSomething() {
+        Account a = null;
+        System.assertNotEquals(a, null, 'account not found');
     }
 }
 ]]></code>


### PR DESCRIPTION
Fixes #5904.

`ApexUnitTestShouldNotUseSeeAllDataTrue` was reporting the violation on the whole class or method node instead of the `seeAllData` annotation parameter itself. In practice this means the highlighted range in editor integrations (e.g. the Salesforce Code Analyzer VS Code extension, per the issue) covers the entire test method instead of just the offending annotation.

The fix is a one-liner: report on the `parameter` node that was already being matched, instead of the enclosing class/method `node`.

Updated the existing expected-violation line numbers in the rule's test XML to match the parameter's actual position (previously they matched the class/method declaration's line, which happened to be adjacent to the annotation in those fixtures), and added a new test case with a multi-line, multi-parameter `@isTest(...)` annotation to make the range-narrowing behavior explicit and hard to regress.
