### PR TITLE
[java] Fix #7054: Capture wildcard components of intersection bounds

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -50,6 +50,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#6135](https://github.com/pmd/pmd/issues/6135): \[html] HtmlCpdLexer giving IndexOutOfBoundsException when script contains unescaped closing tag
 * java
     * [#6926](https://github.com/pmd/pmd/issues/6926): \[java] IllegalArgumentException (Mismatched list sizes) with inconsistent unresolved generic arity
+    * [#7054](https://github.com/pmd/pmd/issues/7054): \[java] IllegalArgumentException with wildcard in intersection-bound Iterable.forEach lambda
 * java-bestpractices
     * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignment is in conditional statement
 * java-codestyle

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -2063,12 +2063,16 @@ public final class TypeOps {
     /**
      * Methods and fields of a type variable come from its upper bound, which must be captured.
      * Capturing a type var does NOT capture its upper bound, so we must treat this
-     * case here.
+     * case here. Intersection bounds need their components captured individually.
      */
     public static JTypeMirror getMemberSource(JTypeMirror t) {
         if (t instanceof JTypeVar) {
             JTypeVar tv = (JTypeVar) t;
-            return capture(tv.getUpperBound());
+            return getMemberSource(tv.getUpperBound());
+        }
+        if (t instanceof JIntersectionType) {
+            return t.getTypeSystem().glb(
+                CollectionUtil.map(((JIntersectionType) t).getComponents(), TypeOps::getMemberSource));
         }
         return capture(t);
     }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.types.*
 import net.sourceforge.pmd.lang.test.ast.shouldBe
 import net.sourceforge.pmd.lang.test.ast.shouldMatchN
 import java.util.*
+import java.util.function.Consumer
 import java.util.function.Supplier
 import java.util.function.ToIntFunction
 import java.util.stream.Collector
@@ -19,6 +20,32 @@ import java.util.stream.Collectors
  * @author Clément Fournier
  */
 class CaptureInferenceTest : ProcessorTestSpec({
+
+    parserTest("Capture wildcard in intersection upper bound #7054") {
+        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+            """
+            class Reproducer {
+                interface Marker { }
+
+                static <C extends Iterable<?> & Marker> void visit(C values) {
+                    values.forEach(value -> { });
+                }
+            }
+            """.trimIndent()
+        )
+
+        val call = acu.firstMethodCall()
+        spy.shouldBeOk {
+            val captured = captureMatcher(`?`)
+            call.methodType.shouldMatchMethod(
+                named = "forEach",
+                declaredIn = Iterable::class[captured],
+                withFormals = listOf(Consumer::class[`?` `super` captured]),
+                returning = void
+            )
+            acu.varId("value") shouldHaveType ts.OBJECT
+        }
+    }
 
     parserTest("Test capture incompatibility recovery") {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
@@ -47,6 +47,66 @@ class CaptureInferenceTest : ProcessorTestSpec({
         }
     }
 
+    listOf(
+        "C extends Iterable<? extends Number> & Marker",
+        "C extends Iterable<? super Integer> & Marker",
+        "C extends Base & Iterable<? extends Number> & Marker",
+        "B extends Iterable<? extends Number> & Marker, C extends B"
+    ).forEach { typeParameters ->
+        parserTest("Capture intersection members <$typeParameters> #7054") {
+            val (acu, spy) = parser.parseWithTypeInferenceSpy(
+                """
+                class Reproducer {
+                    static class Base { }
+                    interface Marker { }
+
+                    static <$typeParameters> void visit(C values) {
+                        values.forEach(value -> { });
+                    }
+                }
+                """.trimIndent()
+            )
+
+            spy.shouldBeOk {
+                val isLowerBound = "? super" in typeParameters
+                val wildcard = if (isLowerBound) `?` `super` Integer::class.raw else `?` extends Number::class.raw
+                val captured = captureMatcher(wildcard)
+                acu.firstMethodCall().methodType.shouldMatchMethod(
+                    named = "forEach",
+                    declaredIn = Iterable::class[captured],
+                    withFormals = listOf(Consumer::class[`?` `super` captured]),
+                    returning = void
+                )
+                acu.varId("value") shouldHaveType if (isLowerBound) ts.OBJECT else Number::class.raw
+            }
+        }
+    }
+
+    parserTest("Capture wildcard in intersection cast #7054") {
+        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+            """
+            class Reproducer {
+                interface Marker { }
+
+                static void visit(Object values) {
+                    ((Iterable<?> & Marker) values).forEach(value -> { });
+                }
+            }
+            """.trimIndent()
+        )
+
+        spy.shouldBeOk {
+            val captured = captureMatcher(`?`)
+            acu.firstMethodCall().methodType.shouldMatchMethod(
+                named = "forEach",
+                declaredIn = Iterable::class[captured],
+                withFormals = listOf(Consumer::class[`?` `super` captured]),
+                returning = void
+            )
+            acu.varId("value") shouldHaveType ts.OBJECT
+        }
+    }
+
     parserTest("Test capture incompatibility recovery") {
         val (acu, spy) = parser.parseWithTypeInferenceSpy(
             """


### PR DESCRIPTION
## Describe the PR

I think this fixes #7054. Calling `forEach` through `C extends Iterable<?> & Marker` currently throws `IllegalArgumentException: <?> cannot be a wildcard bound`, even though the small reproducer compiles without warnings.

[TypeOps.getMemberSource](https://github.com/benstpierre/pmd/blob/7054-capture-intersection-bound/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java) captures a single parameterized upper bound, but an intersection reaches member lookup with its component wildcards uncaptured. This change follows type-variable upper bounds and captures each intersection component before resolving members.

The commits preserve the test-first sequence:

1. Add the exact seven-line reproducer to [CaptureInferenceTest](https://github.com/benstpierre/pmd/blob/7054-capture-intersection-bound/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt). On unmodified PMD, this test fails with the reported exception; the existing tests in that suite pass.
2. Apply the fix and add five related cases: upper/lower wildcard bounds, a class bound, a chained type parameter, and an intersection cast. Assertions check the inferred method signature and lambda parameter type as well as successful analysis.

I'd appreciate a review of whether this is the right place to handle intersection member capture, especially any type-system cases the tests miss.

## Related issues

- Fixes #7054

## Validation

On Corretto JDK 25.0.2 / macOS arm64:

```sh
./mvnw -B -ntp -pl pmd-java -am -PfastSkip -Dtest=CaptureInferenceTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -B -ntp -pl pmd-java -am -PfastSkip test
./mvnw -B -ntp -pl pmd-java -am checkstyle:check
```

The first command fails on the test-only commit and passes with the fix. The full Java reactor test run reports **16,701 tests, 31 skipped, zero failures/errors** (16,670 passed), including the six new regression cases. Checkstyle reports zero violations. All six Java snippets also compile with `javac --release 17 -Xlint:all -Werror`.

The full distribution build across all languages has not been run locally.

## Ready?

- [x] Added unit tests for the bug
- [x] Java reactor unit tests pass (including required core/test modules)
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by GitHub Actions)
- [x] Added in-code documentation and a release-note entry
