### PR TITLE
[java] ExhaustiveSwitchHasDefault: list missing cases in the violation

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* java-bestpractices
+    * [#6984](https://github.com/pmd/pmd/issues/6984): \[java] ExhaustiveSwitchHasDefault: Improve violation message to list missing cases
 * java-codestyle
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultRule.java
@@ -4,8 +4,17 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
@@ -13,14 +22,22 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLike;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTTypePattern;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
 import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * @since 7.10.0 (as XPath) / 7.27.0 (as Java)
  */
 public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
+
+    static final int MAX_NAMED_CASES = 3;
+
     public ExhaustiveSwitchHasDefaultRule() {
         super(ASTSwitchExpression.class, ASTSwitchStatement.class);
     }
@@ -40,7 +57,15 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
     private void visitSwitchLike(ASTSwitchLike node, RuleContext ctx) {
         if (node.isExhaustive() && node.hasDefaultCase()) {
             if (!defaultBranchIsNecessary(node)) {
-                ctx.addViolation(node);
+                List<String> missing = missingCases(node);
+                if (missing.isEmpty()
+                        && node instanceof ASTSwitchExpression
+                        && node.getDefaultCase() instanceof ASTSwitchArrowBranch) {
+                    ctx.addViolationWithMessage(node,
+                            "Remove default case to make sure compiler keeps checking that all cases are present.");
+                } else {
+                    ctx.addViolation(node, formatMissingCases(missing));
+                }
             } else if (!branchJustThrows(node.getDefaultCase())) {
                 ctx.addViolationWithMessage(node, "The switch block is exhaustive. The default case should only throw, nothing else.");
             }
@@ -78,5 +103,68 @@ public class ExhaustiveSwitchHasDefaultRule extends AbstractJavaRulechainRule {
                 .filter(expr -> expr.getReferencedSym() != null)
                 .filter(expr -> expr.getReferencedSym().isFinal())
                 .any(JavaAstUtils::isVarAccessStrictlyWrite);
+    }
+
+    // visible for testing
+    /* private */ static List<String> missingCases(ASTSwitchLike node) {
+        JTypeDeclSymbol symbol = node.getTestedExpression().getTypeMirror().getSymbol();
+        if (!(symbol instanceof JClassSymbol)) {
+            return Collections.emptyList();
+        }
+        JClassSymbol classSymbol = (JClassSymbol) symbol;
+        Set<String> covered = coveredCaseNames(node);
+        List<String> missing = new ArrayList<>();
+        if (classSymbol.isEnum()) {
+            for (JFieldSymbol constant : classSymbol.getEnumConstants()) {
+                if (!covered.contains(constant.getSimpleName())) {
+                    missing.add(constant.getSimpleName());
+                }
+            }
+        } else if (classSymbol.isSealed()) {
+            for (JClassSymbol subtype : classSymbol.getPermittedSubtypes()) {
+                if (!covered.contains(subtype.getSimpleName())) {
+                    missing.add(subtype.getSimpleName());
+                }
+            }
+        }
+        Collections.sort(missing);
+        return missing;
+    }
+
+    private static Set<String> coveredCaseNames(ASTSwitchLike node) {
+        Set<String> names = new HashSet<>();
+        for (ASTSwitchBranch branch : node.getBranches()) {
+            for (ASTExpression expr : branch.getLabel().getExprList()) {
+                if (expr instanceof ASTNullLiteral) {
+                    continue;
+                }
+                if (expr instanceof ASTVariableAccess) {
+                    names.add(((ASTVariableAccess) expr).getName());
+                } else if (expr instanceof ASTFieldAccess) {
+                    names.add(((ASTFieldAccess) expr).getName());
+                }
+            }
+            for (ASTTypePattern pattern : branch.getLabel().children(ASTTypePattern.class)) {
+                JTypeDeclSymbol typeSym = pattern.getTypeNode().getTypeMirror().getSymbol();
+                if (typeSym instanceof JClassSymbol) {
+                    names.add(typeSym.getSimpleName());
+                }
+            }
+        }
+        return names;
+    }
+
+    // visible for testing
+    /* private */ static String formatMissingCases(List<String> names) {
+        if (names.isEmpty()) {
+            return "";
+        }
+        boolean truncated = names.size() > MAX_NAMED_CASES;
+        List<String> shown = truncated ? names.subList(0, MAX_NAMED_CASES) : names;
+        String joined = String.join(", ", shown);
+        if (truncated) {
+            joined += ", ...";
+        }
+        return " (" + joined + ")";
     }
 }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -614,7 +614,7 @@ class ColorTester {
     <rule name="ExhaustiveSwitchHasDefault"
           language="java"
           since="7.10.0"
-          message="The switch block is exhaustive even without the default case"
+          message="Replace default case with explicit cases{0} to make sure compiler keeps checking that all cases are present."
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#exhaustiveswitchhasdefault">
         <description>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -6,8 +6,13 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.branchJustThrows;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchIsNecessary;
+import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.formatMissingCases;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -135,6 +140,24 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
 
             assertFalse(defaultBranchIsNecessary(switchLike));
+        }
+    }
+
+    @Nested
+    class FormatMissingCases {
+        @Test
+        void emptyListOmitsParentheses() {
+            assertEquals("", formatMissingCases(Collections.emptyList()));
+        }
+
+        @Test
+        void singleName() {
+            assertEquals(" (NEW)", formatMissingCases(Collections.singletonList("NEW")));
+        }
+
+        @Test
+        void truncatesAfterThreeNames() {
+            assertEquals(" (A, B, C, ...)", formatMissingCases(Arrays.asList("A", "B", "C", "D", "E")));
         }
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.branchJustThrows;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.defaultBranchIsNecessary;
 import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.formatMissingCases;
+import static net.sourceforge.pmd.lang.java.rule.bestpractices.ExhaustiveSwitchHasDefaultRule.missingCases;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,6 +141,54 @@ class ExhaustiveSwitchHasDefaultTest extends PmdRuleTst {
             ASTSwitchLike switchLike = root.descendants(ASTSwitchStatement.class).first();
 
             assertFalse(defaultBranchIsNecessary(switchLike));
+        }
+    }
+
+    @Nested
+    class MissingCases {
+        @Test
+        @DisplayName("Enum switch lists constants only handled by default")
+        void testEnumMissingConstant() {
+            ASTCompilationUnit root = java.parse("public class Foo { enum State { NEW, ACTIVE, DONE, VOID } static String apply(State state) { return switch (state) { case ACTIVE -> \"active\"; case DONE -> \"done\"; case VOID -> \"void\"; default -> \"x\"; }; } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchLike.class).first();
+
+            assertEquals(Collections.singletonList("NEW"), missingCases(switchLike));
+        }
+
+        @Test
+        @DisplayName("Multiple missing enum constants are sorted")
+        void testEnumMissingConstantsAreSorted() {
+            ASTCompilationUnit root = java.parse("public class Foo { enum State { NEW, ACTIVE, DONE, VOID } void apply(State state) { switch (state) { case ACTIVE -> System.out.println(\"a\"); default -> System.out.println(\"x\"); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchLike.class).first();
+
+            assertEquals(Arrays.asList("DONE", "NEW", "VOID"), missingCases(switchLike));
+        }
+
+        @Test
+        @DisplayName("Sealed type switch lists uncovered permitted subtypes")
+        void testSealedMissingSubtype() {
+            ASTCompilationUnit root = java.parse("sealed interface Foo { final class A implements Foo {} record B() implements Foo {} default void doSomething(Foo foo) { switch (foo) { case A a -> System.out.println(\"a\"); default -> System.out.println(\"x\"); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchLike.class).first();
+
+            assertEquals(Collections.singletonList("B"), missingCases(switchLike));
+        }
+
+        @Test
+        @DisplayName("Fully covered enum has no missing cases")
+        void testAllCovered() {
+            ASTCompilationUnit root = java.parse("public class Foo { enum MyEnum { A, B } void doSomething(MyEnum e) { switch(e) { case A -> System.out.println(\"a\"); case B -> System.out.println(\"b\"); default -> System.out.println(\"x\"); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchLike.class).first();
+
+            assertEquals(Collections.emptyList(), missingCases(switchLike));
+        }
+
+        @Test
+        @DisplayName("Non-enum, non-sealed selector has no named missing cases")
+        void testNonClassSelector() {
+            ASTCompilationUnit root = java.parse("public class Foo { void doSomething(int i) { switch(i) { case 1 -> System.out.println(\"a\"); default -> System.out.println(\"x\"); } } }");
+            ASTSwitchLike switchLike = root.descendants(ASTSwitchLike.class).first();
+
+            assertEquals(Collections.emptyList(), missingCases(switchLike));
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ExhaustiveSwitchHasDefault.xml
@@ -42,7 +42,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>The switch block is exhaustive even without the default case</message>
+            <message>Replace default case with explicit cases to make sure compiler keeps checking that all cases are present.</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -81,6 +81,9 @@ sealed interface Foo {
         <description>Exhaustive Switch with sealed classes - with default: nok</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Replace default case with explicit cases to make sure compiler keeps checking that all cases are present.</message>
+        </expected-messages>
         <code><![CDATA[
 sealed interface Foo {
     final class A implements Foo {}
@@ -194,4 +197,51 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Exhaustive switch expression with unused default: remove it</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Remove default case to make sure compiler keeps checking that all cases are present.</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+    enum MyEnum { A, B };
+
+    String name(MyEnum e) {
+        return switch (e) {
+            case A -> "a";
+            case B -> "b";
+            default -> "unnecessary default";
+        };
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#6984 list the enum constant only handled by default</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Replace default case with explicit cases (NEW) to make sure compiler keeps checking that all cases are present.</message>
+        </expected-messages>
+        <code><![CDATA[
+public final class Reproducer {
+    enum State { NEW, ACTIVE, DONE, VOID }
+
+    static String apply(State state) {
+        return switch (state) {
+            case ACTIVE -> "active";
+            case DONE -> "done";
+            case VOID -> "void";
+            case null, default -> throw new IllegalStateException("unsupported: " + state);
+        };
+    }
+}
+]]></code>
+        <source-type>java 21</source-type>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

ExhaustiveSwitchHasDefault used to say the switch was exhaustive even without default. That read like a false positive when a constant (NEW in the issue) only lived in `default`.

The message is now:

Replace default case with explicit cases (NEW) to make sure compiler keeps checking that all cases are present.

If nothing is missing, the parenthetical is dropped. More than three names get truncated with `...`.

## Related issues

- Fix #6984

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
