### PR TITLE
[java] New rule: ProtectedMemberInFinalClass

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -39,6 +39,10 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
 * The new java rule {% rule java/errorprone/UnusedReturnValue %} finds method calls whose result is not used,
   although ignoring the result of these method calls is likely a mistake.
   The rule is referenced in the quickstart.xml ruleset for Java.
+* New rule {% rule java/codestyle/ProtectedMemberInFinalClass %} finds protected members defined in final classes.
+  Such members should use package or private visibility to clarify their intended scope.
+  The rule replaces now deprecated rules {% rule java/codestyle/AvoidProtectedFieldInFinalClass %} and {% rule java/codestyle/AvoidProtectedMethodInFinalClassNotExtending %}
+  and flags members that were previously not detected by either of these rules, such as nested types or constructors.
 
 #### Renamed Rules
 * The rule {%rule java/design/InstantiableUtilityClass %} (Java Design) was renamed from `UseUtilityClass` to better reflect the problem.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1335,7 +1335,7 @@ public int getLength(String[] strings) {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#protectedmemberinfinalclass">
         <description>
-            Do not use protected members in most final classes since they cannot be subclassed. This does
+            Do not use protected members in final classes since they cannot be subclassed. This does
             not apply to methods that override a protected method from a superclass, since visibility cannot be decreased .
             Clarify your intent by using private or package access modifiers instead.
         </description>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1351,6 +1351,7 @@ public int getLength(String[] strings) {
   RecordDeclaration |
   ClassDeclaration |
   AnnotationTypeDeclaration |
+  ConstructorDeclaration |
   MethodDeclaration[ @Override=false() ]
 )[@Visibility="protected"]
  ]]>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -69,12 +69,15 @@ public class Fo$o {  // not a recommended name
     <rule name="AvoidProtectedFieldInFinalClass"
           language="java"
           since="2.1"
+          deprecated="true"
           message="Avoid protected fields in a final class.  Change to private or package access."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#avoidprotectedfieldinfinalclass">
         <description>
 Do not use protected fields in final classes since they cannot be subclassed.
 Clarify your intent by using private or package access modifiers instead.
+
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule ProtectedMemberInFinalField %}, which covers all class members.
         </description>
         <priority>3</priority>
         <properties>
@@ -102,6 +105,7 @@ public final class Bar {
     <rule name="AvoidProtectedMethodInFinalClassNotExtending"
           language="java"
           since="5.1"
+          deprecated="true"
           message="Avoid protected methods in a final class that doesn't extend anything other than Object.  Change to private or package access."
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#avoidprotectedmethodinfinalclassnotextending">
@@ -109,6 +113,8 @@ public final class Bar {
 Do not use protected methods in most final classes since they cannot be subclassed. This should
 only be allowed in final classes that extend other classes with protected methods (whose
 visibility cannot be reduced). Clarify your intent by using private or package access modifiers instead.
+
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule ProtectedMemberInFinalField %}, which covers all class members.
         </description>
         <priority>3</priority>
         <properties>
@@ -1322,6 +1328,49 @@ public int getLength(String[] strings) {
         </example>
     </rule>
 
+    <rule name="ProtectedMemberInFinalClass"
+          language="java"
+          since="7.27.0"
+          message="Avoid protected members in a final class. Change to private or package access."
+          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#protectedmemberinfinalclass">
+        <description>
+            Do not use protected members in most final classes since they cannot be subclassed. This does
+            not apply to methods that override a protected method from a superclass, since visibility cannot be decreased .
+            Clarify your intent by using private or package access modifiers instead.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//ClassDeclaration[@Final=true()]/ClassBody/
+(
+  FieldDeclaration |
+  EnumDeclaration |
+  RecordDeclaration |
+  ClassDeclaration |
+  AnnotationTypeDeclaration |
+  MethodDeclaration[ @Override=false() ]
+)[@Visibility="protected"]
+ ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public final class Foo {
+  private int bar() {}
+  protected int baz() {} // Foo cannot be subclassed, and doesn't extend anything, so is baz() really private or package visible?
+  protected int field; // This should be a private or package visible field
+  protected enum InnerEnum {} // Same for enums ...
+  protected class InnerClass {} // ... classes ...
+  protected record InnerRecord {} // ... record ...
+  protected @interface InnerAnnotation {} // ... and annotations
+}
+ ]]>
+        </example>
+    </rule>
     <rule name="RemoteInterfaceNamingConvention"
           language="java"
           since="4.0"
@@ -1908,7 +1957,7 @@ class C extends A implements J { // Unnecessary to declare that C implements J, 
         <description>
 Avoid the creation of unnecessary local variables.
 
-This rule has been deprecated since 7.17.0. Use the new rule
+**Deprecated:** This rule has been deprecated since 7.17.0. Use the new rule
 {%rule VariableCanBeInlined %} instead, which additionally covers throw statements.
         </description>
         <priority>3</priority>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1338,6 +1338,8 @@ public int getLength(String[] strings) {
             Do not use protected members in final classes since they cannot be subclassed. This does
             not apply to methods that override a protected method from a superclass, since visibility cannot be decreased .
             Clarify your intent by using private or package access modifiers instead.
+
+            This replaced the old rules "AvoidProtectedFieldInFinalClass" and "AvoidProtectedMethodInFinalClassNotExtending" in PMD 7.27.0
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -92,8 +92,8 @@
     <!-- OTHER -->
     <!-- <rule ref="category/java/codestyle.xml/AtLeastOneConstructor" /> -->
     <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
-    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
-    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
+    <!-- <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/> -->
+    <!-- <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/> -->
     <!-- <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>-->
     <!-- <rule ref="category/java/codestyle.xml/BooleanGetMethodName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/CallSuperInConstructor" /> -->
@@ -113,6 +113,7 @@
     <!-- <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals" /> -->
     <!-- <rule ref="category/java/codestyle.xml/OnlyOneReturn" /> -->
     <!-- <rule ref="category/java/codestyle.xml/PrematureDeclaration" /> -->
+    <rule ref="category/java/codestyle.xml/ProtectedMemberInFinalClass"/>
     <!-- <rule ref="category/java/codestyle.xml/TooManyStaticImports" /> -->
     <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
     <!-- <rule ref="category/java/codestyle.xml/UnnecessaryBlock"/> -->

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ProtectedMemberInFinalClassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ProtectedMemberInFinalClassTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class ProtectedMemberInFinalClassTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ProtectedMemberInFinalClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ProtectedMemberInFinalClass.xml
@@ -181,4 +181,16 @@ public final class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Protected constructor is bad</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+public final class Test {
+    protected Test() {}
+    public Test(String s) {}
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ProtectedMemberInFinalClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ProtectedMemberInFinalClass.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>ok, protected field in non-final class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    protected int x;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, protected field in final class</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    protected int x;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, private field in final class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    private int x;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected field in inner class is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    private class bar { protected int x; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, protected method in non final class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    protected void bar() {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, protected method in final class that doesn't extend anything</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    protected void bar(){}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, protected method in final class that doesn't extend anything but implements interface</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo implements java.io.Serializable {
+    protected void bar(){}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, protected method in final class that does override something</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo extends Bar {
+    protected void bar(){}
+}
+class Bar {
+    protected void bar();
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, protected method in final class that does override something</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo extends Bar {
+    protected void bar(long x){}
+    protected void bar(int x){}
+}
+class Bar {
+    protected void bar(int x);
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, private method in final class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    private void bar(){}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected method in non-final inner class is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    private class Bar { protected int baz(){} }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected method in final inner class that overrides something is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+    private final class Bar extends Super { protected int baz(){} }
+}
+class Super {
+    protected int baz();
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected method in final inner class that does not override anything is bad</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private final class Bar { protected int baz(){} }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1241 False+ AvoidProtectedMethodInFinalClassNotExtending</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+private final class Dummy {
+    @Override
+    protected void finalize() {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Protected nested types are bad</description>
+        <expected-problems>5</expected-problems>
+        <code><![CDATA[
+public final class Test {
+    protected enum Foo {}
+    protected record Bar() {}
+    protected class Baz {}
+    protected interface Face {}
+    protected @interface Annotation {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Public nested types are OK</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Test {
+    public enum Foo {}
+    public record Bar() {}
+    public class Baz {}
+    public interface Face {}
+    public @interface Annotation {}
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Two existing rules for protected members in final classes are merged to one. The new rule also covers nested type declarations where the outer one is final and the inner one is protected.

## Related issues

- Fix #2974

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

