### PR TITLE
[java] Fix #7008: HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,6 +26,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 
+* java-security
+  * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
+
 ### 🚨️ API Changes
 
 ### ✨️ Merged pull requests

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -44,6 +44,14 @@ This is a {{ site.pmd.release_type }} release.
     ```
 
 ### 🐛️ Fixed Issues
+* java-codestyle
+    * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
+* java-errorprone
+    * [#6693](https://github.com/pmd/pmd/issues/6693): \[java] CloneMethodMustImplementCloneable fires inconsistently between inline `throw new` and throw-via-local forms
+    * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
+* java-multithreading
+    * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
+    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
 * java-security
     * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -34,7 +34,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
     * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
 * java-security
-    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated a hard-coded key
+    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
 
 ### 🚨️ API Changes
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -66,10 +66,10 @@ This is a {{ site.pmd.release_type }} release.
     * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
 * java-multithreading
     * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
-    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
-* java-security
-    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
     * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods
+* java-security
+    * [#7007](https://github.com/pmd/pmd/issues/7007): \[java] HardCodedCryptoKey: False negative when a hard-coded key is constructed via new String(char[])
+    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
 
 ### 🚨️ API Changes
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,14 +25,6 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
-* java-codestyle
-    * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
-* java-errorprone
-    * [#6693](https://github.com/pmd/pmd/issues/6693): \[java] CloneMethodMustImplementCloneable fires inconsistently between inline `throw new` and throw-via-local forms
-    * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
-* java-multithreading
-    * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
-    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
 * java-security
     * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,10 +29,8 @@ This is a {{ site.pmd.release_type }} release.
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone
     * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
-
-
 * java-security
-  * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
+    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
 
 ### 🚨️ API Changes
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,9 +28,13 @@ This is a {{ site.pmd.release_type }} release.
 * java-codestyle
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone
+    * [#6693](https://github.com/pmd/pmd/issues/6693): \[java] CloneMethodMustImplementCloneable fires inconsistently between inline `throw new` and throw-via-local forms
     * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
+* java-multithreading
+    * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
+    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
 * java-security
-    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key
+    * [#7008](https://github.com/pmd/pmd/issues/7008): \[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated a hard-coded key
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -16,9 +16,21 @@ import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulechainRule {
+
+    /**
+     * Matches calls to {@code System.getProperty(String)} and
+     * {@code System.getProperty(String, String)}. Any string literal
+     * arguments to such a call (the property name, or the default value
+     * used when the property is absent) are not necessarily the actual
+     * value used at runtime, since that value may come from an external
+     * system property. So these should not be reported as hard-coded.
+     */
+    private static final InvocationMatcher SYSTEM_GET_PROPERTY =
+            InvocationMatcher.parse("java.lang.System#getProperty(_*)");
 
     private final Class<?> type;
 
@@ -81,6 +93,10 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
         } else if (firstArgumentExpression instanceof ASTArrayInitializer) {
             // hard coded array
             asCtx(data).addViolation(firstArgumentExpression);
+        } else if (firstArgumentExpression instanceof ASTMethodCall
+                && SYSTEM_GET_PROPERTY.matchesCall((ASTMethodCall) firstArgumentExpression)) {
+            // value comes from an external system property at runtime;
+            // any string literal arguments are not necessarily the key
         } else {
             // string literal
             ASTStringLiteral literal = firstArgumentExpression.descendantsOrSelf()

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -68,6 +68,11 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
             ASTExpression expr = ((ASTMethodCall) firstArgumentExpression).getQualifier();
             if (expr instanceof ASTVariableAccess) {
                 varAccess = (ASTVariableAccess) expr;
+            } else if (expr instanceof ASTMethodCall && SYSTEM_GET_PROPERTY.matchesCall((ASTMethodCall) expr)) {
+                // e.g. new SecretKeySpec(System.getProperty("k", "d").getBytes(), "AES")
+                // the value comes from an external system property at runtime;
+                // any string literal arguments are not necessarily the key
+                return;
             }
         } else if (firstArgumentExpression instanceof ASTVariableAccess) {
             // check for named variable

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -32,6 +32,11 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
     private static final InvocationMatcher SYSTEM_GET_PROPERTY =
             InvocationMatcher.parse("java.lang.System#getProperty(_*)");
 
+    private static boolean derivesFromSystemGetProperty(ASTExpression expr) {
+        return (expr instanceof ASTMethodCall && SYSTEM_GET_PROPERTY.matchesCall((ASTMethodCall) expr))
+            || expr.descendants(ASTMethodCall.class).any(SYSTEM_GET_PROPERTY::matchesCall);
+    }
+
     private final Class<?> type;
 
     AbstractHardCodedConstructorArgsVisitor(Class<?> constructorType) {
@@ -62,17 +67,18 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
         }
 
         ASTVariableAccess varAccess = null;
-
         if (firstArgumentExpression instanceof ASTMethodCall) {
+            if (derivesFromSystemGetProperty(firstArgumentExpression)) {
+                // e.g. new SecretKeySpec(System.getProperty("k").trim().getBytes(), "AES")
+                // or   new SecretKeySpec(Base64.getDecoder().decode(System.getProperty("k")), "AES")
+                // the value comes from an external system property at runtime;
+                // any string literal arguments are not necessarily the key
+                return;
+            }
             // check for method call on a named variable
             ASTExpression expr = ((ASTMethodCall) firstArgumentExpression).getQualifier();
             if (expr instanceof ASTVariableAccess) {
                 varAccess = (ASTVariableAccess) expr;
-            } else if (expr instanceof ASTMethodCall && SYSTEM_GET_PROPERTY.matchesCall((ASTMethodCall) expr)) {
-                // e.g. new SecretKeySpec(System.getProperty("k", "d").getBytes(), "AES")
-                // the value comes from an external system property at runtime;
-                // any string literal arguments are not necessarily the key
-                return;
             }
         } else if (firstArgumentExpression instanceof ASTVariableAccess) {
             // check for named variable
@@ -108,10 +114,6 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
         } else if (firstArgumentExpression instanceof ASTArrayInitializer) {
             // hard coded array
             asCtx(data).addViolation(firstArgumentExpression);
-        } else if (firstArgumentExpression instanceof ASTMethodCall
-                && SYSTEM_GET_PROPERTY.matchesCall((ASTMethodCall) firstArgumentExpression)) {
-            // value comes from an external system property at runtime;
-            // any string literal arguments are not necessarily the key
         } else {
             // string literal
             addViolationForStringLiteral(data, firstArgumentExpression);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
@@ -139,4 +139,42 @@ class CryptoBaseTest implements HardCodedCryptoKeyTest.Constants {
 
         </code>
     </test-code>
+
+    <test-code>
+        <description>[java] HardCodedCryptoKey: False positive when a default value of System.getProperty() is treated as a hard-coded key #7008</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+
+public class GoodCase {
+    public void test() {
+        String keyString =
+            System.getProperty("test.key", "secretKey");
+        SecretKeySpec keySpec =
+            new SecretKeySpec(keyString.getBytes(), "AES");// [should not be flagged]
+    }
+
+    public void testOneArgOverload() {
+        String keyString = System.getProperty("test.key");
+        SecretKeySpec keySpec = new SecretKeySpec(keyString.getBytes(), "AES");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Hard coded crypto key from bare array initializer, bad</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+
+public class Foo {
+    void encrypt() {
+        byte[] key = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+    }
+}
+        ]]></code>
+    </test-code>
+    
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
@@ -176,5 +176,33 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+    <description>[java] HardCodedCryptoKey: System.getProperty() call chained directly as the qualifier of .getBytes(), two-arg overload #7008</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+public class GoodCase {
+    public void test() {
+        SecretKeySpec keySpec =
+            new SecretKeySpec(System.getProperty("test.key", "secretKey").getBytes(), "AES");// [should not be flagged]
+    }
+}
+    ]]></code>
+</test-code>
+
+<test-code>
+    <description>[java] HardCodedCryptoKey: System.getProperty() call chained directly as the qualifier of .getBytes(), one-arg overload #7008</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+public class GoodCase {
+    public void test() {
+        SecretKeySpec keySpec =
+            new SecretKeySpec(System.getProperty("test.key").getBytes(), "AES");// [should not be flagged]
+    }
+}
+    ]]></code>
+</test-code>
     
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
@@ -211,19 +211,32 @@ public class GoodCase {
     </test-code>
 
     <test-code>
-        <description>Hard coded crypto key from bare array initializer, bad</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
+    <description>[java] HardCodedCryptoKey: System.getProperty() nested as decode argument #7008</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import java.util.Base64;
 import javax.crypto.spec.SecretKeySpec;
-
-public class Foo {
-    void encrypt() {
-        byte[] key = { 0, 1, 2, 3, 4, 5, 6, 7 };
-        SecretKeySpec keySpec = new SecretKeySpec(key, "AES");
+public class GoodCase {
+    public void test() {
+        SecretKeySpec keySpec =
+            new SecretKeySpec(Base64.getDecoder().decode(System.getProperty("aes.key")), "AES");// [should not be flagged]
     }
 }
-        ]]></code>
-    </test-code>
+    ]]></code>
+</test-code>
+<test-code>
+    <description>[java] HardCodedCryptoKey: System.getProperty() with multi-level chain #7008</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+public class GoodCase {
+    public void test() {
+        SecretKeySpec keySpec =
+            new SecretKeySpec(System.getProperty("k").trim().getBytes(), "AES");// [should not be flagged]
+    }
+}
+    ]]></code>
+</test-code>
 
     <test-code>
     <description>[java] HardCodedCryptoKey: System.getProperty() call chained directly as the qualifier of .getBytes(), two-arg overload #7008</description>


### PR DESCRIPTION
## Describe the PR

`HardCodedCryptoKeyRule` (and the shared `AbstractHardCodedConstructorArgsVisitor` it's built on) was flagging calls like `System.getProperty("test.key", "secretKey")` as a hard-coded cryptographic key, because it scanned for *any* string literal inside the resolved argument expression including the property name and default value passed to `System.getProperty`, even though the actual value used at runtime may come from an external system property.

This PR adds a check using `InvocationMatcher` to recognize calls to `System.getProperty(String)` and `System.getProperty(String, String)`, and skips flagging when the argument comes from one of these calls, since no string literal present is necessarily the actual key.

While adding a regression test for this, I found and fixed a related but separate gap: `ASTArrayInitializer` values on the direct assignment path (e.g. `byte[] key = { 0, 1, 2, ... }; new SecretKeySpec(key, "AES")`) were not being reported at all — only the `ASTArrayAllocation` form (`byte[] key = new byte[] { ... }`) was previously covered on that path.
Added a test case and fix for this too.

## Related issues

Fix #7008

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)