### PR TITLE
[ci] gh-actions: Update environment variables for setup-java 6.0.0

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -95,9 +95,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          server-username-env-var: MAVEN_USERNAME
+          server-password-env-var: MAVEN_PASSWORD
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -84,9 +84,9 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          server-username-env-var: MAVEN_USERNAME
+          server-password-env-var: MAVEN_PASSWORD
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:


### PR DESCRIPTION
## Describe the PR

The deploy-to-maven-central job has been showing [new warnings](https://github.com/pmd/pmd/actions/runs/33627557432/job/100238902115#step:3:36) since the update to setup-java 6.0.0
```none
Warning: The 'server-username' input is deprecated and may be removed in a future release. Please use 'server-username-env-var' instead.
Warning: The 'server-password' input is deprecated and may be removed in a future release. Please use 'server-password-env-var' instead.
Warning: The 'gpg-passphrase' input is deprecated and may be removed in a future release. Please use 'gpg-passphrase-env-var' instead.
```

Relevant extract from the setup-java README:
> Renamed environment-variable-name inputs so they are not mistaken for secret values:
> *   server-username -> server-username-env-var
> *   server-password -> server-password-env-var
> *   gpg-passphrase -> gpg-passphrase-env-var
>
> Deprecated aliases still work, but emit warnings.

This PR does the same renamings on our end.

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

