### PR TITLE
[java] AssertEqualsArgumentOrder: False negative for assertEquals with delta

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -110,9 +110,8 @@ public final class TestFrameworksUtil {
             );
 
     public static final List<EqualMethod> EQUAL_METHODS = Arrays.asList(
-        // JUnit Jupiter: expected, actual, [message]
-        new EqualMethod("org.junit.jupiter.api.Assertions#assertEquals(_,_)", 1, 0),
-        new EqualMethod("org.junit.jupiter.api.Assertions#assertEquals(_,_,_)", 1, 0),
+        // JUnit Jupiter: expected, actual, [delta], [message]
+        new EqualMethod("org.junit.jupiter.api.Assertions#assertEquals(_*)", 1, 0),
         // JUnit 3 and 4, Spring: [message], expected, actual
         new EqualMethod("org.junit.Assert#assertEquals(_,_)", 1, 0),
         new EqualMethod("org.junit.Assert#assertEquals(java.lang.String,_,_)", 2, 1),

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssertEqualsArgumentOrder.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssertEqualsArgumentOrder.xml
@@ -150,4 +150,29 @@ public class SimpleTest {
 ]]>
         </code>
     </test-code>
+    <test-code>
+        <description>Jupiter assertions with precision</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,9</expected-linenumbers>
+        <code>
+            <![CDATA[
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+public class SimpleTest {
+    private static final double CONST = 1.0;
+    @Test
+    public void testX() {
+        assertEquals(CONST, 1.0, 0.1, "reason"); // wrong argument order
+        assertEquals(1.0, CONST, 0.1, "other reason"); // OK
+        assertEquals(next(1.0), .5 * 2, 0.1); // wrong argument order
+        assertEquals(.5 * 2, next("foo"), 0.1); // good
+        assertEquals(.5 * 2, 2 * .5, 0.1); // good
+    }
+    private double next(double x) {
+        return 1.0;
+    }
+}
+]]>
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Follow-up for https://github.com/pmd/pmd/pull/6827, adds support for `Assertions.assertEquals` with floating point delta argument.


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- #6826

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

