### PR TITLE
chore(deps): bump build-tools from 39 to 40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>39</pmd.build-tools.version>
+        <pmd.build-tools.version>40</pmd.build-tools.version>
 
         <pmd-designer.version>7.19.3</pmd-designer.version>
 


### PR DESCRIPTION
## Describe the PR

Note - the build will probably fail, as new dogfood rules have been enabled (AssertEqualsArgumentOrder, UnnecessaryCast).

It enables to upgrade checkstyle.

## Related issues

- Refs #6944 
- Refs #6976 
- Refs #6910 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

