### PR TITLE
[html] Fix #6135: HtmlCpdLexer giving IndexOutOfBoundsException when script contains unescaped closing tag

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀️ New and noteworthy
 
 ### 🐛️ Fixed Issues
+* html
+    * [#6135](https://github.com/pmd/pmd/issues/6135): \[html] HtmlCpdLexer giving IndexOutOfBoundsException when script contains unescaped closing tag
 * java-codestyle
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-errorprone

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
@@ -60,8 +60,12 @@ class LineNumbers {
         } else if (n instanceof ASTHtmlElement && hasCloseElement) {
             nextIndex += 2 + n.getXPathNodeName().length() + 1; // </nodename>
         } else if (n instanceof ASTHtmlComment) {
-            nextIndex += 4 + 3; // <!-- and -->
-            nextIndex += ((ASTHtmlComment) n).getData().length();
+            // A synthetic Jsoup comment isn't backed by a real <!--...--> sequence
+            // It runs from '<' to the next bare '>' instead
+            boolean isRealComment = htmlString.startsWith("<!--", nextIndex);
+            String closeMarker = isRealComment ? "-->" : ">";
+            int closeIndex = htmlString.indexOf(closeMarker, nextIndex);
+            nextIndex = closeIndex < 0 ? htmlString.length() : closeIndex + closeMarker.length();
         } else if (n instanceof ASTHtmlTextNode) {
             nextIndex += textLength;
         } else if (n instanceof ASTHtmlCDataNode) {

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
@@ -28,7 +28,7 @@ class LineNumbers {
         if (n instanceof ASTHtmlDocument) {
             nextIndex = index;
         } else if (n instanceof ASTHtmlComment) {
-            nextIndex = htmlString.indexOf("<!--", nextIndex);
+            nextIndex = indexOfComment(nextIndex);
         } else if (n instanceof ASTHtmlElement) {
             nextIndex = htmlString.indexOf("<" + n.getXPathNodeName(), nextIndex);
             nodeLength = htmlString.indexOf(">", nextIndex) - nextIndex + 1;
@@ -74,6 +74,16 @@ class LineNumbers {
 
         setEndLocation(n, nextIndex - 1);
         return nextIndex;
+    }
+
+    /**
+     * Jsoup adds synthetic comment nodes when encountering malformed input.
+     * Due to this, there might be a comment node present that's not backed by any actual text content.
+     * This method handles the index lookup for these cases safely by returning {@code fromIndex} instead of {@code -1}.
+     */
+    private int indexOfComment(int fromIndex) {
+        int idx = htmlString.indexOf("<!--", fromIndex);
+        return idx < 0 ? fromIndex : idx;
     }
 
     private void setBeginLocation(AbstractHtmlNode<?> n, int index) {

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/LineNumbers.java
@@ -60,12 +60,7 @@ class LineNumbers {
         } else if (n instanceof ASTHtmlElement && hasCloseElement) {
             nextIndex += 2 + n.getXPathNodeName().length() + 1; // </nodename>
         } else if (n instanceof ASTHtmlComment) {
-            // A synthetic Jsoup comment isn't backed by a real <!--...--> sequence
-            // It runs from '<' to the next bare '>' instead
-            boolean isRealComment = htmlString.startsWith("<!--", nextIndex);
-            String closeMarker = isRealComment ? "-->" : ">";
-            int closeIndex = htmlString.indexOf(closeMarker, nextIndex);
-            nextIndex = closeIndex < 0 ? htmlString.length() : closeIndex + closeMarker.length();
+            nextIndex = endOfComent(nextIndex);
         } else if (n instanceof ASTHtmlTextNode) {
             nextIndex += textLength;
         } else if (n instanceof ASTHtmlCDataNode) {
@@ -88,6 +83,17 @@ class LineNumbers {
     private int indexOfComment(int fromIndex) {
         int idx = htmlString.indexOf("<!--", fromIndex);
         return idx < 0 ? fromIndex : idx;
+    }
+
+    /**
+    /* A synthetic Jsoup comment isn't backed by a real <!--...--> sequence
+    /* It runs from '<' to the next bare '>' instead
+     */
+    private int endOfComent(int nextIndex) {
+        boolean isRealComment = htmlString.startsWith("<!--", nextIndex);
+        String closeMarker = isRealComment ? "-->" : ">";
+        int closeIndex = htmlString.indexOf(closeMarker, nextIndex);
+        return closeIndex < 0 ? htmlString.length() : closeIndex + closeMarker.length();
     }
 
     private void setBeginLocation(AbstractHtmlNode<?> n, int index) {

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexerTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexerTest.java
@@ -30,4 +30,12 @@ class HtmlCpdLexerTest extends CpdTextComparisonTest {
     void metaTag() {
         doTest("MetaTag");
     }
+
+    /**
+     * @see <a href="https://github.com/pmd/pmd/issues/6135">Issue 6135</a>
+     */
+    @Test
+    void unescapedTagInScript() {
+        doTest("UnescapedTagInScript");
+    }
 }

--- a/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.html
+++ b/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.html
@@ -1,13 +1,7 @@
 <html>
 <head>
 <script type="text/javascript">
-(function(e, t) {
-    function() {
-        var t = {
-            html5Clone: i !== "<:nav></:nav>",
-        };
-    };
-}();
+html5Clone:i.createElement("nav").cloneNode(!0).outerHTML!=="<:nav></:nav>",r.innerHTML="<table><tr><td></td><td>t</td></tr></table>"
 </script>
 </head>
 </html>

--- a/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.html
+++ b/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+<script type="text/javascript">
+(function(e, t) {
+    function() {
+        var t = {
+            html5Clone: i !== "<:nav></:nav>",
+        };
+    };
+}();
+</script>
+</head>
+</html>

--- a/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.txt
+++ b/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.txt
@@ -4,17 +4,24 @@ L1
     [html]                                  1         7
     [\n]                                    7         7
 L2
-    [head]                                  1         6
+    [head]                                  1         7
     [\n]                                    7         7
 L3
-    [script]                                1         5
-    [\n(function(e, t) {\n    function([    32        37
+    [script]                                1         9
+    [\nhtml5Clone:i.createElement("nav"[    32        67
+L4
+    [#comment]                              68        74
+    [",r.innerHTML="]                       75        89
+    [table]                                 90        132
+    [tr]                                    97        124
+    [td]                                    101       109
+    [td]                                    110       119
+    [t]                                     114       114
+    ["\n]                                   133       134
+L5
+    [\n]                                    10        10
+L6
+    [\n]                                    8         8
 L7
-    [#comment]                              38        2
-L8
-    [",\n        };\n    };\n}();\n]        3         5
-L11
-    [\n]                                    6         6
-    [\n]                                    7         7
     [\n]                                    8         8
 EOF

--- a/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.txt
+++ b/pmd-html/src/test/resources/net/sourceforge/pmd/lang/html/cpd/testdata/UnescapedTagInScript.txt
@@ -1,0 +1,20 @@
+    [Image] or [Truncated image[            Bcol      Ecol
+L1
+    [#document]                             1         8
+    [html]                                  1         7
+    [\n]                                    7         7
+L2
+    [head]                                  1         6
+    [\n]                                    7         7
+L3
+    [script]                                1         5
+    [\n(function(e, t) {\n    function([    32        37
+L7
+    [#comment]                              38        2
+L8
+    [",\n        };\n    };\n}();\n]        3         5
+L11
+    [\n]                                    6         6
+    [\n]                                    7         7
+    [\n]                                    8         8
+EOF


### PR DESCRIPTION
<!-- Please, prefix the PR title with the language it applies to within brackets, such as [java] or [apex] -->

## Describe the PR

A workaround for handling the index lookup for Jsoup's synthetic comment nodes. These nodes are added on malformed input, but not backed by the actual html text. Our Jsoup parser uses `Parser.xmlParser()`, so it chokes on inputs like `</: ` inside a script tag.

The proper solution would probably be to use `Parser.htmlParser()`, but as noted in [this comment](https://github.com/pmd/pmd/issues/6135#issuecomment-5318581917), that would break too much behaviour.

Maybe switching to `htmlParser` would be another good item for https://github.com/pmd/pmd/issues/5703?


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #6135 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

