### PR TITLE
[chore] Add oout to allowed list of typos

### DIFF
--- a/.ci/files/typos.toml
+++ b/.ci/files/typos.toml
@@ -54,6 +54,7 @@ strat = "strat"
 ois = "ois"
 parms = "parms"
 opps = "opps"
+oout = "oout"
 
 [default.extend-identifiers]
 # public APIs


### PR DESCRIPTION
## Describe the PR

Add oout to allowed list of typos - It's a common name for ObjectOutputStreams, now used in CloseResource.xml

## Related issues

- See #6918 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

