### PR TITLE
[java] Fix #5732: UnnecessaryCast false positive for package-private members

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,7 +26,7 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 * java-codestyle
-    * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast: False positive for package-private members on subclasses in another package
+    * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 
 
 ### 🚨️ API Changes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,9 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* java-codestyle
+    * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast: False positive for package-private members on subclasses in another package
+
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -110,8 +110,8 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
             // If we remove the cast, even if it might compile,
             // the object will not implement SubItf anymore.
         } else if (isCastRequiredForMemberAccess(castExpr, operandType)) {
-            // Package-private members are not inherited by subclasses in
-            // another package, so the cast is required to select the member.
+            // Package-private members are not accessible on a subtype in
+            // a different package, so the cast is required to select the member.
             return null;
         } else if (isCastUnnecessary(castExpr, context, coercionType, operandType)) {
             reportCast(castExpr, data);
@@ -291,10 +291,9 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
 
     /**
      * Whether this cast is required because it selects a package-private
-     * member that is not inherited by the operand type. Subclasses in a
-     * different package do not inherit package-private methods/fields, so
-     * {@code ((Super) sub).packagePrivate()} cannot be rewritten as
-     * {@code sub.packagePrivate()}.
+     * member that is not accessible on the operand type. When the operand
+     * type is in a different package, {@code ((Super) sub).packagePrivate()}
+     * cannot be rewritten as {@code sub.packagePrivate()}.
      *
      * @see <a href="https://github.com/pmd/pmd/issues/5732">#5732</a>
      */
@@ -319,8 +318,9 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
     }
 
     /**
-     * Public/protected members are inherited; package-private members are
-     * only members of types in the same package as the declaration.
+     * Public/protected members are accessible regardless of package;
+     * package-private members are only accessible on types in the same
+     * package as the declaration.
      */
     private static boolean isPackagePrivateMemberAccessibleOn(JAccessibleElementSymbol member,
                                                               JTypeMirror operandType) {
@@ -328,11 +328,11 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
         if (access != 0) {
             return true;
         }
-        if (!(operandType instanceof JClassType) || TypeOps.isUnresolvedOrNull(operandType)) {
+        if (!(operandType instanceof JClassType)) {
             return true;
         }
         JClassSymbol operandSym = ((JClassType) operandType).getSymbol();
-        return operandSym != null && member.getPackageName().equals(operandSym.getPackageName());
+        return member.getPackageName().equals(operandSym.getPackageName());
     }
 
     private static @Nullable ASTLambdaExpression getLambdaParent(ASTCastExpression castExpr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -19,6 +19,7 @@ import static net.sourceforge.pmd.lang.java.ast.BinaryOp.SUB;
 import static net.sourceforge.pmd.lang.java.ast.BinaryOp.XOR;
 import static net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils.isInfixExprWithOperator;
 
+import java.lang.reflect.Modifier;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
@@ -39,6 +41,9 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.JAccessibleElementSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
@@ -104,6 +109,10 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
             // Eg `SuperItf obj = (SubItf) ()-> {};`
             // If we remove the cast, even if it might compile,
             // the object will not implement SubItf anymore.
+        } else if (isCastRequiredForMemberAccess(castExpr, operandType)) {
+            // Package-private members are not inherited by subclasses in
+            // another package, so the cast is required to select the member.
+            return null;
         } else if (isCastUnnecessary(castExpr, context, coercionType, operandType)) {
             reportCast(castExpr, data);
         } else if (castExpr.getParent() instanceof ASTMethodCall
@@ -277,6 +286,53 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
 
         }
         return false;
+    }
+
+
+    /**
+     * Whether this cast is required because it selects a package-private
+     * member that is not inherited by the operand type. Subclasses in a
+     * different package do not inherit package-private methods/fields, so
+     * {@code ((Super) sub).packagePrivate()} cannot be rewritten as
+     * {@code sub.packagePrivate()}.
+     *
+     * @see <a href="https://github.com/pmd/pmd/issues/5732">#5732</a>
+     */
+    private boolean isCastRequiredForMemberAccess(ASTCastExpression castExpr, JTypeMirror operandType) {
+        JavaNode parent = castExpr.getParent();
+        if (parent instanceof ASTMethodCall) {
+            ASTMethodCall call = (ASTMethodCall) parent;
+            if (call.getQualifier() != castExpr || call.getOverloadSelectionInfo().isFailed()) {
+                return false;
+            }
+            return !isPackagePrivateMemberAccessibleOn(call.getMethodType().getSymbol(), operandType);
+        }
+        if (parent instanceof ASTFieldAccess) {
+            ASTFieldAccess access = (ASTFieldAccess) parent;
+            if (access.getQualifier() != castExpr) {
+                return false;
+            }
+            JFieldSymbol field = access.getReferencedSym();
+            return field != null && !isPackagePrivateMemberAccessibleOn(field, operandType);
+        }
+        return false;
+    }
+
+    /**
+     * Public/protected members are inherited; package-private members are
+     * only members of types in the same package as the declaration.
+     */
+    private static boolean isPackagePrivateMemberAccessibleOn(JAccessibleElementSymbol member,
+                                                              JTypeMirror operandType) {
+        int access = member.getModifiers() & (Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE);
+        if (access != 0) {
+            return true;
+        }
+        if (!(operandType instanceof JClassType) || TypeOps.isUnresolvedOrNull(operandType)) {
+            return true;
+        }
+        JClassSymbol operandSym = ((JClassType) operandType).getSymbol();
+        return operandSym != null && member.getPackageName().equals(operandSym.getPackageName());
     }
 
     private static @Nullable ASTLambdaExpression getLambdaParent(ASTCastExpression castExpr) {

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessarycast/PackagePrivateSuper.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessarycast/PackagePrivateSuper.java
@@ -1,0 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast;
+
+public class PackagePrivateSuper {
+
+    String packagePrivate() {
+        return "pkg";
+    }
+
+    public String publicMethod() {
+        return "pub";
+    }
+
+    String packagePrivateField = "field";
+}

--- a/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessarycast/other/PackagePrivateSub.java
+++ b/pmd-java/src/test/java-resources/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessarycast/other/PackagePrivateSub.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast.other;
+
+import net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast.PackagePrivateSuper;
+
+public class PackagePrivateSub extends PackagePrivateSuper {
+
+    public String extra() {
+        return "extra";
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -1310,4 +1310,77 @@ public class ShadowChainBuilder<S, I> {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5732 False positive: cast required to call package-private method on subclass from another package</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast;
+
+import net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast.other.PackagePrivateSub;
+
+public class Caller {
+    String call(PackagePrivateSub sub) {
+        // Package-private methods are not inherited by subclasses in another package.
+        return ((PackagePrivateSuper) sub).packagePrivate();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5732 False positive: cast required to access package-private field on subclass from another package</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast;
+
+import net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast.other.PackagePrivateSub;
+
+public class Caller {
+    String call(PackagePrivateSub sub) {
+        return ((PackagePrivateSuper) sub).packagePrivateField;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5732 Still flag unnecessary cast when calling a public method on a subclass from another package</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast;
+
+import net.sourceforge.pmd.lang.java.rule.codestyle.unnecessarycast.other.PackagePrivateSub;
+
+public class Caller {
+    String call(PackagePrivateSub sub) {
+        return ((PackagePrivateSuper) sub).publicMethod();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5732 Still flag unnecessary cast when subclass is in the same package</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>13</expected-linenumbers>
+        <code><![CDATA[
+package same;
+
+class Super {
+    String packagePrivate() {
+        return "pkg";
+    }
+}
+
+class Sub extends Super {}
+
+public class Caller {
+    String call(Sub sub) {
+        return ((Super) sub).packagePrivate();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #5732

Package-private methods and fields are not inherited by subclasses in another package, so a cast to the declaring type is required to access them.

`UnnecessaryCast` was treating any subtype cast as removable, including `((Super) sub).packagePrivate()`. Public members and same-package subclasses are still flagged.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)