### PR TITLE
[java] Introduce JPackageSymbol

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
@@ -4,9 +4,11 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.document.FileLocation;
 import net.sourceforge.pmd.lang.document.TextRegion;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 
 /**
  * Package declaration at the top of a {@linkplain ASTCompilationUnit source file}.
@@ -20,9 +22,11 @@ import net.sourceforge.pmd.lang.document.TextRegion;
  * </pre>
  *
  */
-public final class ASTPackageDeclaration extends AbstractJavaNode implements Annotatable, ASTTopLevelDeclaration, JavadocCommentOwner {
+public final class ASTPackageDeclaration extends AbstractJavaNode implements Annotatable, ASTTopLevelDeclaration,
+        JavadocCommentOwner, SymbolDeclaratorNode {
 
     private TextRegion reportRegion;
+    private JPackageSymbol symbol;
 
     ASTPackageDeclaration(int id) {
         super(id);
@@ -57,5 +61,24 @@ public final class ASTPackageDeclaration extends AbstractJavaNode implements Ann
     public String getImage() {
         // the image was null before 7.0, best keep it that way
         return null;
+    }
+
+    void setSymbol(JPackageSymbol symbol) {
+        assert this.symbol == null : "Symbol was not null, already set to " + this.symbol + " by resolver, on node " + this;
+        this.symbol = symbol;
+    }
+
+    /**
+     * @since 7.27.0
+     */
+    @Override
+    public JPackageSymbol getSymbol() {
+        assert this.symbol != null : "Symbol was null, not set by resolver, on node " + this;
+        return this.symbol;
+    }
+
+    @Override
+    public NodeStream<ASTAnnotation> getDeclaredAnnotations() {
+        return asStream().firstChild(ASTModifierList.class).children(ASTAnnotation.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JElementSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JRecordComponentSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol;
@@ -68,6 +69,8 @@ public final class InternalApiBridge {
             ((ASTRecordComponentList) node).setSymbol((JConstructorSymbol) symbol);
         } else if (node instanceof ASTRecordComponent) {
             ((ASTRecordComponent) node).setSymbol((JRecordComponentSymbol) symbol);
+        } else if (node instanceof ASTPackageDeclaration) {
+            ((ASTPackageDeclaration) node).setSymbol((JPackageSymbol) symbol);
         } else {
             throw new AssertionError("Cannot set symbol " + symbol + " on node " + node);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JPackageSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JPackageSymbol.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.symbols;
+
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+
+/**
+ * @since 7.27.0
+ */
+public interface JPackageSymbol extends AnnotableSymbol,
+        BoundToNode<ASTPackageDeclaration> {
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
@@ -37,9 +37,7 @@ public interface SymbolResolver {
     /**
      * @since 7.27.0
      */
-    default @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
-        return null;
-    }
+    @Nullable JPackageSymbol resolvePackage(@NonNull String packageName);
 
     /**
      * Resolves a class symbol from its canonical name. Periods ('.') may
@@ -101,6 +99,18 @@ public interface SymbolResolver {
                 }
                 return null;
             }
+
+            @Override
+            public @Nullable JPackageSymbol resolvePackage(@NonNull String packageName) {
+                for (SymbolResolver resolver : stack) {
+                    JPackageSymbol symbol = resolver.resolvePackage(packageName);
+                    if (symbol != null) {
+                        return symbol;
+                    }
+                }
+                return null;
+            }
+
 
             @Override
             public void logStats() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolVisitor.java
@@ -71,4 +71,12 @@ public interface SymbolVisitor<R, P> {
         return visitLocal(sym, param);
     }
 
+    /**
+     * Delegates to {@link #visitSymbol(JElementSymbol, Object) visitSymbol}.
+     *
+     * @since 7.27.0
+     */
+    default R visitPackage(JPackageSymbol sym, P param) {
+        return visitSymbol(sym, param);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolToStrings.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolToStrings.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFormalParamSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JLocalVariableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JRecordComponentSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol;
@@ -71,6 +72,11 @@ public class SymbolToStrings {
         @Override
         public StringBuilder visitSymbol(JElementSymbol sym, StringBuilder builder) {
             throw new IllegalStateException("Unknown symbol " + sym.getClass());
+        }
+
+        @Override
+        public StringBuilder visitPackage(JPackageSymbol sym, StringBuilder param) {
+            return withImpl(param, "package", sym.getSimpleName());
         }
 
         @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
@@ -15,9 +15,9 @@ import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JModuleSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.Loader.FailedLoader;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.Loader.StreamLoader;
@@ -54,6 +54,7 @@ public class AsmSymbolResolver implements SymbolResolver {
     @Override
     public @Nullable JClassSymbol resolveClassFromBinaryName(@NonNull String binaryName) {
         AssertionUtil.requireParamNotNull("binaryName", binaryName);
+        AssertionUtil.assertValidJavaBinaryName(binaryName);
 
         String internalName = getInternalName(binaryName);
 
@@ -89,8 +90,16 @@ public class AsmSymbolResolver implements SymbolResolver {
     }
 
     @Override
-    public @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
-        return resolveClassFromBinaryName(packageName + ".package-info");
+    public @Nullable JPackageSymbol resolvePackage(@NonNull String packageName) {
+        String packageInfoClass = "package-info.class";
+        if (!packageName.isEmpty()) {
+            packageInfoClass = getInternalName(packageName) + "/" + packageInfoClass;
+        }
+        InputStream inputStream = classLoader.findResource(packageInfoClass);
+        if (inputStream != null) {
+            return new PackageStub(this, packageName, new StreamLoader(packageName, inputStream));
+        }
+        return null;
     }
 
     SignatureParser getSigParser() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/PackageStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/PackageStub.java
@@ -1,0 +1,98 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.symbols.internal.asm;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.pcollections.HashTreePSet;
+import org.pcollections.PSet;
+
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
+import net.sourceforge.pmd.lang.java.symbols.SymbolVisitor;
+import net.sourceforge.pmd.lang.java.symbols.SymbolicValue;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
+
+final class PackageStub implements JPackageSymbol, AnnotationOwner, AsmStub {
+    private final String packageName;
+    private final AsmSymbolResolver resolver;
+    private final ParseLock parseLock;
+    private PSet<SymbolicValue.SymAnnot> annotations = HashTreePSet.empty();
+
+    PackageStub(AsmSymbolResolver resolver, String packageName, @NonNull Loader loader) {
+        this.packageName = packageName;
+        this.resolver = resolver;
+
+        this.parseLock = new ParseLock.CheckedParseLock("PackageStub:" + packageName) {
+            @Override
+            protected boolean doParse() throws IOException {
+                try (InputStream instream = loader.getInputStream()) {
+                    if (instream != null) {
+                        ClassReader classReader = new ClassReader(instream);
+                        PackageStubBuilder builder = new PackageStubBuilder(PackageStub.this, resolver);
+                        classReader.accept(builder, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } catch (IOException e) {
+                    // add a bit more info to the exception
+                    throw new IOException("While loading package-info from " + loader, e);
+                }
+            }
+        };
+    }
+
+    @Override
+    public String getSimpleName() {
+        return packageName;
+    }
+
+    @Override
+    public AsmSymbolResolver getResolver() {
+        return resolver;
+    }
+
+    @Override
+    public TypeSystem getTypeSystem() {
+        return getResolver().getTypeSystem();
+    }
+
+    @Override
+    public <R, P> R acceptVisitor(SymbolVisitor<R, P> visitor, P param) {
+        return null;
+    }
+
+    @Override
+    public void addAnnotation(SymbolicValue.SymAnnot annot) {
+        annotations = annotations.plus(annot);
+    }
+
+    @Override
+    public PSet<SymbolicValue.SymAnnot> getDeclaredAnnotations() {
+        parseLock.ensureParsed();
+        return annotations;
+    }
+
+
+    private static final class PackageStubBuilder extends ClassVisitor {
+        private final PackageStub stub;
+        private final AsmSymbolResolver resolver;
+
+        PackageStubBuilder(PackageStub stub, AsmSymbolResolver resolver) {
+            super(AsmSymbolResolver.ASM_API_V);
+            this.stub = stub;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public AnnotationBuilderVisitor visitAnnotation(String descriptor, boolean visible) {
+            return new AnnotationBuilderVisitor(stub, resolver, visible, descriptor);
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstPackageSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstPackageSym.java
@@ -1,0 +1,25 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.symbols.internal.ast;
+
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
+import net.sourceforge.pmd.lang.java.symbols.SymbolVisitor;
+
+final class AstPackageSym extends AbstractAstAnnotableSym<ASTPackageDeclaration> implements JPackageSymbol {
+    AstPackageSym(ASTPackageDeclaration packageDeclaration, AstSymFactory factory) {
+        super(packageDeclaration, factory);
+    }
+
+    @Override
+    public String getSimpleName() {
+        return node.getName();
+    }
+
+    @Override
+    public <R, P> R acceptVisitor(SymbolVisitor<R, P> visitor, P param) {
+        return visitor.visitPackage(this, param);
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymFactory.java
@@ -6,12 +6,15 @@ package net.sourceforge.pmd.lang.java.symbols.internal.ast;
 
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.internal.JavaAstProcessor;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterOwnerSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
@@ -76,4 +79,7 @@ final class AstSymFactory {
         return new AstClassSym(klass, this, enclosing);
     }
 
+    JPackageSymbol setPackageSymbol(@NonNull ASTPackageDeclaration packageDeclaration) {
+        return new AstPackageSym(packageDeclaration, this);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
@@ -16,6 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTExecutableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.InternalApiBridge;
@@ -76,6 +77,12 @@ final class AstSymbolMakerVisitor extends JavaVisitorBase<AstSymFactory, Void> {
             || node.isEnumConstant()
             || node.isRecordComponent()
             || node.getParent() instanceof ASTFormalParameter);
+    }
+
+    @Override
+    public Void visit(ASTPackageDeclaration node, AstSymFactory data) {
+        data.setPackageSymbol(node);
+        return null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
@@ -11,9 +11,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JModuleSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
 
 /**
@@ -47,7 +47,7 @@ final class MapSymResolver implements SymbolResolver {
     }
 
     @Override
-    public @Nullable AnnotableSymbol resolvePackage(@NonNull String packageName) {
+    public @Nullable JPackageSymbol resolvePackage(@NonNull String packageName) {
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
@@ -24,13 +24,13 @@ import org.pcollections.HashTreePSet;
 import org.pcollections.PSet;
 
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
-import net.sourceforge.pmd.lang.java.symbols.AnnotableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFormalParamSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JLocalVariableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JModuleSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JPackageSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver;
@@ -409,12 +409,9 @@ public final class TypeSystem {
     /**
      * Returns a symbol for the pseudo-class representing a package (usually called "package-info.java")
      *
-     * Returns a AnnotableSymbol, since the only thing this is used for is to check for annotations - and
-     * to keep the option of introducing a JPackageSymbol later.
-     *
      * @since 7.27.0
      */
-    public @Nullable AnnotableSymbol getPackageSymbol(String packageName) {
+    public @Nullable JPackageSymbol getPackageSymbol(String packageName) {
         AssertionUtil.assertValidJavaPackageName(packageName);
 
         return resolver.resolvePackage(packageName);

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.symbols.*
 import net.sourceforge.pmd.lang.java.types.Substitution
@@ -543,6 +544,32 @@ class AstSymbolTests : ParserTestSpec({
             anonAnon::getEnclosingMethod shouldBe null
             initAnon::getEnclosingMethod shouldBe null
             staticInitAnon::getEnclosingMethod shouldBe null
+        }
+    }
+
+    parserTestContainer("Package symbols") {
+        doTest("package declaration only") {
+            val acu = parser.withProcessing().parse("""
+                package com.foo;
+            """)
+
+            val packageSym = acu.descendants(ASTPackageDeclaration::class.java)
+                .first()?.symbol!!
+            packageSym.simpleName shouldBe "com.foo"
+            packageSym.declaredAnnotations shouldBe emptyList()
+        }
+
+        doTest("package with annotations") {
+            val acu = parser.withProcessing().parse("""
+                @Deprecated
+                package com.foo;
+            """)
+
+            val packageSym = acu.descendants(ASTPackageDeclaration::class.java)
+                .first()?.symbol!!
+            packageSym.simpleName shouldBe "com.foo"
+            packageSym.declaredAnnotations.size shouldBe 1
+            packageSym.declaredAnnotations.first().simpleName shouldBe "Deprecated"
         }
     }
 })

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeSystemTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeSystemTest.kt
@@ -125,7 +125,11 @@ class TypeSystemTest : IntelliMarker, FunSpec({
     }
 
     test("Test getPackageSymbol") {
-        ts.getPackageSymbol("java.net")?.simpleName shouldBe "package-info"
+        ts.getPackageSymbol("java.net")?.simpleName shouldBe "java.net"
+    }
+
+    test("Test getPackageSymbol for unnamed (default) package") {
+        ts.getPackageSymbol("") shouldBe null
     }
 
     test("Test parameterize special types") {


### PR DESCRIPTION
## Describe the PR

This is a follow-up on #6916.

When updating #6859, the new AuxClasspathLoader correctly refused to load an absolute path like "/package-info.class". This path was created from the default/unnamed package "" and a pseudo-class "package-info", which is an invalid binaryName for classes.

So, I opted to just implement the JPackageSymbol in a similar way, we load module-infos.

## Related issues

- Refs #6916 
- Required for #6859

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

