### PR TITLE
[java] New rule: OnDemandImport

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,6 +26,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🌟️ New and Changed Rules
 #### New Rules
+*   The new Java rule {% rule java/bestpractices/OnDemandImport %} reports on-demand imports, also known as wildcard imports.
+    By default, static imports from JUnit and TestNG are allowed. The allowed static and type import packages
+    can be configured with `allowStaticImportsFrom` and `allowTypeImportsFrom`.
 *   The new java rule  {% rule java/errorprone/LongLiteralEndingWithLowercaseL %} finds long literals ending with l.
     That helps to avoid confusion between numbers ending with 1 and l. Capital L should be used to define long literals.
 *   The new java rule  {% rule java/bestpractices/TypeNameMismatch %} finds types that are not defined in a .java file

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
@@ -1,0 +1,59 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+public final class OnDemandImportRule extends AbstractJavaRulechainRule {
+
+    private static final PropertyDescriptor<List<String>> ALLOW_STATIC_IMPORTS_FROM =
+            PropertyFactory.stringListProperty("allowStaticImportsFrom")
+                    .desc("Packages from which static on-demand imports are allowed. Use * to allow all.")
+                    .defaultValues("org.junit.jupiter.api", "org.junit", "org.testng")
+                    .build();
+
+    private static final PropertyDescriptor<List<String>> ALLOW_TYPE_IMPORTS_FROM =
+            PropertyFactory.stringListProperty("allowTypeImportsFrom")
+                    .desc("Packages from which type on-demand imports are allowed. Use * to allow all.")
+                    .defaultValue(Collections.emptyList())
+                    .build();
+
+    public OnDemandImportRule() {
+        super(ASTImportDeclaration.class);
+        definePropertyDescriptor(ALLOW_STATIC_IMPORTS_FROM);
+        definePropertyDescriptor(ALLOW_TYPE_IMPORTS_FROM);
+    }
+
+    @Override
+    public Object visit(ASTImportDeclaration node, Object data) {
+        if (node.isImportOnDemand()) {
+            List<String> allowedPackages = getProperty(node.isStatic()
+                    ? ALLOW_STATIC_IMPORTS_FROM
+                    : ALLOW_TYPE_IMPORTS_FROM);
+            if (!isAllowed(node.getImportedName(), allowedPackages, node.isStatic())) {
+                ((RuleContext) data).addViolation(node);
+            }
+        }
+        return null;
+    }
+
+    private static boolean isAllowed(String importedName, List<String> allowedPackages, boolean isStatic) {
+        for (String allowedPackage : allowedPackages) {
+            if ("*".equals(allowedPackage)
+                    || importedName.equals(allowedPackage)
+                    || isStatic && importedName.startsWith(allowedPackage + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
@@ -47,14 +47,20 @@ public final class OnDemandImportRule extends AbstractJavaRulechainRule {
     }
 
     private boolean isAllowed(String importedName, boolean isStatic) {
-        List<String> allowedPackages = getProperty(isStatic
-                ? ALLOW_STATIC_IMPORTS_FROM
-                : ALLOW_TYPE_IMPORTS_FROM);
-        for (String allowedPackage : allowedPackages) {
-            if ("*".equals(allowedPackage)
-                    || importedName.equals(allowedPackage)
-                    || isStatic && importedName.startsWith(allowedPackage + ".")) {
-                return true;
+        if (isStatic) {
+            for (String allowedPackage : getProperty(ALLOW_STATIC_IMPORTS_FROM)) {
+                if ("*".equals(allowedPackage)
+                        || importedName.equals(allowedPackage)
+                        || importedName.startsWith(allowedPackage + ".")) {
+                    return true;
+                }
+            }
+        } else {
+            for (String allowedPackage : getProperty(ALLOW_TYPE_IMPORTS_FROM)) {
+                if ("*".equals(allowedPackage)
+                        || importedName.equals(allowedPackage)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportRule.java
@@ -13,6 +13,9 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.reporting.RuleContext;
 
+/**
+ * @since 7.28.0
+ */
 public final class OnDemandImportRule extends AbstractJavaRulechainRule {
 
     private static final PropertyDescriptor<List<String>> ALLOW_STATIC_IMPORTS_FROM =
@@ -36,17 +39,17 @@ public final class OnDemandImportRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
         if (node.isImportOnDemand()) {
-            List<String> allowedPackages = getProperty(node.isStatic()
-                    ? ALLOW_STATIC_IMPORTS_FROM
-                    : ALLOW_TYPE_IMPORTS_FROM);
-            if (!isAllowed(node.getImportedName(), allowedPackages, node.isStatic())) {
+            if (!isAllowed(node.getImportedName(), node.isStatic())) {
                 ((RuleContext) data).addViolation(node);
             }
         }
         return null;
     }
 
-    private static boolean isAllowed(String importedName, List<String> allowedPackages, boolean isStatic) {
+    private boolean isAllowed(String importedName, boolean isStatic) {
+        List<String> allowedPackages = getProperty(isStatic
+                ? ALLOW_STATIC_IMPORTS_FROM
+                : ALLOW_TYPE_IMPORTS_FROM);
         for (String allowedPackage : allowedPackages) {
             if ("*".equals(allowedPackage)
                     || importedName.equals(allowedPackage)

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1154,6 +1154,32 @@ class Foo {{
         </example>
     </rule>
 
+    <rule name="OnDemandImport"
+          language="java"
+          since="7.28.0"
+          message="Avoid on-demand imports"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.OnDemandImportRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#ondemandimport">
+        <description>
+On-demand imports (also called wildcard imports) should be used sparingly. By default, this rule allows
+static on-demand imports from JUnit and TestNG, and reports all type on-demand imports.
+
+Entries in `allowStaticImportsFrom` may name either a declaring type or a package containing declaring types.
+For example, `org.junit` allows `org.junit.Assert.*`, but not `org.junitx.Assert.*`. Entries in
+`allowTypeImportsFrom` match packages exactly, so `java.util` does not allow `java.util.concurrent.*`.
+Use `*` in either property to allow all on-demand imports of that kind.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+import static org.junit.jupiter.api.Assertions.*; // allowed by default
+import static java.lang.Math.*;                   // violation
+import java.util.*;                               // violation
+import java.util.List;                            // OK
+]]>
+        </example>
+    </rule>
+
     <rule name="OneDeclarationPerLine"
           language="java"
           since="5.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/OnDemandImportTest.java
@@ -1,0 +1,10 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class OnDemandImportTest extends PmdRuleTst {
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OnDemandImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OnDemandImport.xml
@@ -4,11 +4,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_1_1_1.xsd">
     <test-code>
-        <description>reports on-demand imports except supported test framework static imports</description>
+        <description>reports on-demand imports</description>
         <expected-problems>2</expected-problems>
-        <expected-linenumbers>2,3</expected-linenumbers>
+        <expected-linenumbers>1,2</expected-linenumbers>
         <code><![CDATA[
-import static org.junit.jupiter.api.Assertions.*;
 import static java.lang.Math.*;
 import java.util.*;
 import java.util.List;
@@ -106,6 +105,5 @@ import module java.base;
 
 class Foo { }
         ]]></code>
-        <source-type>java 25</source-type>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OnDemandImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OnDemandImport.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests https://pmd.sourceforge.net/rule-tests_1_1_1.xsd">
+    <test-code>
+        <description>reports on-demand imports except supported test framework static imports</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,3</expected-linenumbers>
+        <code><![CDATA[
+import static org.junit.jupiter.api.Assertions.*;
+import static java.lang.Math.*;
+import java.util.*;
+import java.util.List;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>allows static imports from all supported test frameworks by default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.*;
+import static org.testng.Assert.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>does not treat a similarly named package as an allowed subpackage</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import static org.junitx.Assert.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>configures multiple allowed static imports</description>
+        <rule-property name="allowStaticImportsFrom">com.acme.test,java.lang.Math</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+import static com.acme.test.Assertions.*;
+import static java.lang.Math.*;
+import static org.junit.Assert.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>type import exclusions match packages exactly</description>
+        <rule-property name="allowTypeImportsFrom">java.util</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+import java.util.*;
+import java.util.concurrent.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>asterisk allows all static imports</description>
+        <rule-property name="allowStaticImportsFrom">*</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import static java.lang.Math.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>asterisk allows all type imports</description>
+        <rule-property name="allowTypeImportsFrom">*</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.*;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ignores single imports</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+
+class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ignores module imports</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import module java.base;
+
+class Foo { }
+        ]]></code>
+        <source-type>java 25</source-type>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Adds the Java Best Practices rule `OnDemandImport` for reporting wildcard imports.

The rule reports type wildcard imports by default. Static wildcard imports from JUnit 4, JUnit Jupiter, and TestNG are allowed by default. Both behaviors can be configured with `allowStaticImportsFrom` and `allowTypeImportsFrom`; `*` allows every import in the corresponding category.

The rule uses `ASTImportDeclaration` through the rulechain and ignores single-type and Java module imports.

## Related issues

- Fix #7047

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)


