### PR TITLE
[doc] chore: Improve RuleTagChecker to find invalid in-ruleset references

### DIFF
--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -27,12 +27,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RuleTagChecker {
-    private static final Logger LOG = LoggerFactory.getLogger(DeadLinksChecker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RuleTagChecker.class);
 
     private static final String QUOTE = "\"";
     private static final Pattern RULE_TAG = Pattern.compile("\\{%\\s*rule\\s+(\"?[^\"%\\}\\s]+\"?)\\s*");
     private static final Pattern RULE_REFERENCE = Pattern.compile("\"?(\\w+)\\/(\\w+)\\/(\\w+)\"?");
     private static final Pattern RULE_SIMPLE_REFERENCE = Pattern.compile("\"?(\\w+)\"?");
+    private static final String GROUP_LANGUAGE = "language";
+    private static final String GROUP_CATEGORY = "category";
+    private static final Pattern RULE_DOC_FILENAME = Pattern.compile("^.*rules[/\\\\](?<" + GROUP_LANGUAGE + ">\\w+)[/\\\\](?<" + GROUP_CATEGORY + ">\\w+)\\.md$");
 
     private final Path pagesDirectory;
     private final List<String> issues = new ArrayList<>();
@@ -66,6 +69,16 @@ public class RuleTagChecker {
         }
 
         LOG.debug("Checking {}", file);
+
+        Matcher filenameMatcher = RULE_DOC_FILENAME.matcher(file.toString());
+        String language = null;
+        String category = null;
+        if (filenameMatcher.matches()) {
+            language = filenameMatcher.group(GROUP_LANGUAGE);
+            category = filenameMatcher.group(GROUP_CATEGORY);
+            LOG.debug("Language: {} Category: {}", language, category);
+        }
+
         int lineNo = 0;
         for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
             lineNo++;
@@ -78,28 +91,40 @@ public class RuleTagChecker {
                 } else if (ruleReference.startsWith(QUOTE) && !ruleReference.endsWith(QUOTE)
                         || !ruleReference.startsWith(QUOTE) && ruleReference.endsWith(QUOTE)) {
                     addIssue(file, lineNo, "Rule tag for " + ruleReference + " has a missing quote");
-                } else if (!ruleReferenceTargetExists(ruleReference)) {
+                } else if (!ruleReferenceTargetExists(ruleReference, language, category)) {
                     addIssue(file, lineNo, "Rule " + ruleReference + " is not found");
                 }
             }
         }
     }
 
-    private boolean ruleReferenceTargetExists(String ruleReference) {
+    private boolean ruleReferenceTargetExists(String ruleReference, String currentLanguage, String currentCategory) {
         Matcher ruleRefMatcher = RULE_REFERENCE.matcher(ruleReference);
         Matcher simpleRefMatcher = RULE_SIMPLE_REFERENCE.matcher(ruleReference);
-        if (ruleRefMatcher.matches()) {
-            String language = ruleRefMatcher.group(1);
-            String category = ruleRefMatcher.group(2);
-            String rule = ruleRefMatcher.group(3);
 
+        String language = null;
+        String category = null;
+        String rule = null;
+
+        if (ruleRefMatcher.matches()) {
+            language = ruleRefMatcher.group(1);
+            category = ruleRefMatcher.group(2);
+            rule = ruleRefMatcher.group(3);
+        } else if (simpleRefMatcher.matches()) {
+            language = currentLanguage;
+            category = currentCategory;
+            rule = simpleRefMatcher.group(1);
+        }
+
+        if (rule != null && language != null && category != null) {
             Path ruleDocPage = pagesDirectory.resolve("pmd/rules/" + language + "/" + category.toLowerCase(Locale.ROOT) + ".md");
             Set<String> rules = getRules(ruleDocPage);
             return rules.contains(rule);
-        } else if (simpleRefMatcher.matches()) {
-            // can't check - would need to know the current language + category
-            return true;
         }
+
+        // can't check - would need to know the current language + category
+        LOG.warn("Cannot verify rule reference '{}' for rule {} (originating in language: {} category: {})",
+                ruleReference, rule, currentLanguage, currentCategory);
         return false;
     }
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
@@ -9,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 import java.nio.file.FileSystems;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
@@ -5,9 +5,11 @@
 
 package net.sourceforge.pmd.doc.internal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
 import java.nio.file.FileSystems;
+import java.util.Comparator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -19,18 +21,21 @@ class RuleTagCheckerTest {
         RuleTagChecker checker = new RuleTagChecker(FileSystems.getDefault().getPath("src/test/resources/ruletagchecker"));
         List<String> issues = checker.check();
 
-        assertEquals(7, issues.size());
-        assertEquals("ruletag-examples.md: 9: Rule tag for \"java/bestpractices/AvoidPrintStackTrace\" is not closed properly",
-                issues.get(0));
-        assertEquals("ruletag-examples.md:12: Rule \"java/notexistingcategory/AvoidPrintStackTrace\" is not found",
-                issues.get(1));
-        assertEquals("ruletag-examples.md:14: Rule \"java/bestpractices/NotExistingRule\" is not found",
-                issues.get(2));
-        assertEquals("ruletag-examples.md:16: Rule tag for \"java/bestpractices/OtherRule has a missing quote",
-                issues.get(3));
-        assertEquals("ruletag-examples.md:17: Rule tag for java/bestpractices/OtherRule\" has a missing quote",
-                issues.get(4));
-        assertEquals("ruletag-examples.md:21: Rule tag for \"OtherRule has a missing quote", issues.get(5));
-        assertEquals("ruletag-examples.md:22: Rule tag for OtherRule\" has a missing quote", issues.get(6));
+        issues.sort(Comparator.naturalOrder());
+
+        assertThat(issues, contains(
+                "pmd/rules/java/codestyle.md: 8: Rule NotExistingRule is not found",
+                "pmd/rules/java/codestyle.md: 9: Rule \"NotExistingRule\" is not found",
+                "pmd/rules/java/codestyle.md:17: Rule java/notexistingcategory/AvoidPrintStackTrace is not found",
+                "pmd/rules/java/design.md: 9: Rule tag for \"java/bestpractices/AvoidPrintStackTrace\" is not closed properly",
+                "pmd/rules/java/design.md:12: Rule \"java/notexistingcategory/AvoidPrintStackTrace\" is not found",
+                "pmd/rules/java/design.md:14: Rule \"java/bestpractices/NotExistingRule\" is not found",
+                "pmd/rules/java/design.md:16: Rule tag for \"java/bestpractices/OtherRule has a missing quote",
+                "pmd/rules/java/design.md:17: Rule tag for java/bestpractices/OtherRule\" has a missing quote",
+                "pmd/rules/java/design.md:19: Rule OtherRule is not found",
+                "pmd/rules/java/design.md:20: Rule \"OtherRule\" is not found",
+                "pmd/rules/java/design.md:21: Rule tag for \"OtherRule has a missing quote",
+                "pmd/rules/java/design.md:22: Rule tag for OtherRule\" has a missing quote"
+        ));
     }
 }

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.contains;
 import java.nio.file.FileSystems;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,10 @@ class RuleTagCheckerTest {
         RuleTagChecker checker = new RuleTagChecker(FileSystems.getDefault().getPath("src/test/resources/ruletagchecker"));
         List<String> issues = checker.check();
 
-        issues.sort(Comparator.naturalOrder());
+        issues = issues.stream()
+                        .map(s -> s.replace('\\', '/')) // convert windows paths
+                        .sorted()
+                        .collect(Collectors.toList());
 
         assertThat(issues, contains(
                 "pmd/rules/java/codestyle.md: 8: Rule NotExistingRule is not found",

--- a/pmd-doc/src/test/resources/ruletagchecker/docs/pages/pmd/rules/java/codestyle.md
+++ b/pmd-doc/src/test/resources/ruletagchecker/docs/pages/pmd/rules/java/codestyle.md
@@ -1,0 +1,17 @@
+
+## RuleAInCodestyle
+
+Sample rule doc for tests.
+
+## RuleBInCodestyle
+
+This rule description references {% rule NotExistingRule %}. This is wrong.
+This rule description references {% rule "NotExistingRule" %}. This is wrong (with quotes).
+
+This rule description references {% rule RuleAInCodestyle %}. This is correct.
+
+This rule description references {% rule java/codestyle/RuleAInCodestyle %}. This is correct.
+
+This rule description references {% rule java/bestpractices/AvoidPrintStackTrace %}. This is correct.
+
+This rule description references {% rule java/notexistingcategory/AvoidPrintStackTrace %}. This is wrong.

--- a/pmd-doc/src/test/resources/ruletagchecker/docs/pages/pmd/rules/java/design.md
+++ b/pmd-doc/src/test/resources/ruletagchecker/docs/pages/pmd/rules/java/design.md
@@ -1,6 +1,6 @@
 ---
 title: Sample Page with rule tags
-permalink: rule_tag_samples.html
+permalink: design.html
 ---
 
 This is a link to the rule AvoidPrintStackTrace: {% rule "java/bestpractices/AvoidPrintStackTrace" %}.

--- a/pmd-doc/src/test/resources/simplelogger.properties
+++ b/pmd-doc/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+#org.slf4j.simpleLogger.log.net.sourceforge.pmd.doc.internal.RuleTagChecker=debug


### PR DESCRIPTION
## Describe the PR

This finds now cases like #7005.

Note: the check runs on the CI. To run it locally, enable the profile "generate-rule-docs", either via `-Pgenerate-rule-docs` or in your settings.xml.


## Related issues

- See #7005

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

