### PR TITLE
[java] Fix #7009: ReplaceJavaUtilDate/Calendar miss pattern variables and record components

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* java-errorprone
+    * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2805,6 +2805,7 @@ deprecated there as well in favour of `java.time` API.
                 //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //FormalParameter[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
+                //RecordComponent[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //TypePattern[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Calendar')]]
                 ]]></value>
@@ -2869,6 +2870,7 @@ deprecated there as well in favour of `java.time` API.
                 //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //FormalParameter[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
+                //RecordComponent[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //TypePattern[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Date')]]
                 ]]></value>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2805,6 +2805,7 @@ deprecated there as well in favour of `java.time` API.
                 //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //FormalParameter[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
+                //TypePattern[ClassType[pmd-java:typeIs('java.util.Calendar')]] |
                 //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Calendar')]]
                 ]]></value>
             </property>
@@ -2868,6 +2869,7 @@ deprecated there as well in favour of `java.time` API.
                 //LocalVariableDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //FormalParameter[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //FieldDeclaration[ClassType[pmd-java:typeIs('java.util.Date')]] |
+                //TypePattern[ClassType[pmd-java:typeIs('java.util.Date')]] |
                 //ConstructorCall[ClassType[pmd-java:typeIs('java.util.Date')]]
                 ]]></value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
@@ -117,6 +117,31 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>bad, record component of type java.util.Calendar</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,4</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+    record Period(Calendar start, Calendar end) { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, record component not of type java.util.Calendar</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.LocalDate;
+
+public class Foo {
+    record Period(LocalDate start, LocalDate end) { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>ok, pattern variable not of type java.util.Calendar</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilCalendar.xml
@@ -80,4 +80,55 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>bad, pattern variable of type java.util.Calendar</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+    void bar(Object o) {
+        if (o instanceof Calendar c) {
+            System.out.println(c);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, pattern variable in a switch case label</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import java.util.GregorianCalendar;
+
+public class Foo {
+    String bar(Object o) {
+        return switch (o) {
+            case GregorianCalendar c -> c.toString();
+            default -> "";
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, pattern variable not of type java.util.Calendar</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.LocalDate;
+
+public class Foo {
+    void bar(Object o) {
+        if (o instanceof LocalDate d) {
+            System.out.println(d);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
@@ -78,14 +78,14 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>bad, pattern variable of type java.sql.Timestamp</description>
+        <description>bad, pattern variable declared with a fully qualified type name</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void bar(Object o) {
-        if (o instanceof java.sql.Timestamp ts) {
-            System.out.println(ts);
+        if (o instanceof java.util.Date d) {
+            System.out.println(d);
         }
     }
 }
@@ -111,20 +111,45 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>bad, record deconstruction pattern with components of type java.util.Date</description>
+        <description>bad, type pattern nested in a record deconstruction pattern</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    record Box(Object value) { }
+
+    void bar(Object o) {
+        if (o instanceof Box(Date d)) {
+            System.out.println(d);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, record component of type java.util.Date</description>
         <expected-problems>2</expected-problems>
-        <expected-linenumbers>7,7</expected-linenumbers>
+        <expected-linenumbers>4,4</expected-linenumbers>
         <code><![CDATA[
 import java.util.Date;
 
 public class Foo {
     record Range(Date from, Date to) { }
+}
+        ]]></code>
+    </test-code>
 
-    void bar(Object o) {
-        if (o instanceof Range(Date from, Date to)) {
-            System.out.println(from);
-        }
-    }
+    <test-code>
+        <description>ok, record component not of type java.util.Date</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.LocalDate;
+
+public class Foo {
+    record Range(LocalDate from, LocalDate to) { }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReplaceJavaUtilDate.xml
@@ -59,4 +59,89 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>bad, pattern variable of type java.util.Date</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    void bar(Object o) {
+        if (o instanceof Date d) {
+            System.out.println(d);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, pattern variable of type java.sql.Timestamp</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void bar(Object o) {
+        if (o instanceof java.sql.Timestamp ts) {
+            System.out.println(ts);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, pattern variable in a switch case label</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    String bar(Object o) {
+        return switch (o) {
+            case Date d -> d.toString();
+            default -> "";
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, record deconstruction pattern with components of type java.util.Date</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,7</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Date;
+
+public class Foo {
+    record Range(Date from, Date to) { }
+
+    void bar(Object o) {
+        if (o instanceof Range(Date from, Date to)) {
+            System.out.println(from);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, pattern variable not of type java.util.Date</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.LocalDateTime;
+
+public class Foo {
+    void bar(Object o) {
+        if (o instanceof LocalDateTime ldt) {
+            System.out.println(ldt);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Both rules match only `LocalVariableDeclaration`, `FormalParameter`, `FieldDeclaration` and `ConstructorCall`, so neither a pattern variable nor a record component is reported.

`TypePattern` covers `instanceof` patterns, `switch` case labels and the components of a record deconstruction pattern. `RecordComponent` covers record component declarations.

With only the new test cases applied they report 0 problems and fail; with the XPath change all 21 pass in the two rule tests.

## Related issues

- Fix #7009

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)
