### PR TITLE
[java] Fix rule reference from `ProtectedMemberInFinalField` to `ProtectedMemberInFinalClass`

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -77,7 +77,7 @@ public class Fo$o {  // not a recommended name
 Do not use protected fields in final classes since they cannot be subclassed.
 Clarify your intent by using private or package access modifiers instead.
 
-**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule ProtectedMemberInFinalField %}, which covers all class members.
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule java/design/ProtectedMemberInFinalClass %}, which covers all class members.
         </description>
         <priority>3</priority>
         <properties>
@@ -114,7 +114,7 @@ Do not use protected methods in most final classes since they cannot be subclass
 only be allowed in final classes that extend other classes with protected methods (whose
 visibility cannot be reduced). Clarify your intent by using private or package access modifiers instead.
 
-**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule ProtectedMemberInFinalField %}, which covers all class members.
+**Deprecated:** This rule is deprecated since PMD 7.27.0 and will be removed with PMD 8.0.0. This rule has been replaced by {% rule java/design/ProtectedMemberInFinalClass %}, which covers all class members.
         </description>
         <priority>3</priority>
         <properties>


### PR DESCRIPTION

It seems there is no such rule referenced at

<img width="499" height="277" alt="image" src="https://github.com/user-attachments/assets/892099fc-1094-43f8-8fe1-0a1d6c73634a" />

and _ProtectedMemberInFinalClass_ says:

<img width="843" height="63" alt="image" src="https://github.com/user-attachments/assets/e9d8332d-74eb-4c3b-bee6-c22c96f501de" />


- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

