### PR TITLE
[apex] Add ApexSemanticErrors rule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrorsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrorsRule.java
@@ -1,0 +1,107 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTApexFile;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.document.TextRange2d;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+import io.github.apexdevtools.api.Issue;
+import io.github.apexdevtools.api.IssueLocation;
+
+/**
+ * Reports semantic errors found by the Apex Language Server multifile analysis.
+ */
+public class ApexSemanticErrorsRule extends AbstractApexRule { // NOPMD - this rule intentionally runs once per file
+
+    @Override
+    public Object visit(ASTApexFile node, Object data) {
+        RuleContext context = asCtx(data);
+        Set<String> reportedIssues = new HashSet<>();
+
+        for (Issue issue : node.getGlobalIssues()) {
+            if (!Boolean.TRUE.equals(issue.isError()) || !belongsToFile(issue, node)) {
+                continue;
+            }
+
+            FileLocation location = toFileLocation(node, issue.fileLocation());
+            String deduplicationKey = deduplicationKey(issue, location);
+            if (!reportedIssues.add(deduplicationKey)) {
+                continue;
+            }
+
+            Node reportNode = findSmallestContainingNode(node, location.toRange2d());
+            context.addViolationWithPosition(reportNode, node.getAstInfo(), location, "{0}", issue.message());
+        }
+
+        return data;
+    }
+
+    private static boolean belongsToFile(Issue issue, ASTApexFile node) {
+        String issuePath = issue.filePath();
+        String currentPath = node.getTextDocument().getFileId().getAbsolutePath();
+        if (issuePath == null || currentPath == null) {
+            return false;
+        }
+        if (issuePath.equals(currentPath)) {
+            return true;
+        }
+
+        try {
+            Path normalizedIssuePath = Paths.get(issuePath).toAbsolutePath().normalize();
+            Path normalizedCurrentPath = Paths.get(currentPath).toAbsolutePath().normalize();
+            return normalizedIssuePath.equals(normalizedCurrentPath);
+        } catch (InvalidPathException ignored) {
+            return false;
+        }
+    }
+
+    private static FileLocation toFileLocation(ASTApexFile node, IssueLocation issueLocation) {
+        int startLine = issueLocation.startLineNumber();
+        int startColumn = issueLocation.startCharOffset() + 1;
+        int endLine = issueLocation.endLineNumber();
+        int endColumn = issueLocation.endCharOffset() + 1;
+
+        // Apex-LS ranges use an inclusive end offset. PMD ranges use an exclusive end column.
+        if (startLine != endLine || startColumn != endColumn) {
+            endColumn++;
+        }
+
+        try {
+            TextRange2d range = TextRange2d.range2d(startLine, startColumn, endLine, endColumn);
+            return FileLocation.range(node.getTextDocument().getFileId(), range);
+        } catch (IllegalArgumentException ignored) {
+            return node.getReportLocation();
+        }
+    }
+
+    private static Node findSmallestContainingNode(Node node, TextRange2d issueRange) {
+        for (Node child : node.children()) {
+            if (child.getReportLocation().toRange2d().contains(issueRange)) {
+                return findSmallestContainingNode(child, issueRange);
+            }
+        }
+        return node;
+    }
+
+    private static String deduplicationKey(Issue issue, FileLocation location) {
+        return issue.filePath() + '\u0000'
+            + location.getStartLine() + '\u0000'
+            + location.getStartColumn() + '\u0000'
+            + location.getEndLine() + '\u0000'
+            + location.getEndColumn() + '\u0000'
+            + issue.rule().name() + '\u0000'
+            + issue.message();
+    }
+}

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -49,6 +49,42 @@ public class Foo {
 ]]>
     </example>
   </rule>
+
+  <rule name="ApexSemanticErrors"
+        language="apex"
+        since="7.27.0"
+        message="{0}"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.ApexSemanticErrorsRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#apexsemanticerrors">
+    <description><![CDATA[
+Reports semantic and type errors produced by the
+[Apex Language Server](https://github.com/apex-dev-tools/apex-ls) multifile analysis. Set the
+`PMD_APEX_ROOT_DIRECTORY` environment variable to the directory containing `sfdx-project.json`.
+
+The rule reports only Apex-LS issues whose `isError()` value is true. It preserves each diagnostic's
+message and source range. Syntax, Error, and Missing diagnostics are supported; Warning and Unused
+diagnostics are ignored.
+
+| Scenario | Apex-LS support |
+|----------|-----------------|
+| Local variable and return type mismatches | Supported |
+| Invalid method arguments and missing Apex types | Supported |
+| Valid references between local Apex classes | Supported |
+| Custom SObject field metadata and field type mismatches | Supported |
+| Unknown standard-object fields when no local field extends the object | Supported |
+| Unknown standard-object fields after any local custom field extends the object | Not reported by Apex-LS because the extended standard object is marked incomplete |
+
+The rule does not connect to an org, download schema, or supplement Apex-LS with its own semantic checker.
+    ]]></description>
+    <priority>1</priority>
+    <example><![CDATA[
+public class Example {
+    public static Integer invalidReturnType() {
+        return 'not an Integer'; // ApexSemanticErrors
+    }
+}
+]]></example>
+  </rule>
   
   <rule name="AvoidDirectAccessTriggerMap"
         language="apex"

--- a/pmd-apex/src/main/resources/rulesets/apex/apex-semantic-errors.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/apex-semantic-errors.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ruleset name="Apex Semantic Errors"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+  <description>
+    Reports Apex Language Server semantic and type errors.
+  </description>
+
+  <rule name="ApexSemanticErrors"
+        language="apex"
+        since="7.27.0"
+        message="{0}"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.ApexSemanticErrorsRule"
+        externalInfoUrl="https://docs.pmd-code.org/latest/pmd_rules_apex_errorprone.html#apexsemanticerrors">
+    <description>
+      Reports semantic and type errors found by Apex Language Server against local Salesforce project metadata.
+    </description>
+    <priority>1</priority>
+  </rule>
+</ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexSemanticIssuesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexSemanticIssuesTest.java
@@ -1,0 +1,63 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.multifile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.sourceforge.pmd.lang.apex.ApexLanguageProperties;
+
+import com.nawforce.pkgforce.path.PathLike;
+import com.nawforce.runtime.platform.Environment;
+import io.github.apexdevtools.api.Issue;
+import scala.Option;
+
+class ApexSemanticIssuesTest {
+
+    private static final Path PROJECT = Paths.get(
+            "src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1")
+            .toAbsolutePath();
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void exposesSemanticIssuesFromApexLs() {
+        Option<PathLike> cachePath = Option.apply(new com.nawforce.runtime.platform.Path(tempDir));
+        Environment.setCacheDirOverride(Option.apply(cachePath));
+
+        ApexLanguageProperties properties = new ApexLanguageProperties();
+        properties.setProperty(ApexLanguageProperties.MULTIFILE_DIRECTORY, Optional.of(PROJECT.toString()));
+        ApexMultifileAnalysis analysis = new ApexMultifileAnalysis(properties);
+
+        Path apexFile = PROJECT.resolve("force-app/main/default/classes/FieldTypeMismatch.cls");
+        List<Issue> issues = analysis.getFileIssues(apexFile.toString());
+        Path validApexFile = PROJECT.resolve("force-app/main/default/classes/ValidField.cls");
+        List<Issue> validFileIssues = analysis.getFileIssues(validApexFile.toString());
+        assertFalse(analysis.isFailed());
+        assertTrue(validFileIssues.stream().anyMatch(issue -> !Boolean.TRUE.equals(issue.isError())));
+
+        List<Issue> errors = issues.stream()
+                .filter(issue -> Boolean.TRUE.equals(issue.isError()))
+                .collect(java.util.stream.Collectors.toList());
+        assertEquals(1, errors.size());
+        Issue error = errors.get(0);
+        assertEquals("Error", error.rule().name());
+        assertEquals(4, error.fileLocation().startLineNumber());
+        assertEquals(8, error.fileLocation().startCharOffset());
+        assertEquals(41, error.fileLocation().endCharOffset());
+        assertEquals("Incompatible types in assignment, from 'System.String' to 'System.Decimal'",
+                error.message());
+    }
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrorsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrorsTest.java
@@ -1,0 +1,131 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileTestSupport;
+import net.sourceforge.pmd.lang.rule.RuleSet;
+import net.sourceforge.pmd.lang.rule.RuleSetLoader;
+import net.sourceforge.pmd.reporting.Report;
+import net.sourceforge.pmd.reporting.RuleViolation;
+
+class ApexSemanticErrorsTest {
+
+    private static final Path TEST_RESOURCES = Paths.get(
+            "src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors");
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void standaloneRulesetExposesRule() {
+        RuleSet ruleSet = new RuleSetLoader().loadFromResource("rulesets/apex/apex-semantic-errors.xml");
+        assertNotNull(ruleSet.getRuleByName("ApexSemanticErrors"));
+    }
+
+    @Test
+    void reportsSupportedErrorsWithNativeMessagesAndLocations() throws IOException {
+        Report report = runRule(TEST_RESOURCES.resolve("project1"), "project1-cache");
+
+        assertEquals(5, report.getViolations().size());
+        assertViolation(report, "FieldTypeMismatch.cls", 4, 9, 43,
+                "Incompatible types in assignment, from 'System.String' to 'System.Decimal'");
+        assertViolation(report, "LocalVariableTypeMismatch.cls", 3, 17, 33,
+                "Incompatible types in assignment, from 'System.String' to 'System.Integer'");
+        assertViolation(report, "MissingType.cls", 3, 9, 22,
+                "No variable or type found for 'MissingClass' on 'MissingType'");
+        assertViolation(report, "WrongMethodArgument.cls", 6, 9, 31,
+                "No matching method found for 'takesInteger' on 'WrongMethodArgument' taking arguments "
+                        + "'System.String', wrong argument types for calling "
+                        + "'private static void takesInteger(System.Integer value)'");
+        assertViolation(report, "InvalidReturnType.cls", 3, 9, 25,
+                "Incompatible return type, 'System.String' is not assignable to 'System.Integer'");
+
+        assertNoViolation(report, "ValidField.cls");
+        assertNoViolation(report, "ValidCrossClassReference.cls");
+        assertNoViolation(report, "UnknownField.cls");
+    }
+
+    @Test
+    void reportsUnknownFieldWithoutLocalStandardObjectExtension() throws IOException {
+        Report report = runRule(TEST_RESOURCES.resolve("project2"), "project2-cache");
+
+        assertEquals(1, report.getViolations().size());
+        RuleViolation violation = report.getViolations().get(0);
+        assertEquals("UnknownField.cls", violation.getFileId().getFileName());
+        assertTrue(violation.getDescription().contains("Does_Not_Exist__c"));
+    }
+
+    @Test
+    void localFieldMetadataMakesTheDiagnosticDisappear() throws IOException {
+        Path sourceProject = TEST_RESOURCES.resolve("project3");
+        Report withMetadata = runRule(sourceProject, "metadata-present-cache");
+        assertEquals(0, withMetadata.getViolations().size());
+
+        Path projectWithoutMetadata = tempDir.resolve("project-without-metadata");
+        copyDirectory(sourceProject, projectWithoutMetadata);
+        Files.delete(projectWithoutMetadata.resolve(
+                "force-app/main/default/objects/Account/fields/Known_Text__c.field-meta.xml"));
+
+        Report withoutMetadata = runRule(projectWithoutMetadata, "metadata-absent-cache");
+        assertEquals(1, withoutMetadata.getViolations().size());
+        assertTrue(withoutMetadata.getViolations().get(0).getDescription().contains("Known_Text__c"));
+    }
+
+    private Report runRule(Path project, String cacheDirectory) throws IOException {
+        Path cache = Files.createDirectories(tempDir.resolve(cacheDirectory));
+        return ApexMultifileTestSupport.runRule(cache, project, "errorprone", "ApexSemanticErrors");
+    }
+
+    private static void assertViolation(Report report, String fileName, int line, int startColumn, int endColumn,
+                                        String message) {
+        List<RuleViolation> matches = report.getViolations().stream()
+                .filter(violation -> fileName.equals(violation.getFileId().getFileName()))
+                .collect(Collectors.toList());
+        assertEquals(1, matches.size(), "Expected exactly one violation in " + fileName);
+
+        RuleViolation violation = matches.get(0);
+        assertEquals(line, violation.getBeginLine());
+        assertEquals(line, violation.getEndLine());
+        assertEquals(startColumn, violation.getBeginColumn());
+        assertEquals(endColumn, violation.getEndColumn());
+        assertEquals(message, violation.getDescription());
+    }
+
+    private static void assertNoViolation(Report report, String fileName) {
+        assertTrue(report.getViolations().stream()
+                .noneMatch(violation -> fileName.equals(violation.getFileId().getFileName())));
+    }
+
+    private static void copyDirectory(Path source, Path target) throws IOException {
+        try (Stream<Path> files = Files.walk(source)) {
+            Iterator<Path> iterator = files.iterator();
+            while (iterator.hasNext()) {
+                Path path = iterator.next();
+                Path destination = target.resolve(source.relativize(path));
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(destination);
+                } else {
+                    Files.copy(path, destination);
+                }
+            }
+        }
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/FieldTypeMismatch.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/FieldTypeMismatch.cls
@@ -1,0 +1,6 @@
+public class FieldTypeMismatch {
+    public static void run() {
+        Account account = new Account();
+        account.Known_Number__c = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/FieldTypeMismatch.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/FieldTypeMismatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/InvalidReturnType.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/InvalidReturnType.cls
@@ -1,0 +1,5 @@
+public class InvalidReturnType {
+    public static Integer getValue() {
+        return 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/InvalidReturnType.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/InvalidReturnType.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalHelper.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalHelper.cls
@@ -1,0 +1,4 @@
+public class LocalHelper {
+    public static void doSomething() {
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalHelper.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalVariableTypeMismatch.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalVariableTypeMismatch.cls
@@ -1,0 +1,5 @@
+public class LocalVariableTypeMismatch {
+    public static void run() {
+        Integer value = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalVariableTypeMismatch.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/LocalVariableTypeMismatch.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/MissingType.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/MissingType.cls
@@ -1,0 +1,5 @@
+public class MissingType {
+    public static void run() {
+        MissingClass.doSomething();
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/MissingType.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/MissingType.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/UnknownField.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/UnknownField.cls
@@ -1,0 +1,6 @@
+public class UnknownField {
+    public static void run() {
+        Account account = new Account();
+        account.Does_Not_Exist__c = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/UnknownField.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/UnknownField.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidCrossClassReference.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidCrossClassReference.cls
@@ -1,0 +1,5 @@
+public class ValidCrossClassReference {
+    public static void run() {
+        LocalHelper.doSomething();
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidCrossClassReference.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidCrossClassReference.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidField.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidField.cls
@@ -1,0 +1,6 @@
+public class ValidField {
+    public static void run() {
+        Account account = new Account();
+        account.Known_Text__c = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidField.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/ValidField.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/WrongMethodArgument.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/WrongMethodArgument.cls
@@ -1,0 +1,8 @@
+public class WrongMethodArgument {
+    private static void takesInteger(Integer value) {
+    }
+
+    public static void run() {
+        takesInteger('hello');
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/WrongMethodArgument.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/classes/WrongMethodArgument.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/objects/Account/fields/Known_Number__c.field-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/objects/Account/fields/Known_Number__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Known_Number__c</fullName>
+    <externalId>false</externalId>
+    <label>Known Number</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/objects/Account/fields/Known_Text__c.field-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/force-app/main/default/objects/Account/fields/Known_Text__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Known_Text__c</fullName>
+    <externalId>false</externalId>
+    <label>Known Text</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project1/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sourceApiVersion": "67.0"
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/force-app/main/default/classes/UnknownField.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/force-app/main/default/classes/UnknownField.cls
@@ -1,0 +1,6 @@
+public class UnknownField {
+    public static void run() {
+        Account account = new Account();
+        account.Does_Not_Exist__c = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/force-app/main/default/classes/UnknownField.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/force-app/main/default/classes/UnknownField.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project2/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sourceApiVersion": "67.0"
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/classes/ValidField.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/classes/ValidField.cls
@@ -1,0 +1,6 @@
+public class ValidField {
+    public static void run() {
+        Account account = new Account();
+        account.Known_Text__c = 'hello';
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/classes/ValidField.cls-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/classes/ValidField.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>67.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/objects/Account/fields/Known_Text__c.field-meta.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/force-app/main/default/objects/Account/fields/Known_Text__c.field-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Known_Text__c</fullName>
+    <label>Known Text</label>
+    <length>255</length>
+    <type>Text</type>
+</CustomField>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexSemanticErrors/project3/sfdx-project.json
@@ -1,0 +1,10 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sourceApiVersion": "67.0"
+}


### PR DESCRIPTION
## Describe the PR

Adds `ApexSemanticErrors`, an Error Prone rule that reports semantic and type errors already produced by Apex LS during PMD's multifile analysis.

The rule runs once for each `ASTApexFile` and converts its native Apex LS issues into PMD violations. It:

- reports only issues where `Issue.isError()` is `true`
- keeps the original diagnostic message and source range
- attaches each violation to the smallest AST node containing that range, with the file root as a fallback
- ignores issues belonging to another file
- removes duplicate issues before reporting them

Project discovery continues to use `PMD_APEX_ROOT_DIRECTORY`. This does not add another type checker, load an org schema, or connect to a Salesforce org.

### Covered diagnostics

| Case | Result |
| --- | --- |
| Incompatible local assignment | Reported |
| Incompatible custom-field assignment | Reported |
| Missing Apex type | Reported |
| Invalid method argument | Reported |
| Invalid return value | Reported |
| Unknown standard-object field without a local extension | Reported |
| Valid field from local SFDX metadata | Not reported |
| Valid cross-class reference | Not reported |
| Apex LS warnings such as `Unused` | Not reported |

The integration fixtures contain a complete SFDX project with Apex classes and custom-field metadata. A separate metadata lifecycle test verifies that removing a field definition creates a diagnostic and restoring it clears the diagnostic.

### Apex LS limitation

When local metadata extends a platform standard object, Apex LS treats that object as incomplete and suppresses unknown-field diagnostics for other fields on the same object. The rule preserves that behavior; it does not attempt to fill the gap with a second semantic implementation.

A standalone `rulesets/apex/apex-semantic-errors.xml` ruleset is included for tools that load custom PMD rulesets, including Salesforce Code Analyzer v5.

## Related issues

- Fixes #7002

## Test results

- `./mvnw clean verify` — all 44 reactor modules passed
- `./mvnw -pl pmd-apex test` — 1,432 tests, 0 failures, 0 errors, 1 existing skip
- `./mvnw -pl pmd-apex -DskipTests pmd:pmd@pmd-main pmd:check@pmd-main checkstyle:check@checkstyle-check` — passed (existing PMD warnings only; 0 Checkstyle violations)

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes
- [x] Added (in-code) documentation
