### PR TITLE
[java] Fix #6958: Add configurable Boolean handling to BooleanGetMethodName

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -45,12 +45,15 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
   The old name still works but is deprecated.
 
 #### Changed Rules
-* The Java rule [`CommentRequired`](https://docs.pmd-code.org/pmd-doc-7.27.0-SNAPSHOT/pmd_rules_java_documentation.html#commentrequired)
+* The rule {% rule java/documentation/CommentRequired %} (Java Documentation)
   has a new property `packageMethodCommentRequirement`. It controls whether Javadoc comments are required (or
   unwanted) for package-private methods and constructors. Previously, only `public` and `protected` methods could
   be configured (via `publicMethodCommentRequirement` and `protectedMethodCommentRequirement`). The new property
   defaults to `Ignored`, so existing rule configurations are unaffected.
   This was implemented in [#6880](https://github.com/pmd/pmd/pull/6880).
+* The rule {% rule java/codestyle/BooleanGetMethodName %} (Java Codestyle) has a new property
+  `includeWrappedType`. If set to true (default), the rule treats Boolean and boolean identical.
+  If set to false, the rule follows the bean convention and treats Boolean like any other object.
 
 #### Deprecated Rules
 * The java rule {% rule java/errorprone/CheckSkipResult %} has been deprecated for removal
@@ -81,6 +84,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
     * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
 * java-codestyle
+    * [#6958](https://github.com/pmd/pmd/issues/6958): \[java] BooleanGetMethodName should have the option to treat boolean wrapper type differently
     * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.
     * [#6651](https://github.com/pmd/pmd/issues/6651): \[java] UnnecessaryImport false-positive when Javadoc {@link} references an array type
     * [#6709](https://github.com/pmd/pmd/issues/6709): \[java] LambdaCanBeMethodReference: False positive with array creation containing constructor call in receiver

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -178,6 +178,7 @@ public class SomeJNIClass {
         <description>
             Methods that return boolean or Boolean results should be named as predicate statements to denote this.
             I.e., 'isReady()', 'hasValues()', 'canCommit()', 'willFail()', etc. Avoid the use of the 'get' prefix for these methods.
+            By default, methods returning the Boolean wrapper type are checked as well. This can be disabled with the includeWrappedType property.
         </description>
         <priority>4</priority>
         <properties>
@@ -187,16 +188,17 @@ public class SomeJNIClass {
 //MethodDeclaration
     [starts-with(@Name, 'get')]
     [@Arity = 0 or $checkParameterizedMethods = true()]
-    [ (PrimitiveType[@Kind = 'boolean'] or ClassType[pmd-java:typeIs('java.lang.Boolean')]) and @Override = false() ]
+    [ (PrimitiveType[@Kind = 'boolean'] or ($includeWrappedType and ClassType[pmd-java:typeIs('java.lang.Boolean')])) and @Override = false() ]
 ]]>
                 </value>
             </property>
             <property name="checkParameterizedMethods" type="Boolean" description="Check parameterized methods" value="false"/>
+            <property name="includeWrappedType" type="Boolean" description="Include methods returning the Boolean wrapper type" value="true"/>
         </properties>
         <example>
             <![CDATA[
 public boolean getFoo();            // bad
-public Boolean getFoo();            // bad
+public Boolean getFoo();            // bad by default
 public boolean isFoo();             // ok
 public Boolean isFoo();             // ok
 public boolean getFoo(boolean bar); // ok, unless checkParameterizedMethods=true

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -198,7 +198,7 @@ public class SomeJNIClass {
         <example>
             <![CDATA[
 public boolean getFoo();            // bad
-public Boolean getFoo();            // bad by default
+public Boolean getFoo();            // bad if includeWrappedType=true (default)
 public boolean isFoo();             // ok
 public Boolean isFoo();             // ok
 public boolean getFoo(boolean bar); // ok, unless checkParameterizedMethods=true

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/BooleanGetMethodName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/BooleanGetMethodName.xml
@@ -101,6 +101,32 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Should not match boxed Boolean when includeWrappedType is false (#6958)</description>
+        <rule-property name="includeWrappedType">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Boolean getEnabled() {
+        return true;
+    }
+}
+    ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Should still match primitive boolean when includeWrappedType is false (#6958)</description>
+        <rule-property name="includeWrappedType">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean getEnabled() {
+        return true;
+    }
+}
+    ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Should not match for boxed Boolean on methods annotated with @Override (#5253)</description>
         <expected-problems>0</expected-problems>
         <expected-suppressions>


### PR DESCRIPTION
## Describe the PR

The `BooleanGetMethodName` rule currently treats primitive `boolean` and
`java.lang.Boolean` return types identically.

However, JavaBeans-compatible tooling commonly expects `getX()` for the
`Boolean` wrapper type, while `isX()` is used for primitive `boolean`.

This change adds the `includeWrappedType` property to make checking
`java.lang.Boolean` configurable.

The property defaults to `true` to preserve the existing behavior.

Added regression tests covering both `includeWrappedType=true` and
`includeWrappedType=false` behavior.

## Related issues

- Fix #6958

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

