### PR TITLE
[java] Fix #6967: Make violation message of UnusedReturnValue consistent by removing type parameters

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -103,7 +103,6 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
-    * [#6967](https://github.com/pmd/pmd/issues/6967): \[java] UnusedReturnValue produces inconsistent violation messages
 * java-multithreading
     * [#6747](https://github.com/pmd/pmd/issues/6747): \[java] NonThreadSafeSingleton: False negative with ternary conditional operator
 * kotlin

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -103,6 +103,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6742](https://github.com/pmd/pmd/issues/6742): \[java] CloseResource: False positive when a correctly-closed resource is declared without initializer
     * [#6826](https://github.com/pmd/pmd/issues/6826): \[java] AssertEqualsArgumentOrder: False positive for double assertEquals
     * [#6900](https://github.com/pmd/pmd/issues/6900): \[java] DoubleCheckedLocking: False negative when the outer null check is written as !(x != null)
+    * [#6967](https://github.com/pmd/pmd/issues/6967): \[java] UnusedReturnValue produces inconsistent violation messages
 * java-multithreading
     * [#6747](https://github.com/pmd/pmd/issues/6747): \[java] NonThreadSafeSingleton: False negative with ternary conditional operator
 * kotlin

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -49,7 +49,7 @@ public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
     private String formatCall(ASTMethodCall call) {
         JMethodSig methodSig = call.getMethodType();
 
-        return methodSig.getDeclaringType() + "." + methodSig.getName() + "()";
+        return methodSig.getDeclaringType().getSymbol().getSimpleName() + "." + methodSig.getName() + "()";
     }
 
     private boolean shouldCheckResult(ASTMethodCall call) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedReturnValueRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
@@ -49,7 +50,7 @@ public class UnusedReturnValueRule extends AbstractJavaRulechainRule {
     private String formatCall(ASTMethodCall call) {
         JMethodSig methodSig = call.getMethodType();
 
-        return methodSig.getDeclaringType().getSymbol().getSimpleName() + "." + methodSig.getName() + "()";
+        return ((JClassSymbol) methodSig.getDeclaringType().getSymbol()).getCanonicalName() + "." + methodSig.getName() + "()";
     }
 
     private boolean shouldCheckResult(ASTMethodCall call) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
@@ -31,7 +31,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>7</expected-linenumbers>
         <expected-messages>
-            <message>Result of 'Foo.bar()' is ignored.</message>
+            <message>Result of 'foo.bar.Foo.bar()' is ignored.</message>
         </expected-messages>
         <code>
             <![CDATA[
@@ -756,7 +756,7 @@ public class Foo extends FileInputStream {
         <description>Violation message when generics are used</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>Result of 'Collection.size()' is ignored.</message>
+            <message>Result of 'java.util.Collection.size()' is ignored.</message>
         </expected-messages>
         <code><![CDATA[
 import java.util.Collection;
@@ -765,6 +765,27 @@ class Wildcard
 {
     public static void foo(Collection < ? extends Wildcard[] > collection) {
         collection.size();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Violation message for nested classes</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Result of 'java.util.Map.Entry.getValue()' is ignored.</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.util.Map;
+
+class Foo
+{
+    public static void foo(Map<String, Integer> x)
+    {
+        for (final Map.Entry<String, Integer> entry : x.entrySet()) {
+            entry.getValue();
+        }
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedReturnValue.xml
@@ -29,12 +29,14 @@ public class Foo {
     <test-code>
         <description>Verify violation message</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
+        <expected-linenumbers>7</expected-linenumbers>
         <expected-messages>
             <message>Result of 'Foo.bar()' is ignored.</message>
         </expected-messages>
         <code>
             <![CDATA[
+package foo.bar;
+
 import net.sourceforge.pmd.lang.java.rule.errorprone.unusedreturnvalue.CheckReturnValue;
 
 public class Foo {
@@ -745,6 +747,24 @@ public class Foo extends FileInputStream {
     }
 
     public void skip(int n) throws IOException {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Violation message when generics are used</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Result of 'Collection.size()' is ignored.</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.util.Collection;
+
+class Wildcard
+{
+    public static void foo(Collection < ? extends Wildcard[] > collection) {
+        collection.size();
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

Instead of
```
Result of 'java.util.Collection<capture#XXX of ? extends com.puppycrawl.tools.checkstyle.checks.whitespace.whitespacearound.Wildcard[]>.size()' is ignored.
```
the violation now is
```
Result of 'java.util.Collection.size()' is ignored.
```

## Related issues

- Fix #6967 

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

