### PR TITLE
[java] Work on #4787: remove remaining usages of @Image/Node.getImage()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAmbiguousName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAmbiguousName.java
@@ -71,6 +71,11 @@ public final class ASTAmbiguousName extends AbstractJavaExpr implements ASTRefer
 
     @Override
     public String getImage() {
+        return getName();
+    }
+
+    /** Returns the entire name, including periods if any. */
+    public String getName() {
         if (getFirstToken() == getLastToken()) {
             return getFirstToken().getImage();
         }
@@ -79,11 +84,6 @@ public final class ASTAmbiguousName extends AbstractJavaExpr implements ASTRefer
             tok.getImageCs().appendChars(sb);
         }
         return sb.toString();
-    }
-
-    /** Returns the entire name, including periods if any. */
-    public String getName() {
-        return getImage();
     }
 
     boolean wasProcessed() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBreakStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBreakStatement.java
@@ -24,6 +24,8 @@ public final class ASTBreakStatement extends AbstractStatement {
     private static final Function<Object, ASTStatement> BREAK_TARGET_MAPPER =
         NodeStream.asInstanceOf(ASTLoopStatement.class, ASTSwitchStatement.class);
 
+    private String label;
+
     ASTBreakStatement(int id) {
         super(id);
     }
@@ -38,7 +40,13 @@ public final class ASTBreakStatement extends AbstractStatement {
      * Returns the label, or null if there is none.
      */
     public @Nullable String getLabel() {
-        return getImage();
+        return label;
+    }
+
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.label = image;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTContinueStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTContinueStatement.java
@@ -25,6 +25,8 @@ public final class ASTContinueStatement extends AbstractStatement {
     private static final Function<Object, ASTLoopStatement> CONTINUE_TARGET_MAPPER =
         NodeStream.asInstanceOf(ASTLoopStatement.class);
 
+    private String label;
+
     ASTContinueStatement(int id) {
         super(id);
     }
@@ -35,12 +37,17 @@ public final class ASTContinueStatement extends AbstractStatement {
         return visitor.visit(this, data);
     }
 
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.label = image;
+    }
 
     /**
      * Returns the label, or null if there is none.
      */
     public @Nullable String getLabel() {
-        return getImage();
+        return label;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldAccess.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldAccess.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.types.JVariableSig.FieldSig;
 public final class ASTFieldAccess extends AbstractJavaExpr implements ASTNamedReferenceExpr, QualifiableExpression {
 
     private FieldSig typedSym;
+    private String fieldName;
 
 
     ASTFieldAccess(int id) {
@@ -55,10 +56,15 @@ public final class ASTFieldAccess extends AbstractJavaExpr implements ASTNamedRe
         return (ASTExpression) getChild(0);
     }
 
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.fieldName = image;
+    }
 
     @Override
     public String getName() {
-        return getImage();
+        return fieldName;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclaration.java
@@ -22,6 +22,7 @@ public final class ASTImportDeclaration extends AbstractJavaNode implements ASTT
     private boolean isImportOnDemand;
     private boolean isStatic;
     private boolean moduleImport;
+    private String importedName;
 
     ASTImportDeclaration(int id) {
         super(id);
@@ -70,7 +71,13 @@ public final class ASTImportDeclaration extends AbstractJavaNode implements ASTT
      * this is the name of the module.
      */
     public @NonNull String getImportedName() {
-        return super.getImage();
+        return importedName;
+    }
+
+
+    @Override
+    protected void setImage(String image) {
+        this.importedName = image;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLabeledStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLabeledStatement.java
@@ -15,6 +15,8 @@ package net.sourceforge.pmd.lang.java.ast;
  */
 public final class ASTLabeledStatement extends AbstractStatement {
 
+    private String label;
+
     ASTLabeledStatement(int id) {
         super(id);
     }
@@ -25,11 +27,17 @@ public final class ASTLabeledStatement extends AbstractStatement {
         return visitor.visit(this, data);
     }
 
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.label = image;
+    }
+
     /**
      * Returns the name of the label.
      */
     public String getLabel() {
-        return getImage();
+        return label;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
@@ -22,9 +22,16 @@ public final class ASTMemberValuePair extends AbstractJavaNode {
     public static final String VALUE_ATTR = "value";
 
     private boolean isShorthand;
+    private String name;
 
     ASTMemberValuePair(int id) {
         super(id);
+    }
+
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.name = image;
     }
 
     /**
@@ -32,7 +39,7 @@ public final class ASTMemberValuePair extends AbstractJavaNode {
      * This returns {@code "value"} if this is a shorthand declaration.
      */
     public String getName() {
-        return getImage();
+        return name;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
@@ -21,6 +21,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public final class ASTMethodCall extends AbstractInvocationExpr implements QualifiableExpression {
 
+    private String methodName;
+
     ASTMethodCall(int id) {
         super(id);
     }
@@ -49,8 +51,14 @@ public final class ASTMethodCall extends AbstractInvocationExpr implements Quali
     }
 
     @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.methodName = image;
+    }
+
+    @Override
     public @NonNull String getMethodName() {
-        return super.getImage();
+        return methodName;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
@@ -27,6 +27,7 @@ public final class ASTPackageDeclaration extends AbstractJavaNode implements Ann
 
     private TextRegion reportRegion;
     private JPackageSymbol symbol;
+    private String name;
 
     ASTPackageDeclaration(int id) {
         super(id);
@@ -54,7 +55,12 @@ public final class ASTPackageDeclaration extends AbstractJavaNode implements Ann
      * @since 6.30.0
      */
     public String getName() {
-        return super.getImage();
+        return name;
+    }
+
+    @Override
+    protected void setImage(String image) {
+        this.name = image;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
@@ -28,15 +28,24 @@ import net.sourceforge.pmd.lang.java.types.JTypeVar;
  */
 public final class ASTTypeParameter extends AbstractTypedSymbolDeclarator<JTypeParameterSymbol> implements Annotatable {
 
+    private String name;
+
     ASTTypeParameter(int id) {
         super(id);
+    }
+
+
+    @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.name = image;
     }
 
     /**
      * Returns the name of the type variable introduced by this declaration.
      */
     public String getName() {
-        return getImage();
+        return name;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableAccess.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableAccess.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.types.JVariableSig;
 public final class ASTVariableAccess extends AbstractJavaExpr implements ASTNamedReferenceExpr {
 
     private JVariableSig typedSym;
+    private String name;
 
     /**
      * Constructor promoting an ambiguous name to a variable reference.
@@ -52,8 +53,14 @@ public final class ASTVariableAccess extends AbstractJavaExpr implements ASTName
     }
 
     @Override
+    protected void setImage(String image) {
+        super.setImage(image);
+        this.name = image;
+    }
+
+    @Override
     public String getName() {
-        return getImage();
+        return name;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractExecutableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractExecutableDeclaration.java
@@ -25,7 +25,6 @@ abstract class AbstractExecutableDeclaration<T extends JExecutableSymbol>
 
     void setIdentToken(JavaccToken identToken) {
         this.identToken = identToken;
-        setImage(identToken.getImage());
     }
 
     @Override
@@ -60,6 +59,6 @@ abstract class AbstractExecutableDeclaration<T extends JExecutableSymbol>
 
     @Override
     public String getName() {
-        return super.getImage();
+        return identToken.getImage();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CognitiveComplexityVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CognitiveComplexityVisitor.java
@@ -174,7 +174,7 @@ public class CognitiveComplexityVisitor extends JavaVisitorBase<CognitiveComplex
     public Void visit(ASTContinueStatement node, State state) {
 
         // hack to detect if there is a label
-        boolean hasLabel = node.getImage() != null;
+        boolean hasLabel = node.getLabel() != null;
 
         if (hasLabel) {
             state.fundamentalComplexity();
@@ -186,7 +186,7 @@ public class CognitiveComplexityVisitor extends JavaVisitorBase<CognitiveComplex
     public Void visit(ASTBreakStatement node, State state) {
 
         // hack to detect if there is a label
-        boolean hasLabel = node.getImage() != null;
+        boolean hasLabel = node.getLabel() != null;
 
         if (hasLabel) {
             state.fundamentalComplexity();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
@@ -74,9 +74,9 @@ public class PrimitiveWrapperInstantiationRule extends AbstractJavaRulechainRule
         ASTStringLiteral stringLiteral = getFirstArgStringLiteralOrNull(arguments);
         ASTBooleanLiteral boolLiteral = getFirstArgBooleanLiteralOrNull(arguments);
         if (stringLiteral != null) {
-            if ("\"true\"".equals(stringLiteral.getImage())) {
+            if ("\"true\"".equals(stringLiteral.getLiteralText().toString())) {
                 ctx.addViolationWithMessage(node, messagePart + "(\"true\")`, prefer `Boolean.TRUE`");
-            } else if ("\"false\"".equals(stringLiteral.getImage())) {
+            } else if ("\"false\"".equals(stringLiteral.getLiteralText().toString())) {
                 ctx.addViolationWithMessage(node, messagePart + "(\"false\")`, prefer `Boolean.FALSE`");
             } else {
                 ctx.addViolationWithMessage(node, messagePart + "(\"...\")`, prefer `Boolean.valueOf`");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -89,9 +89,9 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
     public Object visit(ASTEnumConstant node, Object data) {
         // This inlines checkMatches because there's no variable declarator id
 
-        if (!getProperty(enumConstantRegex).matcher(node.getImage()).matches()) {
+        if (!getProperty(enumConstantRegex).matcher(node.getName()).matches()) {
             asCtx(data).addViolation(node, "enum constant",
-                                     node.getImage(),
+                                     node.getName(),
                                      getProperty(enumConstantRegex).toString());
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -96,7 +96,7 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTStringLiteral node, Object data) {
-        String image = node.getImage();
+        String image = node.getLiteralText().toString();
 
         // just catching strings of 'minLength' chars or more (including the
         // enclosing quotes)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SuspiciousOctalEscapeRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 
@@ -15,7 +16,7 @@ public class SuspiciousOctalEscapeRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTStringLiteral node, Object data) {
-        String image = node.getImage();
+        Chars image = node.getLiteralText();
         // trim quotes
         String s = image.substring(1, image.length() - 1);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -881,12 +881,12 @@ public final class DataflowPass {
 
         @Override
         public SpanInfo visit(ASTContinueStatement node, SpanInfo data) {
-            return data.global.continueTargets.doBreak(data, node.getImage());
+            return data.global.continueTargets.doBreak(data, node.getLabel());
         }
 
         @Override
         public SpanInfo visit(ASTBreakStatement node, SpanInfo data) {
-            return processBreakableStmt(node, data, () -> data.global.breakTargets.doBreak(data, node.getImage()));
+            return processBreakableStmt(node, data, () -> data.global.breakTargets.doBreak(data, node.getLabel()));
         }
 
         @Override

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -2278,7 +2278,7 @@ Foo[] x = { ... }; //Equivalent to above line
  (: Filter out ignored field name :)
  [not(ancestor::VariableDeclarator[1][@Name = 'serialVersionUID'])]
  [
-   some $num in tokenize(@Image, "[dDfFlLeE+\-]")
+   some $num in tokenize(@LiteralText, "[dDfFlLeE+\-]")
    satisfies not(
                   ( contains($num, ".")
                     and string-length(substring-before($num, ".")) <= $acceptableDecimalLength

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -641,19 +641,19 @@ the property ignoreMagicNumbers is not taken into account, if there are multiple
 //IfStatement/*[1]/*[pmd-java:nodeIs('Literal')]
     [not(pmd-java:nodeIs('NullLiteral'))]
     [not(pmd-java:nodeIs('BooleanLiteral'))]
-    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @LiteralText))]
 |
 (: consider also deeper expressions :)
 //IfStatement[$ignoreExpressions = false()]/*[1]//*[not(self::UnaryExpression[@Operator = '-'])]/*[pmd-java:nodeIs('Literal')]
     [not(pmd-java:nodeIs('NullLiteral'))]
     [not(pmd-java:nodeIs('BooleanLiteral'))]
-    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @LiteralText))]
 |
 (: consider negative literals :)
 //IfStatement[$ignoreExpressions = false()]/*[1]//UnaryExpression[@Operator = '-']/*[pmd-java:nodeIs('Literal')]
     [not(pmd-java:nodeIs('NullLiteral'))]
     [not(pmd-java:nodeIs('BooleanLiteral'))]
-    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @Image)))]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @LiteralText)))]
 |
 (: consider multiple literals in expressions :)
 //IfStatement[$ignoreExpressions = false()]/*[1][count(*[pmd-java:nodeIs('Literal')]
@@ -1520,7 +1520,7 @@ Use Environment.getExternalStorageDirectory() instead of "/sdcard"
         <priority>3</priority>
         <properties>
             <property name="xpath">
-                <value>//StringLiteral[starts-with(@Image,'"/sdcard')]</value>
+                <value>//StringLiteral[starts-with(@LiteralText,'"/sdcard')]</value>
             </property>
         </properties>
         <example>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -903,13 +903,13 @@ or StringBuffer.toString().length() == ...
 (: finds sb.toString().equals(someVar) where var is a final variable initialized with literal "" :)
 //MethodCall[pmd-java:matchesSig('_#equals(_)')
   and MethodCall[pmd-java:matchesSig('java.lang.AbstractStringBuilder#toString()')]
-  and ArgumentList/VariableAccess[@Name = //VariableDeclarator[StringLiteral[@Image='""']]
+  and ArgumentList/VariableAccess[@Name = //VariableDeclarator[StringLiteral[@LiteralText='""']]
                                             /VariableId[pmd-java:modifiers() = 'final']/@Name]]
 |
 (: finds sb.toString().equals("") :)
 //MethodCall[pmd-java:matchesSig('_#equals(_)')
   and MethodCall[pmd-java:matchesSig('java.lang.AbstractStringBuilder#toString()')]
-  and ArgumentList/StringLiteral[@Image='""']]
+  and ArgumentList/StringLiteral[@LiteralText='""']]
 ]]></value>
             </property>
         </properties>


### PR DESCRIPTION
## Describe the PR

This PR removes the remaining uses of @Image/Node.getImage() from pmd-java.

## Related issues

- See #4787

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

