### PR TITLE
[doc] Fix #6961: dont choke on cut off links

### DIFF
--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
@@ -323,7 +323,7 @@ public class RuleDocGenerator {
     }
 
     /**
-     * Shortens and escapes (for markdown) some special characters. Otherwise the shortened text
+     * Shortens and escapes (for Markdown) some special characters. Otherwise the shortened text
      * could contain some unfinished sequences.
      * @param rule
      * @return
@@ -337,7 +337,7 @@ public class RuleDocGenerator {
                         .replaceAll("\\|", "\\\\|")
                         .replaceAll("`", "'")
                         .replaceAll("\\*", "")
-                        .replaceAll("\\[([^\\]]+)\\]\\([^\\)]*\\)", "$1")
+                        .replaceAll("\\[([^\\]]+)\\]\\([^\\)]*\\)", "$1")  // Markdown links
                 ),
                 100));
         return EscapeUtils.preserveRuleTagQuotes(htmlEscaped);

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleDocGenerator.java
@@ -336,7 +336,9 @@ public class RuleDocGenerator {
                         .replaceAll("\n+|\r+", " ")
                         .replaceAll("\\|", "\\\\|")
                         .replaceAll("`", "'")
-                        .replaceAll("\\*", "")),
+                        .replaceAll("\\*", "")
+                        .replaceAll("\\[([^\\]]+)\\]\\([^\\)]*\\)", "$1")
+                ),
                 100));
         return EscapeUtils.preserveRuleTagQuotes(htmlEscaped);
     }

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -69,18 +69,26 @@ public class RuleTagChecker {
         int lineNo = 0;
         for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
             lineNo++;
-            Matcher ruleTagMatcher = RULE_TAG.matcher(line);
-            while (ruleTagMatcher.find()) {
-                String ruleReference = ruleTagMatcher.group(1);
-                int pos = ruleTagMatcher.end();
-                if (line.charAt(pos) != '%' || line.charAt(pos + 1) != '}') {
-                    addIssue(file, lineNo, "Rule tag for " + ruleReference + " is not closed properly");
-                } else if (ruleReference.startsWith(QUOTE) && !ruleReference.endsWith(QUOTE)
-                        || !ruleReference.startsWith(QUOTE) && ruleReference.endsWith(QUOTE)) {
-                    addIssue(file, lineNo, "Rule tag for " + ruleReference + " has a missing quote");
-                } else if (!ruleReferenceTargetExists(ruleReference)) {
-                    addIssue(file, lineNo, "Rule " + ruleReference + " is not found");
+            try {
+                Matcher ruleTagMatcher = RULE_TAG.matcher(line);
+                while (ruleTagMatcher.find()) {
+                    String ruleReference = ruleTagMatcher.group(1);
+                    int pos = ruleTagMatcher.end();
+                    if (pos + 1 >= line.length()
+                            || line.charAt(pos) != '%'
+                            || pos + 1 >= line.length() || line.charAt(pos + 1) != '}'
+                    ) {
+                        addIssue(file, lineNo, "Rule tag for " + ruleReference + " is not closed properly");
+                    } else if (ruleReference.startsWith(QUOTE) && !ruleReference.endsWith(QUOTE)
+                            || !ruleReference.startsWith(QUOTE) && ruleReference.endsWith(QUOTE)
+                    ) {
+                        addIssue(file, lineNo, "Rule tag for " + ruleReference + " has a missing quote");
+                    } else if (!ruleReferenceTargetExists(ruleReference)) {
+                        addIssue(file, lineNo, "Rule " + ruleReference + " is not found");
+                    }
                 }
+            } catch (Exception e) {
+                throw new ParseException(file, lineNo, e);
             }
         }
     }
@@ -144,6 +152,12 @@ public class RuleTagChecker {
         if (!issues.isEmpty()) {
             issues.forEach(System.err::println);
             throw new AssertionError("Wrong rule tags detected");
+        }
+    }
+
+    private static class ParseException extends RuntimeException {
+        private ParseException(Path file, int line, Exception cause) {
+            super(String.format("File: %s, Line: %d: %s", file.toString(), line, cause.getMessage()), cause);
         }
     }
 }

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -76,7 +76,7 @@ public class RuleTagChecker {
                     int pos = ruleTagMatcher.end();
                     if (pos + 1 >= line.length()
                             || line.charAt(pos) != '%'
-                            || pos + 1 >= line.length() || line.charAt(pos + 1) != '}'
+                            || line.charAt(pos + 1) != '}'
                     ) {
                         addIssue(file, lineNo, "Rule tag for " + ruleReference + " is not closed properly");
                     } else if (ruleReference.startsWith(QUOTE) && !ruleReference.endsWith(QUOTE)

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -155,7 +155,7 @@ public class RuleTagChecker {
         }
     }
 
-    private static class ParseException extends RuntimeException {
+    private static final class ParseException extends RuntimeException {
         private ParseException(Path file, int line, Exception cause) {
             super(String.format("File: %s, Line: %d: %s", file.toString(), line, cause.getMessage()), cause);
         }

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -87,7 +87,7 @@ public class RuleTagChecker {
                         addIssue(file, lineNo, "Rule " + ruleReference + " is not found");
                     }
                 }
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 throw new ParseException(file, lineNo, e);
             }
         }

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
@@ -19,7 +19,7 @@ class RuleTagCheckerTest {
         RuleTagChecker checker = new RuleTagChecker(FileSystems.getDefault().getPath("src/test/resources/ruletagchecker"));
         List<String> issues = checker.check();
 
-        assertEquals(7, issues.size());
+        assertEquals(8, issues.size());
         assertEquals("ruletag-examples.md: 9: Rule tag for \"java/bestpractices/AvoidPrintStackTrace\" is not closed properly",
                 issues.get(0));
         assertEquals("ruletag-examples.md:12: Rule \"java/notexistingcategory/AvoidPrintStackTrace\" is not found",
@@ -32,5 +32,6 @@ class RuleTagCheckerTest {
                 issues.get(4));
         assertEquals("ruletag-examples.md:21: Rule tag for \"OtherRule has a missing quote", issues.get(5));
         assertEquals("ruletag-examples.md:22: Rule tag for OtherRule\" has a missing quote", issues.get(6));
+        assertEquals("ruletag-examples.md:25: Rule tag for \"OtherRule\" is not closed properly", issues.get(7));
     }
 }

--- a/pmd-doc/src/test/resources/expected/java.md
+++ b/pmd-doc/src/test/resources/expected/java.md
@@ -21,6 +21,7 @@ editmepath: false
 *   [RenamedRule3](pmd_rules_java_sample.html#renamedrule3): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been renamed. Use instead [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer).
 *   [RenamedRule4](pmd_rules_java_sample.html#renamedrule4): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been renamed. Use instead [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer).
 *   [SampleRuleWithEnumProperties](pmd_rules_java_sample.html#samplerulewithenumproperties): This rule is for testing enum properties
+*   [SampleRuleWithLotsOfLinks](pmd_rules_java_sample.html#samplerulewithlotsoflinks): This Rule is for Testing links
 *   [XSSInDocumentation](pmd_rules_java_sample.html#xssindocumentation): &lt;script&gt;alert('XSS at the beginning');&lt;/script&gt; HTML tags might appear at various places.        ...
 
 ## Additional rulesets

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -628,7 +628,7 @@ This rule is for testing enum properties
 
 ## SampleRuleWithLotsOfLinks
 
-**Since:** PMD 7.27.0
+**Since:** PMD 7.28.0
 
 **Priority:** Medium (3)
 

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -5,7 +5,7 @@ permalink: pmd_rules_java_sample.html
 folder: pmd/rules/java
 sidebaractiveurl: /pmd_rules_java.html
 editmepath: ../rulesets/ruledoctest/sample.xml
-keywords: Sample, DeprecatedSample, JumbledIncrementer, MovedRule, OverrideBothEqualsAndHashcode, RenamedRule1, RenamedRule2, RenamedRule3, RenamedRule4, SampleRuleWithEnumProperties, XSSInDocumentation
+keywords: Sample, DeprecatedSample, JumbledIncrementer, MovedRule, OverrideBothEqualsAndHashcode, RenamedRule1, RenamedRule2, RenamedRule3, RenamedRule4, SampleRuleWithEnumProperties, SampleRuleWithLotsOfLinks, XSSInDocumentation
 rules:
   DeprecatedSample: |
     Just some description of a deprecated rule.
@@ -56,6 +56,8 @@ rules:
     
   SampleRuleWithEnumProperties: |
     This rule is for testing enum properties
+  SampleRuleWithLotsOfLinks: |
+    This [Rule](http://some.host/somelink) is for [Testing](https://yet.another.link/) links
   XSSInDocumentation: |
     &lt;script&gt;alert('XSS at the beginning');&lt;/script&gt; HTML tags might appear at various places.
     Sometimes they should be escaped, sometimes not:
@@ -622,6 +624,24 @@ This rule is for testing enum properties
         <property name="enumListProperty" value="" />
     </properties>
 </rule>
+```
+
+## SampleRuleWithLotsOfLinks
+
+**Since:** PMD 7.27.0
+
+**Priority:** Medium (3)
+
+This [Rule](http://some.host/somelink) is for [Testing](https://yet.another.link/) links
+
+**This rule is defined by the following XPath expression:**
+``` xpath
+
+```
+
+**Use this rule by referencing it:**
+``` xml
+<rule ref="category/java/sample.xml/SampleRuleWithLotsOfLinks" />
 ```
 
 ## XSSInDocumentation

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -236,4 +236,17 @@ RuleTag with full category and without quotes: Use {% rule java/sample/RenamedRu
         <description>This rule is for testing enum properties</description>
         <priority>3</priority>
     </rule>
+
+    <rule name="SampleRuleWithLotsOfLinks"
+          language="java"
+          since="7.27.0"
+          message="Message"
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+        <description>
+<![CDATA[
+This [Rule](http://some.host/somelink) is for [Testing](https://yet.another.link/) links
+]]>
+        </description>
+        <priority>3</priority>
+    </rule>
 </ruleset>

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -239,7 +239,7 @@ RuleTag with full category and without quotes: Use {% rule java/sample/RenamedRu
 
     <rule name="SampleRuleWithLotsOfLinks"
           language="java"
-          since="7.27.0"
+          since="7.28.0"
           message="Message"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
         <description>

--- a/pmd-doc/src/test/resources/ruletagchecker/docs/pages/ruletag-examples.md
+++ b/pmd-doc/src/test/resources/ruletagchecker/docs/pages/ruletag-examples.md
@@ -20,3 +20,6 @@ This is a rule tag, that references a rule in the same category: {% rule OtherRu
 This is a rule tag, that references a rule in the same category: {% rule "OtherRule" %} (correct).
 This is a rule tag, that references a rule in the same category: {% rule "OtherRule %} (missing quote).
 This is a rule tag, that references a rule in the same category: {% rule OtherRule" %} (missing quote).
+
+The next line ends in exactly the right spot to trigger a StringIndexOutOfBoundsException.
+This is a rule tag, that references a rule in the same category: {% rule "OtherRule"


### PR DESCRIPTION
## Describe the PR

This fixes RuleDocGenerator to not generate partial links in the rule index (by not generating links at all for the description exerpt) and fixes RuleTagChecker to still handle that case gracefully.

## Related issues

- Fix #6961 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

