### PR TITLE
[java] Fix #5940: UnusedAssignment FP when constant operand short-circuits the condition

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* java-bestpractices
+    * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignement is in conditional statement
 * java-codestyle
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,7 +26,7 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛️ Fixed Issues
 * java-bestpractices
-    * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignement is in conditional statement
+    * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignment is in conditional statement
 * java-codestyle
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -567,12 +567,45 @@ public final class DataflowPass {
             SpanInfo cur = before;
             cur = linkConditional(cur, orExpr.getLeftOperand(), thenState, elseState, false);
             thenState.absorb(cur);
-            cur = linkConditional(cur, orExpr.getRightOperand(), thenState, elseState, false);
-            thenState.absorb(cur);
+            // If the left operand is a compile-time constant that already
+            // decides the value of the condition, the right operand is
+            // never evaluated (JLS 15.23.2, 15.24.2), so its assignments
+            // may not kill anything. Note that a CT constant cannot have
+            // side effects.
+            Object leftValue = orExpr.getLeftOperand().getConstValue();
+            boolean leftDecides = orExpr.getOperator() == BinaryOp.CONDITIONAL_OR
+                                  ? Boolean.TRUE.equals(leftValue)
+                                  : Boolean.FALSE.equals(leftValue);
+            if (leftDecides) {
+                recordReachingDefsInDeadOperand(cur, orExpr.getRightOperand());
+            } else {
+                cur = linkConditional(cur, orExpr.getRightOperand(), thenState, elseState, false);
+                thenState.absorb(cur);
 
-            elseState.absorb(cur);
+                elseState.absorb(cur);
+            }
 
             return cur;
+        }
+
+        /**
+         * Records the reaching definitions of the references of an operand
+         * that is never evaluated, using the state that reaches it. The
+         * operand has no effect on the surrounding flow state, but rules
+         * that query reaching definitions (e.g. LawOfDemeter) expect them
+         * to be recorded: the fallback of {@link DataflowResult#getReachingDefinitions}
+         * only supports final fields and blank locals.
+         */
+        private void recordReachingDefsInDeadOperand(SpanInfo before, ASTExpression expr) {
+            expr.descendantsOrSelf().crossFindBoundaries()
+                .filterIs(ASTNamedReferenceExpr.class)
+                .forEach(ref -> {
+                    JVariableSymbol sym = ref.getReferencedSym();
+                    VarLocalInfo info = sym == null ? null : before.symtable.get(sym);
+                    if (info != null) {
+                        SpanInfo.updateReachingDefs(ref, sym, info);
+                    }
+                });
         }
 
         @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -573,10 +573,9 @@ public final class DataflowPass {
             // may not kill anything. Note that a CT constant cannot have
             // side effects.
             Object leftValue = orExpr.getLeftOperand().getConstValue();
-            boolean leftDecides = orExpr.getOperator() == BinaryOp.CONDITIONAL_OR
-                                  ? Boolean.TRUE.equals(leftValue)
-                                  : Boolean.FALSE.equals(leftValue);
-            if (leftDecides) {
+            if ((orExpr.getOperator() == BinaryOp.CONDITIONAL_OR && Boolean.TRUE.equals(leftValue))
+                    || (orExpr.getOperator() == BinaryOp.CONDITIONAL_AND && Boolean.FALSE.equals(leftValue))
+            ) {
                 recordReachingDefsInDeadOperand(cur, orExpr.getRightOperand());
             } else {
                 cur = linkConditional(cur, orExpr.getRightOperand(), thenState, elseState, false);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -4093,4 +4093,250 @@ public class TreeNode {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] Assignment in short-circuited condition operand is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok2 = true;
+        if (false && (ok2 = false)) {
+            return;
+        }
+        System.out.println(ok2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment after a negated constant operand is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (!true && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in short-circuited || operand is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (true || (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment after a non-literal constant false operand is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (1 == 2 && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Parenthesized constant operand still short-circuits #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if ((false) && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Constant chain operand short-circuits the rest of the condition #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (false && true && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Short-circuit inside a non-constant disjunction #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process(boolean flag) {
+        boolean ok = true;
+        if (flag || false && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in short-circuited loop condition is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        while (false && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in short-circuited ternary condition is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public int process() {
+        int x = 1;
+        int y = false && (x = 2) == 2 ? 1 : 2;
+        return x + y;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Constant field operand short-circuits the condition #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static final boolean DEBUG = false;
+
+    public void process() {
+        boolean ok = true;
+        if (DEBUG && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in evaluated || operand kills the initializer #5940</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (false || (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in evaluated &amp;&amp; operand kills the initializer #5940</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (true && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Constant false disjunction operand does not short-circuit #5940</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        boolean ok = true;
+        if (false && true || (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Field assignment in short-circuited condition operand is never evaluated #5940</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int f;
+
+    public Foo() {
+        this.f = 1;
+        if (false && (this.f = 2) == 2) {
+            return;
+        }
+        System.out.println(this.f);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Initializer whose only read is in a short-circuited condition operand, with reportUnusedVariables #5940</description>
+        <rule-property name="reportUnusedVariables">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void process() {
+        int x = 1;
+        if (false && x > 0) {
+            return;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -1347,4 +1347,29 @@ class MyObjectProvider {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Usages in a short-circuited condition operand have known reaching definitions #5940; the final chain anchors that the rule still reports</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>13</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    static class Holder {
+        Object getItem() { return null; }
+    }
+
+    static boolean f2(Object o) { return false; }
+
+    public void example(Bar b) {
+        Holder h = new Holder();
+        if (true || f2(h.getItem())) {
+            f2(h);
+        }
+        b.getC().doIt();
+    }
+}
+class C { void doIt() {} }
+class Bar { C getC() {} }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## Describe the PR

`DataflowPass` now stops processing the right operand of a `&&`/`||` when the left operand is a compile-time constant that already decides the value of the condition (JLS 15.23.2, 15.24.2). Such an operand is never evaluated, so the assignments it contains do not happen and cannot kill earlier definitions. This removes the reported false positive: the initializer of `ok2` was reported as unused although the reassignment in `if (false && (ok2 = false))` never executes.

The references of the skipped operand still get their reaching definitions recorded, computed from the state that reaches the operand. Without this, rules that query reaching definitions hit the fallback of `DataflowPass.getReachingDefinitions`, whose contract only covers final fields and blank locals: on the first push this crashed LawOfDemeter with a `ContextedAssertionError` on `com.sun.java.util.jar.pack.Attribute` in the openjdk-11 regression corpus (1 new error, and 20 LawOfDemeter findings of that file lost to error recovery). The regression test in `LawOfDemeter.xml` pins this.

The prune applies in condition position (if/while/ternary), where `linkConditional` models short-circuiting. Assignments in short-circuited operands in other expression positions (e.g. `boolean r = false && (b = false);`) are still over-approximated: modeling shortcut conditionals in every position needs its own control-flow treatment, which is out of scope here. I can prepare a follow-up if this direction is of interest. The same false positive also exists with a non-constant left operand when the then branch completes abruptly without an else branch: `if (flag && (b = false)) { return; } use(b);` reports the initializer as unused both on main and with this PR, although `flag == false` short-circuits and keeps the initializer. Covering that variant needs the no-else fall-through merge to account for paths on which the right operand was not evaluated, an engine-level change that is out of scope here (reported as #7018).

## Related issues

- Fix #5940

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

## Behavior delta

1. Intent: assignments in a condition operand that a compile-time constant short-circuits away are no longer treated as executing. In the default configuration the change can only remove reports. With `reportUnusedVariables=true` there is one addition family: an initializer whose only read lies inside the short-circuited operand is now reported, since that read never executes and the variable really is only initialized and never read (on main the dead read still counts as a use).
2. Delta: unit matrix of 16 new test-codes two-state green (9 fix encoders report the FP on main, 6 guards keep the correct behavior, 1 opt-in encoder pins the `reportUnusedVariables=true` addition); corpus delta over java-regression-tests@main, checkstyle-9.1 `src/main/java`, PMD's own sources and the jdk-11+28 `Attribute` file is exactly the FP sample itself; 0 unclassified deltas.
3. Recompute: the collapsed table below lists the matrix; the Regression Tester report on this PR covers the full corpus, I will cross-check it when it posts.

<details>
<summary>Unit matrix and corpus evidence</summary>

| test | kind | expected | main | this PR |
|---|---|---|---|---|
| `if (false && (ok2 = false))` (issue sample) | fix encoder | 0 | 1 | 0 |
| `if (true \|\| (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if (1 == 2 && (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if (!true && (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if ((false) && (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if (false && true && (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if (flag \|\| false && (ok = false))` | fix encoder | 0 | 1 | 0 |
| `if (DEBUG && (ok = false))` with `static final boolean DEBUG = false` | fix encoder | 0 | 1 | 0 |
| `Foo() { this.f = 1; if (false && (this.f = 2) == 2) ... }` (field) | fix encoder | 0 | 1 | 0 |
| `while (false && (ok = false))` | guard | 0 | 0 | 0 |
| `false && (x = 2) == 2 ? 1 : 2` (ternary) | guard | 0 | 0 | 0 |
| `if (false \|\| (ok = false))` | guard | 1 @L3 | 1 | 1 |
| `if (true && (ok = false))` | guard | 1 @L3 | 1 | 1 |
| `if (false && true \|\| (ok = false))` | guard | 1 @L3 | 1 | 1 |
| `if (true \|\| f2(h.getItem()))` with initialized local `h` (LawOfDemeter) | guard | 1 @L13 | 1 | 1 |
| `int x = 1; if (false && x > 0)` with `reportUnusedVariables=true` | opt-in addition | 1 @L3 | 0 | 1 |

The three UnusedAssignment guards expecting a violation pin the evaluated-operand cases (`false ||`, `true &&`, constant-false disjunction). With a value-blind mutant that prunes on any constant left operand, exactly these three fail (expected 1, got 0), so they are load-bearing. The LawOfDemeter guard pins the recording of reaching definitions in the skipped operand: a prune that skips exploration without recording fails it with `ContextedAssertionError: Should be a blank local variable` (the state of the first push), main and this PR both pass it.

Corpus check: `UnusedAssignment`, `ImmutableField`, `SingularField`, `LawOfDemeter`, `AvoidThrowingNullPointerException`, `ReturnEmptyCollectionRatherThanNull`, `ImplicitSwitchFallThrough`, `InvalidLogMessageFormat` were run before/after (same driver, `main` version of `DataflowPass` first on the classpath for the before run) over java-regression-tests@main (50 files), checkstyle-9.1 `src/main/java` (412 files), PMD's own `pmd-core`/`pmd-java` sources, and the jdk-11+28 `com.sun.java.util.jar.pack.Attribute` file that produced the regression tester error: 1946 vs 1945 violations, 0 errors on both sides, the only diff is the #5940 sample itself (probe file); `Attribute` yields the identical 26 findings on both sides. No auxclasspath was configured, so absolute counts can differ from the Regression Tester run, but the before/after comparison is symmetric. The corpus runs use the default configuration, so the `reportUnusedVariables=true` addition family is not visible there.

FP boundary (probe-verified): the false positive is observable when the then branch completes abruptly and there is no else branch. An `if` with an else branch, a normally completing then branch, `while`/`for` conditions, a ternary condition and `do {} while (...)` all stay clean on main; the report that remains on `do { b = true; } while (false && (b = false));` is a true positive, since the body assignment kills the initializer regardless of the condition.

</details>
