### PR TITLE
[java] UnusedReturnValue: Fix description

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3588,7 +3588,7 @@ public class Test {
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedReturnValueRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedreturnvalue">
         <description>
-The UnusedReturnValue rule ensures that developers do not ignore the return values of methods where doing so value would likely be a bug.
+The UnusedReturnValue rule ensures that developers do not ignore the return values of methods where doing so would likely be a bug.
 
 This could be because you are treating a mutation-by-copy operation (like String.concat() or BigDecimal.add())
 as an in-place mutation, or forgetting to handle a critical validation result, error code, or stream.


### PR DESCRIPTION
## Describe the PR

This PR removes one word from the description of the new rule `UnusedReturnValue`.

## Related issues

- See #6916