### PR TITLE
[core] Fix #7013: Only access PMDConfiguration.auxClasspath if it is actually set.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.LoggerFactory;
 
 import net.sourceforge.pmd.cache.internal.AnalysisCache;
@@ -341,6 +342,16 @@ public class PMDConfiguration extends AbstractConfiguration {
     }
 
     /**
+     * Returns true, if an auxClasspath is configured.
+     *
+     * @return true, if an auxClasspath is configured.
+     * @since 7.28.0
+     */
+    public boolean hasAuxClasspath() {
+        return auxClasspath != null;
+    }
+
+    /**
      * Gets the currently set auxClasspath.
      *
      * @return the configured auxClasspath. Might be {@code null}.
@@ -348,7 +359,7 @@ public class PMDConfiguration extends AbstractConfiguration {
      * @see #prependAuxClasspath(String)
      * @since 7.27.0
      */
-    public String getAuxClasspath() {
+    public @Nullable String getAuxClasspath() {
         if (classLoader != null) {
             throw new IllegalStateException("Can't mix setClasspath with getAuxClasspath!");
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -218,7 +218,7 @@ public final class PmdAnalysis implements AutoCloseable {
             //  CLI syntax is implemented. #2947
             props.setProperty(LanguagePropertyBundle.SUPPRESS_MARKER, config.getSuppressMarker());
             if (props instanceof JvmLanguagePropertyBundle) {
-                if (config.getAuxClasspath() != null) {
+                if (config.hasAuxClasspath()) {
                     props.setProperty(JvmLanguagePropertyBundle.AUX_CLASSPATH, config.getAuxClasspath());
                 } else {
                     ClassLoader externallyConfiguredClassLoader = config.getClassLoader();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
@@ -4,12 +4,14 @@
 
 package net.sourceforge.pmd;
 
+import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -26,9 +28,11 @@ import org.mockito.Mockito;
 
 import net.sourceforge.pmd.lang.Dummy2LanguageModule;
 import net.sourceforge.pmd.lang.DummyLanguageModule;
+import net.sourceforge.pmd.lang.JvmLanguagePropertyBundle;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageProcessor;
 import net.sourceforge.pmd.lang.LanguagePropertyBundle;
+import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.SimpleTestTextFile;
@@ -220,6 +224,22 @@ class PmdAnalysisTest {
 
         try (PmdAnalysis pmd = PmdAnalysis.create(config)) {
             assertThat(pmd.getLanguageProperties(language), sameInstance(configuredBundle));
+        }
+    }
+
+    @Test
+    void testCreateConfigWithCustomClasspath() {
+        LanguageRegistry registry = new LanguageRegistry(setOf(new FakeJvmLanguageModule()));
+        PMDConfiguration config = new PMDConfiguration(registry);
+        config.setClassLoader(this.getClass().getClassLoader());
+
+        assertDoesNotThrow(() -> PmdAnalysis.create(config));
+    }
+
+    private static class FakeJvmLanguageModule extends DummyLanguageModule {
+        @Override
+        public LanguagePropertyBundle newPropertyBundle() {
+            return new JvmLanguagePropertyBundle(this);
         }
     }
 }


### PR DESCRIPTION
## Describe the PR

PMDConfiguration.getAuxClasspath() checks if a classloader is configured and throws an exception if it is. This doesn't work for how it is used in PmdAnalysis.create().

This PR adds a way to check if an auxClasspath is configured or not.

## Related issues

- Fix #7013

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

