### PR TITLE
[apex] Fix #6988: Add ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation rule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -18,7 +18,7 @@ public final class ASTAnnotationParameter extends AbstractApexNode.Single<Elemen
      * The {@code critical} modifier of the {@code @IsTest} annotation, used together with the
      * {@code RunRelevantTests} deployment test level. (Beta, Salesforce API v66.0+)
      *
-     * @since 7.14.0
+     * @since 7.27.0
      */
     public static final String CRITICAL = "critical";
 
@@ -26,7 +26,7 @@ public final class ASTAnnotationParameter extends AbstractApexNode.Single<Elemen
      * The {@code testFor} modifier of the {@code @IsTest} annotation, used together with the
      * {@code RunRelevantTests} deployment test level. (Beta, Salesforce API v66.0+)
      *
-     * @since 7.14.0
+     * @since 7.27.0
      */
     public static final String TEST_FOR = "testFor";
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -14,6 +14,22 @@ import com.google.summit.ast.modifier.ElementValue;
 public final class ASTAnnotationParameter extends AbstractApexNode.Single<ElementArgument> {
     public static final String SEE_ALL_DATA = "seeAllData";
 
+    /**
+     * The {@code critical} modifier of the {@code @IsTest} annotation, used together with the
+     * {@code RunRelevantTests} deployment test level. (Beta, Salesforce API v66.0+)
+     *
+     * @since 7.14.0
+     */
+    public static final String CRITICAL = "critical";
+
+    /**
+     * The {@code testFor} modifier of the {@code @IsTest} annotation, used together with the
+     * {@code RunRelevantTests} deployment test level. (Beta, Salesforce API v66.0+)
+     *
+     * @since 7.14.0
+     */
+    public static final String TEST_FOR = "testFor";
+
     ASTAnnotationParameter(ElementArgument elementArgument) {
         super(elementArgument);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -139,6 +139,7 @@ public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> 
             Document document = factory.newDocumentBuilder().parse(metaXmlPath.toFile());
             NodeList nodes = document.getElementsByTagName("apiVersion");
             if (nodes.getLength() == 0) {
+                LOG.debug("No apiVersion found in {}", metaXmlPath);
                 return null;
             }
             return Double.parseDouble(nodes.item(0).getTextContent().trim());

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -128,6 +128,7 @@ public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> 
         FileId fileId = getAstInfo().getTextDocument().getFileId();
         Path metaXmlPath = Paths.get(fileId.getAbsolutePath() + "-meta.xml");
         if (!Files.isRegularFile(metaXmlPath)) {
+            LOG.debug("File {} doesn't exist to read apiVersion", metaXmlPath);
             return null;
         }
         try {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -4,10 +4,23 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import net.sourceforge.pmd.lang.apex.ApexLanguageProcessor;
 import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileAnalysis;
@@ -24,8 +37,11 @@ import io.github.apexdevtools.api.Issue;
 
 public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> implements RootNode {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ASTApexFile.class);
+
     private final AstInfo<ASTApexFile> astInfo;
     private final @NonNull ApexMultifileAnalysis multifileAnalysis;
+    private Optional<Double> apiVersion;
 
     ASTApexFile(ParserTask task,
                 CompilationUnit compilationUnit,
@@ -87,5 +103,49 @@ public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> 
             return baseApexClass.getQualifiedName().toString();
         }
         return null;
+    }
+
+    /**
+     * Returns the Salesforce API version declared in this file's companion
+     * {@code *-meta.xml} descriptor (e.g. {@code Foo.cls-meta.xml}), if one
+     * exists and can be read.
+     *
+     * <p>Returns {@link Optional#empty()} when there is no on-disk companion
+     * metadata file (for example when analyzing in-memory source, as in most
+     * unit tests), when it can't be read, or when it has no {@code <apiVersion>}
+     * element. Callers should treat an empty result as "unknown", not as "low
+     * version".
+     *
+     * @since 7.27.0
+     */
+    public @NonNull Optional<Double> getApiVersion() {
+        if (apiVersion == null) {
+            apiVersion = Optional.ofNullable(readApiVersionFromMetaXml());
+        }
+        return apiVersion;
+    }
+
+    private Double readApiVersionFromMetaXml() {
+        FileId fileId = getAstInfo().getTextDocument().getFileId();
+        Path metaXmlPath = Paths.get(fileId.getAbsolutePath() + "-meta.xml");
+        if (!Files.isRegularFile(metaXmlPath)) {
+            return null;
+        }
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(false);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            Document document = factory.newDocumentBuilder().parse(metaXmlPath.toFile());
+            NodeList nodes = document.getElementsByTagName("apiVersion");
+            if (nodes.getLength() == 0) {
+                return null;
+            }
+            return Double.parseDouble(nodes.item(0).getTextContent().trim());
+        } catch (IOException | SAXException | ParserConfigurationException | NumberFormatException e) {
+            LOG.debug("Could not read apiVersion from {}: {}", metaXmlPath, e.toString());
+            return null;
+        }
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTApexFile.java
@@ -144,7 +144,7 @@ public final class ASTApexFile extends AbstractApexNode.Single<CompilationUnit> 
             }
             return Double.parseDouble(nodes.item(0).getTextContent().trim());
         } catch (IOException | SAXException | ParserConfigurationException | NumberFormatException e) {
-            LOG.debug("Could not read apiVersion from {}: {}", metaXmlPath, e.toString());
+            LOG.debug("Could not read apiVersion from {}: {}", metaXmlPath, e.toString(), e);
             return null;
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
@@ -12,6 +12,8 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
  * Apex unit test classes should declare either the {@code critical} or the {@code testFor} modifier
  * of the {@code @IsTest} annotation, so that their relevance for a {@code RunRelevantTests} deployment
  * is explicit rather than left entirely to Salesforce's automatic dependency detection.
+ *
+ * @since 7.27.0
  */
 public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule extends AbstractApexUnitTestRule {
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
@@ -1,0 +1,45 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotationParameter;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+
+/**
+ * Apex unit test classes should declare either the {@code critical} or the {@code testFor} modifier
+ * of the {@code @IsTest} annotation, so that their relevance for a {@code RunRelevantTests} deployment
+ * is explicit rather than left entirely to Salesforce's automatic dependency detection.
+ */
+public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule extends AbstractApexUnitTestRule {
+
+    @Override
+    public Object visit(final ASTUserClass node, final Object data) {
+        if (!isTestMethodOrClass(node)) {
+            return data;
+        }
+
+        checkForRunRelevantTestsAnnotation(node, data);
+        return super.visit(node, data);
+    }
+
+    private void checkForRunRelevantTestsAnnotation(final ASTUserClass node, final Object data) {
+        final ASTModifierNode modifierNode = node.firstChild(ASTModifierNode.class);
+
+        if (modifierNode != null) {
+            for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
+                if (parameter.hasName(ASTAnnotationParameter.CRITICAL) && parameter.getBooleanValue()) {
+                    return;
+                }
+                if (parameter.hasName(ASTAnnotationParameter.TEST_FOR)
+                        && parameter.getValue() != null && !parameter.getValue().isEmpty()) {
+                    return;
+                }
+            }
+        }
+
+        asCtx(data).addViolation(node);
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.apex.ast.ASTAnnotationParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
@@ -39,7 +40,9 @@ public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule extends A
         final ASTModifierNode modifierNode = node.firstChild(ASTModifierNode.class);
 
         if (modifierNode != null) {
-            for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
+            for (ASTAnnotationParameter parameter : modifierNode.children(ASTAnnotation.class)
+                    .filter(a -> "IsTest".equals(a.getName()))
+                    .children(ASTAnnotationParameter.class)) {
                 if (parameter.hasName(ASTAnnotationParameter.CRITICAL) && parameter.getBooleanValue()) {
                     return;
                 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule.java
@@ -15,6 +15,8 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
  */
 public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule extends AbstractApexUnitTestRule {
 
+    private static final double MIN_API_VERSION = 66.0;
+
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
         if (!isTestMethodOrClass(node)) {
@@ -26,6 +28,12 @@ public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule extends A
     }
 
     private void checkForRunRelevantTestsAnnotation(final ASTUserClass node, final Object data) {
+        // the 'critical'/'testFor' modifiers are only available starting with API v66.0; if the
+        // class's api version is known and older than that, it can't use them, so don't flag it
+        if (node.getRoot().getApiVersion().map(version -> version < MIN_API_VERSION).orElse(false)) {
+            return;
+        }
+
         final ASTModifierNode modifierNode = node.firstChild(ASTModifierNode.class);
 
         if (modifierNode != null) {

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -102,6 +102,52 @@ private class TestRunAs {
         </example>
     </rule>
 
+    <rule name="ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation"
+          language="apex"
+          since="7.14.0"
+          message="Apex unit test classes should have either the 'critical' or the 'testFor' modifier of the @IsTest annotation"
+          class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#apexunittestclassshouldhaverunrelevanttestsannotation">
+        <description>
+Apex unit test classes should declare either `@IsTest(critical=true)` or `@IsTest(testFor='...')` (Beta, Salesforce
+API v66.0+), used together with the `RunRelevantTests` deployment test level. Without one of these modifiers, a test
+class relies entirely on Salesforce's automatic dependency detection to decide whether it runs during a
+`RunRelevantTests` deployment. For test classes covering critical paths, or classes that exercise code reached only
+through dynamic mechanisms (e.g. `Type.forName`, metadata-driven routing/dispatch), automatic detection can miss the
+dependency, and the test class may silently be skipped during a deployment even though the code it protects changed.
+
+See more here: [IsTest Annotation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation_isTest.htm)
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+@isTest
+private class OpportunityEODTest { // not good, no 'critical' or 'testFor' modifier
+    @isTest
+    static void validatesOrgWideBehavior() {
+        // ...
+    }
+}
+
+@isTest(critical=true) // good, explicitly marked as always relevant
+private class OpportunityEODTest {
+    @isTest
+    static void validatesOrgWideBehavior() {
+        // ...
+    }
+}
+
+@isTest(testFor='ApexClass:InvoiceEngine, ApexTrigger:InvoiceTrigger') // good, explicitly tied to its dependencies
+private class InvoiceDynamicFlowTests {
+    @isTest
+    static void validatesDynamicInvocationPath() {
+        // ...
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="ApexUnitTestMethodShouldHaveIsTestAnnotation"
           since="6.13.0"
           language="apex"

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -104,7 +104,7 @@ private class TestRunAs {
 
     <rule name="ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation"
           language="apex"
-          since="7.14.0"
+          since="7.27.0"
           message="Apex unit test classes should have either the 'critical' or the 'testFor' modifier of the @IsTest annotation"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#apexunittestclassshouldhaverunrelevanttestsannotation">
@@ -115,6 +115,9 @@ class relies entirely on Salesforce's automatic dependency detection to decide w
 `RunRelevantTests` deployment. For test classes covering critical paths, or classes that exercise code reached only
 through dynamic mechanisms (e.g. `Type.forName`, metadata-driven routing/dispatch), automatic detection can miss the
 dependency, and the test class may silently be skipped during a deployment even though the code it protects changed.
+
+Classes whose `meta.xml` declares an API version older than 66.0 are not flagged, since these modifiers aren't
+available to them. Classes whose API version couldn't be determined are still flagged.
 
 See more here: [IsTest Annotation](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation_isTest.htm)
         </description>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
@@ -15,14 +15,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileTestSupport;
 import net.sourceforge.pmd.reporting.Report;
-import net.sourceforge.pmd.test.PmdRuleTst;
 
 /**
  * Tests that {@link ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule} takes the class's
  * {@code apiVersion} (read from its companion {@code -meta.xml} file) into account. This requires
  * real files on disk, so it can't be expressed with the usual in-memory XML-based rule tests.
  */
-class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest extends PmdRuleTst {
+class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest {
 
     private static final String TEST_RESOURCES_BASE =
             "src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/";

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest.java
@@ -1,0 +1,59 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileTestSupport;
+import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+/**
+ * Tests that {@link ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationRule} takes the class's
+ * {@code apiVersion} (read from its companion {@code -meta.xml} file) into account. This requires
+ * real files on disk, so it can't be expressed with the usual in-memory XML-based rule tests.
+ */
+class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationApiVersionTest extends PmdRuleTst {
+
+    private static final String TEST_RESOURCES_BASE =
+            "src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/";
+
+    @TempDir
+    private Path tempDir;
+
+    /**
+     * The class has no 'critical'/'testFor' modifier, but its meta.xml declares an API version
+     * older than 66.0, where these modifiers aren't available. It should not be flagged.
+     */
+    @Test
+    void lowApiVersionIsNotFlagged() throws IOException {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "lowApiVersion"));
+        assertEquals(0, report.getViolations().size(),
+                "Expected no violation when the class's API version is below 66.0");
+    }
+
+    /**
+     * Same class, but its meta.xml declares an API version of 66.0 or above, where the
+     * 'critical'/'testFor' modifiers are available. It should be flagged.
+     */
+    @Test
+    void highApiVersionIsFlagged() throws IOException {
+        Report report = runRule(Paths.get(TEST_RESOURCES_BASE + "highApiVersion"));
+        assertEquals(1, report.getViolations().size(),
+                "Expected a violation when the class's API version is 66.0 or above");
+    }
+
+    private Report runRule(Path testProjectDir) throws IOException {
+        return ApexMultifileTestSupport.runRule(tempDir, testProjectDir, "bestpractices",
+                "ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation");
+    }
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
 import net.sourceforge.pmd.test.PmdRuleTst;
 
-public class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest extends PmdRuleTst {
+class ApexUnitTestClassShouldHaveRunRelevantTestsAnnotationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/sfdx-project.json
@@ -1,0 +1,9 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/src/SampleTest.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/src/SampleTest.cls
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+@isTest
+private class SampleTest {
+
+    @isTest
+    static void validatesOrgWideBehavior() {
+        System.assert(true);
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/src/SampleTest.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/highApiVersion/src/SampleTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/sfdx-project.json
@@ -1,0 +1,9 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ],
+  "namespace": "test_ns"
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/src/SampleTest.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/src/SampleTest.cls
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+@isTest
+private class SampleTest {
+
+    @isTest
+    static void validatesOrgWideBehavior() {
+        System.assert(true);
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/src/SampleTest.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/RunRelevantTestsApiVersion/lowApiVersion/src/SampleTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test-data xmlns="http://pmd.sourceforge.net/rule-tests" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
    <test-code>
       <description>Problematic apex unit test - no critical or testFor modifier</description>
@@ -23,6 +24,24 @@ private class OpportunityEODTest {
       <expected-problems>0</expected-problems>
       <code>
          <![CDATA[
+@isTest(critical=true)
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Apex unit test class using critical=true with extra annotation</description>
+      <expected-problems>0</expected-problems>
+      <code>
+         <![CDATA[
+@Deprecated
 @isTest(critical=true)
 private class OpportunityEODTest {
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
@@ -53,7 +53,7 @@ private class InvoiceDynamicFlowTests {
    </test-code>
 
    <test-code>
-      <description>ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation assumes APEX is case sensitive for modifier names</description>
+      <description>Modifier names are matched case-insensitively, so CRITICAL=true still counts as 'critical'</description>
       <expected-problems>0</expected-problems>
       <code>
          <![CDATA[

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+   <test-code>
+      <description>Problematic apex unit test - no critical or testFor modifier</description>
+      <expected-problems>1</expected-problems>
+      <code>
+         <![CDATA[
+@isTest
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Apex unit test class using critical=true</description>
+      <expected-problems>0</expected-problems>
+      <code>
+         <![CDATA[
+@isTest(critical=true)
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Apex unit test class using testFor</description>
+      <expected-problems>0</expected-problems>
+      <code>
+         <![CDATA[
+@isTest(testFor='ApexClass:InvoiceEngine, ApexTrigger:InvoiceTrigger')
+private class InvoiceDynamicFlowTests {
+
+   @isTest
+   static void validatesDynamicInvocationPath() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation assumes APEX is case sensitive for modifier names</description>
+      <expected-problems>0</expected-problems>
+      <code>
+         <![CDATA[
+@isTest(CRITICAL=true)
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Apex unit test class explicitly setting critical=false is still flagged</description>
+      <expected-problems>1</expected-problems>
+      <code>
+         <![CDATA[
+@isTest(critical=false)
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Apex unit test class combined with seeAllData, missing critical/testFor</description>
+      <expected-problems>1</expected-problems>
+      <code>
+         <![CDATA[
+@isTest(seeAllData=false)
+private class OpportunityEODTest {
+
+   @isTest
+   static void validatesOrgWideBehavior() {
+      System.assert(true);
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+
+   <test-code>
+      <description>Not a test class - not flagged</description>
+      <expected-problems>0</expected-problems>
+      <code>
+         <![CDATA[
+private class OpportunityEOD {
+
+   static void run() {
+      System.debug('running');
+   }
+}
+        ]]>
+      </code>
+   </test-code>
+</test-data>


### PR DESCRIPTION

<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

- Adds a new Apex best practice rule `ApexUnitTestClassShouldHaveRunRelevantTestsAnnotation` that flags test classes missing either the `critical` or `testFor` modifier on the `@IsTest` annotation.
- These modifiers are required to opt in to Salesforce's `RunRelevantTests` deployment test level (API v66.0+, Beta).
- Classes whose companion `*-meta.xml` declares an API version older than 66.0 are not flagged, since the modifiers aren't available to them.
- Classes whose API version could not be determined are still flagged (fail-safe).

## Related issues

- Fix #6988 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

