### PR TITLE
chore: Fix AssertEqualsArgumentOrder

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStreamTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStreamTest.java
@@ -29,8 +29,8 @@ class CharStreamTest {
 
         assertThrows(EOFException.class, stream::readChar);
 
-        assertEquals(stream.getStartOffset(), 0);
-        assertEquals(stream.getEndOffset(), 0);
+        assertEquals(0, stream.getStartOffset());
+        assertEquals(0, stream.getEndOffset());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
@@ -47,7 +47,7 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
         assertEquals("dummyRuleset.xml", rs.getFileName());
 
         rs = new RuleSetLoader().loadFromResource(TEST_RULESET_1);
-        assertEquals(rs.getFileName(), TEST_RULESET_1, "wrong RuleSet file name");
+        assertEquals(TEST_RULESET_1, rs.getFileName(), "wrong RuleSet file name");
     }
 
     /**
@@ -803,7 +803,7 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
         assertTrue(r instanceof RuleReference, "Rule Reference");
         assertFalse(r.isDeprecated(), "Not deprecated");
         assertTrue(((RuleReference) r).getRule().isDeprecated(), "Original Rule Deprecated");
-        assertEquals(r.getName(), DEPRECATED_RULE_NAME, "Rule name");
+        assertEquals(DEPRECATED_RULE_NAME, r.getName(), "Rule name");
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
@@ -407,7 +407,7 @@ class IteratorUtilTest {
 
         int size = IteratorUtil.count(iter);
 
-        assertEquals(size, 3);
+        assertEquals(3, size);
         assertExhausted(iter);
     }
 
@@ -417,7 +417,7 @@ class IteratorUtilTest {
 
         int size = IteratorUtil.count(iter);
 
-        assertEquals(size, 0);
+        assertEquals(0, size);
     }
 
     @Test


### PR DESCRIPTION
## Describe the PR

Luckily, there were no false positives. So, this can be merged anytime.

## Related issues

- Refs pmd/build-tools#186

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

