### PR TITLE
[java] Fix #6943: UnnecessaryCast: false positives related to generics

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -113,6 +113,7 @@ Note: Type data is not yet accessible in XPath rules or the PMD Rule Designer. T
     * [#6737](https://github.com/pmd/pmd/issues/6737): \[java] TooManyStaticImports: @<!-- -->SuppressWarnings("PMD.TooManyStaticImports") has stopped working
     * [#6846](https://github.com/pmd/pmd/issues/6846): \[java] VariableDeclarationUsageDistance: False positive with variables grouped at the top of a block
     * [#6867](https://github.com/pmd/pmd/issues/6867): \[java] UnnecessaryFullyQualifiedName: ContextedAssertionError: This should be unreachable: unknown constant ScopeInfo: MODULE_IMPORT
+    * [#6943](https://github.com/pmd/pmd/issues/6943): \[java] UnnecessaryCast: False positives related to generics
 * java-design
     * [#6714](https://github.com/pmd/pmd/issues/6714): \[java] Rename UseUtilityClass to InstantiableUtilityClass
     * [#6844](https://github.com/pmd/pmd/issues/6844): \[java] AvoidThrowingNewInstanceOfSameException: message inconsistent with logic

--- a/pmd-core/pmd-core-exclude-pmd.properties
+++ b/pmd-core/pmd-core-exclude-pmd.properties
@@ -1,2 +1,6 @@
 # ignore missing override for isEmpty() method, see #4291 #5299
 net.sourceforge.pmd.lang.document.Chars=MissingOverride
+
+# Temporary: #6982 / #6943. pmd-main still uses released PMD which FPs these raw casts.
+# Remove after the next PMD release.
+net.sourceforge.pmd.properties.AbstractPropertySource=UnnecessaryCast

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -171,7 +171,7 @@ public abstract class AbstractPropertySource implements PropertySource {
         Map<String, String> propertiesWithValues = new HashMap<>();
         propertyDescriptors.forEach(propertyDescriptor -> {
             Object value = propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
-            @SuppressWarnings({"unchecked", "rawtypes", "PMD.UnnecessaryCast"})
+            @SuppressWarnings({"unchecked", "rawtypes"})
             String valueString = ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
             propertiesWithValues.put(propertyDescriptor.name(), valueString);
         });

--- a/pmd-java/pmd-java-exclude-pmd.properties
+++ b/pmd-java/pmd-java-exclude-pmd.properties
@@ -2,3 +2,7 @@
 # is only necessary once 7.27.0 analyzes this code. The pmd-main check uses the released PMD,
 # for which it is an UnnecessaryWarningSuppression. Remove this after the 7.27.0 release, see #6941
 net.sourceforge.pmd.lang.java.rule.errorprone.NonSerializableClassRule=UnnecessaryWarningSuppression
+
+# Temporary: #6982 / #6943. pmd-main still uses released PMD which FPs these raw casts.
+# Remove after the next PMD release.
+net.sourceforge.pmd.lang.java.symbols.table.internal.JavaResolvers=UnnecessaryCast

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -27,6 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
@@ -38,6 +39,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.JTypeVar;
@@ -118,7 +120,18 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
             .anyMatch(fp -> isTypeExpression(fp.getTypeMirror(Substitution.EMPTY)));
         if (!generic) {
             JTypeMirror declaringType = methodType.getDeclaringType();
-            if (!isTypeExpression(methodType.getSymbol().getReturnType(Substitution.EMPTY))) {
+            JTypeMirror returnType = methodType.getSymbol().getReturnType(Substitution.EMPTY);
+            if (isTypeExpression(returnType)) {
+                // A raw cast changes a generic return type (e.g. PropertySerializer<T>
+                // becomes the raw type). That can be required for a chained call
+                // such as serializer().toString(value) on PropertyDescriptor<?>.
+                JTypeMirror coercionType = castExpr.getCastType().getTypeMirror();
+                ExprContext methodCtx = ((ASTMethodCall) castExpr.getParent()).getConversionContext();
+                if (coercionType.isRaw()
+                    && (methodCtx.isMissing() || methodCtx.hasKind(ExprContextKind.INVOCATION))) {
+                    return;
+                }
+            } else {
                 // declaring type of List<T>::size is List<T>, but since the return type
                 // is not generic, it's enough to check that operand is a List
                 declaringType = declaringType.getErasure();
@@ -134,7 +147,10 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
     }
 
     private boolean isCastUnnecessary(ASTCastExpression castExpr, @NonNull ExprContext context, JTypeMirror coercionType, JTypeMirror operandType) {
-        if (operandType.equals(coercionType)) {
+        if (isCastNarrowingEnclosingType(castExpr, coercionType)) {
+            // e.g. (Outer<S, ?>.Inner) outer.new Inner() when outer is Outer<? super S, ?>
+            return false;
+        } else if (operandType.equals(coercionType)) {
             return true;
         } else if (context.isMissing()) {
             // then we have fewer violation conditions
@@ -162,6 +178,32 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
      */
     private boolean isCastToRawType(JTypeMirror coercionType, JTypeMirror operandType) {
         return coercionType.isRaw() && !operandType.isRaw();
+    }
+
+    /**
+     * Whether this cast changes the enclosing type arguments of a
+     * qualified inner-class instance creation. The type of
+     * {@code outer.new Inner()} is determined by {@code outer}, so a
+     * cast to {@code Outer<S>.Inner} is required when {@code outer} is
+     * e.g. {@code Outer<? super S>} - even if type resolution reports
+     * the same type for the operand and the cast.
+     */
+    private static boolean isCastNarrowingEnclosingType(ASTCastExpression castExpr, JTypeMirror coercionType) {
+        ASTExpression operand = castExpr.getOperand();
+        if (!(operand instanceof ASTConstructorCall) || !(coercionType instanceof JClassType)) {
+            return false;
+        }
+        ASTConstructorCall ctor = (ASTConstructorCall) operand;
+        if (!ctor.isQualifiedInstanceCreation()) {
+            return false;
+        }
+        ASTExpression qualifier = ctor.getQualifier();
+        JClassType castEnclosing = ((JClassType) coercionType).getEnclosingType();
+        if (qualifier == null || castEnclosing == null) {
+            return false;
+        }
+        JTypeMirror qualifierType = qualifier.getTypeMirror();
+        return !TypeOps.isUnresolvedOrNull(qualifierType) && !qualifierType.isSubtypeOf(castEnclosing);
     }
 
     private void reportCast(ASTCastExpression castExpr, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
@@ -521,7 +521,7 @@ public final class JavaResolvers {
             return isAccessibleIn(nestRoot, accessPackageName, sym, isSubtype(access, sym.getEnclosingClass()));
         };
 
-        @SuppressWarnings({"unchecked", "PMD.UnnecessaryCast"})
+        @SuppressWarnings("unchecked")
         ShadowChainBuilder<S, ?>.ResolverBuilder builder = (ShadowChainBuilder<S, ?>.ResolverBuilder) classes.new ResolverBuilder();
 
         for (JClassType next : DIRECT_STRICT_SUPERTYPES.iterable(c)) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -1248,4 +1248,44 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#6943 False positive: raw cast then generic method used in a chain</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+interface PropertySerializer<T> {
+    String toString(T value);
+}
+
+interface PropertyDescriptor<T> {
+    PropertySerializer<T> serializer();
+}
+
+public class Foo {
+    // Dogfood: AbstractPropertySource#toStringMap
+    // PropertyDescriptor<?>.serializer() is PropertySerializer<?>, whose toString
+    // does not accept Object. The raw cast is required for the chained call.
+    String serialize(PropertyDescriptor<?> propertyDescriptor, Object value) {
+        return ((PropertyDescriptor) propertyDescriptor).serializer().toString(value);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6943 False positive: cast of qualified inner instance with different enclosing args</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class ShadowChainBuilder<S, I> {
+    public class ResolverBuilder { }
+
+    // Dogfood: JavaResolvers#getNamedMemberResolver
+    // classes.new ResolverBuilder() has type ShadowChainBuilder<? super S, ?>.ResolverBuilder
+    // which is not assignable to ShadowChainBuilder<S, ?>.ResolverBuilder.
+    ShadowChainBuilder<S, ?>.ResolverBuilder create(ShadowChainBuilder<? super S, ?> classes) {
+        return (ShadowChainBuilder<S, ?>.ResolverBuilder) classes.new ResolverBuilder();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -1273,6 +1273,28 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>#6943 False positive: raw cast passed as method argument (INVOCATION context)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+interface PropertySerializer<T> {
+    String toString(T value);
+}
+
+interface PropertyDescriptor<T> {
+    PropertySerializer<T> serializer();
+}
+
+public class Foo {
+    void take(PropertySerializer s) {}
+
+    void serialize(PropertyDescriptor<?> propertyDescriptor, Object value) {
+        take(((PropertyDescriptor) propertyDescriptor).serializer());
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>#6943 False positive: cast of qualified inner instance with different enclosing args</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

`UnnecessaryCast` reports two kinds of generic casts that do not compile if removed:

1. A raw cast used as the receiver of a method whose return type is generic, when that result is used in a chained call. Example from dogfood (`AbstractPropertySource`): `((PropertyDescriptor) propertyDescriptor).serializer().toString(value)` — on `PropertyDescriptor<?>`, `serializer()` is `PropertySerializer<?>` and `toString` does not accept `Object`.
2. A cast of a qualified inner-class instance creation that narrows the enclosing type arguments. Example from dogfood (`JavaResolvers`): `(ShadowChainBuilder<S, ?>.ResolverBuilder) classes.new ResolverBuilder()` when `classes` is `ShadowChainBuilder<? super S, ?>`.

The first case was reported by the method-call heuristic (added for #6029) because `serializer()` itself has no generic parameters. The second case is treated as a no-op when type resolution reports the same type for the operand and the cast; the qualifier's type is not a subtype of the enclosing type written in the cast, so the cast is required.

## Related issues

- Fixes #6943

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

### Tests

`./mvnw -pl pmd-java -am test -Dtest=UnnecessaryCastTest -Dsurefire.failIfNoSpecifiedTests=false` — **64 tests, 0 failures, 1 skipped** (Java 21).

The two new cases fail on unfixed `main` (1 violation each) and pass with this change. Existing method-call cases (`((List) o1).size()`, `((List) o1).get(0)` assigned to `Object`) still report.


Made with [Cursor](https://cursor.com)