### PR TITLE
[java] Fix dataflow state for conditional initializers

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -64,6 +64,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * java-bestpractices
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
+    * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
 * java-codestyle
     * [#6651](https://github.com/pmd/pmd/issues/6651): \[java] UnnecessaryImport false-positive when Javadoc {@link} references an array type
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -931,7 +931,7 @@ public final class DataflowPass {
             JVariableSymbol var = node.getVarId().getSymbol();
             ASTExpression rhs = node.getInitializer();
             if (rhs != null) {
-                rhs.acceptVisitor(this, data);
+                data = rhs.acceptVisitor(this, data);
                 data.assign(var, rhs);
             } else if (isAssignedImplicitly(node.getVarId())) {
                 data.declareBlank(node.getVarId());

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -2060,6 +2060,25 @@ public class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>[java] Post-increment in conditional initializer is used afterwards #6200</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private boolean c;
+
+    private int foo(int x) {
+        return x + 1;
+    }
+
+    public int visit(int i) {
+        int x = c ? foo(i++) : 17;
+        return i;
+    }
+}
+        ]]></code>
+    </test-code>
+
 
 
     <test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -2073,7 +2073,7 @@ public class Foo {
 
     public int visit(int i) {
         int x = c ? foo(i++) : 17;
-        return i;
+        return i + x;
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

  Preserve the dataflow state returned while visiting local variable initializers. Conditional initializers return a merged branch state; discarding it caused assignments such as `i++` in one branch to be
  reported as unused even when the variable was read afterwards.

  A regression test covers the reported conditional-initializer case.

  ## Related issues

  - Fix #6200

  ## Ready?

  - [x] Added unit tests for fixed bug/feature
  - [x] Passing all unit tests
  - [x] Complete build `./mvnw clean verify` passes
  - [x] Added in-code documentation if needed