### PR TITLE
chore(deps): bump io.github.apex-dev-tools:apex-parser from 5.1.0 to 5.2.0

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -96,12 +96,12 @@
         <dependency>
             <groupId>io.github.apex-dev-tools</groupId>
             <artifactId>apex-parser</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.adangel</groupId>
             <artifactId>summit-ast</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.apex-dev-tools</groupId>


### PR DESCRIPTION
## Describe the PR

Note that this updates the grammar to be more strict and it doesn't allow some invalid syntax around Annotations anymore. It also fixes some bugs in the grammar.

For details see https://github.com/apex-dev-tools/apex-parser/releases/tag/v5.2.0

Due to the grammar change, an updated summit-ast 3.1.0 is required.

## Related issues

- Closes #7000

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

