### PR TITLE
[java] Fix #6965: AbstractClassWithoutAnyMethod false positive on derived abstract class

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -80,11 +80,13 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#5041](https://github.com/pmd/pmd/issues/5041): \[java] Parsing failed in ParseLock#doParse(): IndexOutOfBoundsException 
     * [#6768](https://github.com/pmd/pmd/issues/6768): \[java] Disambiguation IllegalStateException resolving a synthesized record accessor used as a call argument alongside an anonymous class
 * java-bestpractices
+    * [#1237](https://github.com/pmd/pmd/issues/1237): \[java] AbstractClassWithoutAnyMethod - Only detecting empty classes 
     * [#2033](https://github.com/pmd/pmd/issues/2033): \[jsp] NoClassAttribute rule is generating a false positive
     * [#5514](https://github.com/pmd/pmd/issues/5514): \[java] ExhaustiveSwitchHasDefault fails for non-exhaustive switch statements
     * [#5670](https://github.com/pmd/pmd/issues/5670): \[java] ExhaustiveSwitchHasDefault issue with final fields not initialized in constructor
     * [#6200](https://github.com/pmd/pmd/issues/6200): \[java] UnusedAssignment: False positive about the ++ unary operator
     * [#6611](https://github.com/pmd/pmd/issues/6611): \[java] UnnecessaryVarargsArrayCreation: false positive when removing the array creates overload ambiguity
+    * [#6965](https://github.com/pmd/pmd/issues/6965): \[java] AbstractClassWithoutAnyMethod False Positive on derived abstract class
 * java-codestyle
     * [#6958](https://github.com/pmd/pmd/issues/6958): \[java] BooleanGetMethodName should have the option to treat boolean wrapper type differently
     * [#6274](https://github.com/pmd/pmd/issues/6274): \[java] UselessParentheses: Treat parentheses around a ternary in the else-branch as clarifying, consistent with the then-branch.
@@ -98,7 +100,6 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
     * [#6925](https://github.com/pmd/pmd/issues/6925): \[java] ImmutableField: false positive on picocli annotated fields with default
-    * [#6965](https://github.com/pmd/pmd/issues/6965): \[java] AbstractClassWithoutAnyMethod false positive on derived abstract class
 * java-documentation
     * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -98,6 +98,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic
     * [#6881](https://github.com/pmd/pmd/issues/6881): \[java] CognitiveComplexity does not count switch expressions
     * [#6925](https://github.com/pmd/pmd/issues/6925): \[java] ImmutableField: false positive on picocli annotated fields with default
+    * [#6965](https://github.com/pmd/pmd/issues/6965): \[java] AbstractClassWithoutAnyMethod false positive on derived abstract class
 * java-documentation
     * [#6270](https://github.com/pmd/pmd/issues/6270): \[java] CommentSize: Skip file header comments.
 * java-errorprone

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -19,8 +19,6 @@ Rules that help you discover design issues.
 If an abstract class does not provide any methods, it may be acting as a simple data container
 that is not meant to be instantiated. In this case, it is probably better to use a private or
 protected constructor in order to prevent instantiation than make the class misleadingly abstract.
-This rule does not report abstract subclasses: if the parent type already declares abstract
-methods, the subclass must stay abstract and cannot be replaced by a private constructor.
         </description>
         <priority>1</priority>
         <properties>
@@ -28,8 +26,7 @@ methods, the subclass must stay abstract and cannot be replaced by a private con
                 <value>
 <![CDATA[
 //ClassDeclaration
-    [@Abstract = true() and @Interface = false()]
-    [not(ExtendsList)]
+    [@Abstract = true() and @Interface = false() and not(ExtendsList)]
     [ClassBody[not(ConstructorDeclaration | MethodDeclaration)]]
     [not(pmd-java:hasAnnotation('com.google.auto.value.AutoValue')
          or pmd-java:hasAnnotation('lombok.AllArgsConstructor')

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -19,6 +19,8 @@ Rules that help you discover design issues.
 If an abstract class does not provide any methods, it may be acting as a simple data container
 that is not meant to be instantiated. In this case, it is probably better to use a private or
 protected constructor in order to prevent instantiation than make the class misleadingly abstract.
+This rule does not report abstract subclasses: if the parent type already declares abstract
+methods, the subclass must stay abstract and cannot be replaced by a private constructor.
         </description>
         <priority>1</priority>
         <properties>
@@ -27,6 +29,7 @@ protected constructor in order to prevent instantiation than make the class misl
 <![CDATA[
 //ClassDeclaration
     [@Abstract = true() and @Interface = false()]
+    [not(ExtendsList)]
     [ClassBody[not(ConstructorDeclaration | MethodDeclaration)]]
     [not(pmd-java:hasAnnotation('com.google.auto.value.AutoValue')
          or pmd-java:hasAnnotation('lombok.AllArgsConstructor')

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
@@ -155,19 +155,6 @@ public abstract class SpecificBoo extends BaseFooType {
     </test-code>
 
     <test-code>
-        <description>#6965 derived abstract class whose parent already has abstract methods (nested)</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-abstract class AbstractSuperclass {
-    protected abstract void foo();
-}
-
-abstract class EmptySubclass extends AbstractSuperclass {
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
         <description>Verify location of violation</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>2-2</expected-linenumbers>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
@@ -142,7 +142,7 @@ abstract class RequiredArgs {
     </test-code>
 
     <test-code>
-        <description>[java] AbstractClassWithoutAnyMethod false positive on derived abstract class #6965</description>
+        <description>[java] AbstractClassWithoutAnyMethod false positive on derived abstract class #1237/#6965</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public abstract class BaseFooType {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
@@ -142,6 +142,32 @@ abstract class RequiredArgs {
     </test-code>
 
     <test-code>
+        <description>[java] AbstractClassWithoutAnyMethod false positive on derived abstract class #6965</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public abstract class BaseFooType {
+    public abstract Foo getFoo();
+}
+
+public abstract class SpecificBoo extends BaseFooType {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6965 derived abstract class whose parent already has abstract methods (nested)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+abstract class AbstractSuperclass {
+    protected abstract void foo();
+}
+
+abstract class EmptySubclass extends AbstractSuperclass {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Verify location of violation</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>2-2</expected-linenumbers>


### PR DESCRIPTION
## Describe the PR

`AbstractClassWithoutAnyMethod` flags an empty abstract class even when it extends a type that already has abstract methods. That class has to stay abstract, so the usual "use a private constructor" advice does not apply.

The XPath now skips classes with an `ExtendsList`, same idea as `AbstractClassWithoutAbstractMethod`.

## Related issues

- Fixes #1237
- Fixes #6965

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
