### PR TITLE
[java] Fix #7007: HardCodedCryptoKey detection for String(char[])

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -53,7 +53,9 @@ This is a {{ site.pmd.release_type }} release.
     * [#7009](https://github.com/pmd/pmd/issues/7009): \[java] ReplaceJavaUtilDate is suppressed by using pattern variable
 * java-multithreading
     * [#6297](https://github.com/pmd/pmd/issues/6297): \[java] AvoidUsingVolatile: Update documentation
-    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods 
+    * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods
+* java-security
+    * [#7007](https://github.com/pmd/pmd/issues/7007): \[java] HardCodedCryptoKey: False negative when a hard-coded key is constructed via new String(char[])
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -72,6 +72,16 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
                     && varAccess.getConstValue() instanceof String) {
                 asCtx(data).addViolation(varAccess);
             }
+        } else if (firstArgumentExpression instanceof ASTConstructorCall) {
+            ASTConstructorCall constructorCall = (ASTConstructorCall) firstArgumentExpression;
+            ASTArgumentList arguments = constructorCall.getArguments();
+            if (arguments.size() == 1
+                    && TypeTestUtil.isExactlyA(String.class, constructorCall.getTypeNode())
+                    && TypeTestUtil.isExactlyA(char[].class, arguments.get(0))) {
+                validateHardCodedCharArray(data, arguments.get(0));
+            } else {
+                addViolationForStringLiteral(data, firstArgumentExpression);
+            }
         } else if (firstArgumentExpression instanceof ASTArrayAllocation) {
             // hard coded array
             ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
@@ -83,11 +93,43 @@ abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulec
             asCtx(data).addViolation(firstArgumentExpression);
         } else {
             // string literal
-            ASTStringLiteral literal = firstArgumentExpression.descendantsOrSelf()
-                    .filterIs(ASTStringLiteral.class).first();
-            if (literal != null) {
-                asCtx(data).addViolation(literal);
+            addViolationForStringLiteral(data, firstArgumentExpression);
+        }
+    }
+
+    private void validateHardCodedCharArray(Object data, ASTExpression expression) {
+        if (expression instanceof ASTVariableAccess) {
+            ASTVariableId varDecl = ((ASTVariableAccess) expression).getReferencedSym().tryGetNode();
+            if (varDecl != null) {
+                validateHardCodedCharArray(data, varDecl.getInitializer());
             }
+        } else if (expression instanceof ASTArrayAllocation) {
+            ASTArrayInitializer arrayInit = ((ASTArrayAllocation) expression).getArrayInitializer();
+            if (isConstantCharArray(arrayInit)) {
+                asCtx(data).addViolation(arrayInit);
+            }
+        } else if (expression instanceof ASTArrayInitializer && isConstantCharArray((ASTArrayInitializer) expression)) {
+            asCtx(data).addViolation(expression);
+        }
+    }
+
+    private boolean isConstantCharArray(ASTArrayInitializer arrayInit) {
+        if (arrayInit == null) {
+            return false;
+        }
+        for (ASTExpression element : arrayInit) {
+            if (!(element.getConstValue() instanceof Character)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void addViolationForStringLiteral(Object data, ASTExpression expression) {
+        ASTStringLiteral literal = expression.descendantsOrSelf()
+                .filterIs(ASTStringLiteral.class).first();
+        if (literal != null) {
+            asCtx(data).addViolation(literal);
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/HardCodedCryptoKey.xml
@@ -123,6 +123,54 @@ public class Foo {
         ]]></code>
     </test-code>
     <test-code>
+        <description>[java] Hardcoded key constructed from char array #7007</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+
+public class Foo {
+    void encrypt() {
+        String key = new String(new char[] {'h', 'a', 'r', 'd', 'c', 'o', 'd', 'e', 'd', 'K', 'e', 'y'});
+        byte[] bytes = key.getBytes();
+        SecretKeySpec keySpec = new SecretKeySpec(bytes, "AES");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Dynamic char array converted to String, good</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+
+public class Foo {
+    void encrypt(String input) {
+        char[] chars = input.toCharArray();
+        String key = new String(chars);
+        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Dynamic element in char array converted to String, good</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.SecretKeySpec;
+
+public class Foo {
+    void encrypt(String input) {
+        String key = new String(new char[] {'h', input.charAt(0)});
+        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>[java] Hardcoded constant in parent interface #6191</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Summary

- detect hard-coded cryptographic keys constructed with `String(char[])`
- follow the character-array initializer while avoiding dynamic array contents
- add regression coverage for hard-coded and dynamic character arrays

## Testing

- `./mvnw -pl pmd-java -Dtest='net.sourceforge.pmd.lang.java.rule.security.*Test' test`
- `./mvnw -pl pmd-java -DskipTests checkstyle:check`
- `git diff --check`

Closes #7007
