### PR TITLE
[java] InsecureCryptoIv: Detect unchanged default-initialized IV arrays

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -69,6 +69,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#6780](https://github.com/pmd/pmd/issues/6780): \[java] NonThreadSafeSingleton: False negative with property checkNonStaticMethods
 * java-security
     * [#7007](https://github.com/pmd/pmd/issues/7007): \[java] HardCodedCryptoKey: False negative when a hard-coded key is constructed via new String(char[])
+    * [#7015](https://github.com/pmd/pmd/issues/7015): \[java] InsecureCryptoIv: False negative for unchanged default-initialized arrays
 
 ### 🚨️ API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
@@ -4,6 +4,24 @@
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayDimExpr;
+import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+
 /**
  * Finds hardcoded static Initialization Vectors vectors used with cryptographic
  * operations.
@@ -20,9 +38,132 @@ package net.sourceforge.pmd.lang.java.rule.security;
  * @since 6.3.0
  *
  */
+// The inherited visit checks arguments without traversing children.
+@SuppressWarnings("PMD.DontCallSuperVisitWhenUsingRuleChain")
 public class InsecureCryptoIvRule extends AbstractHardCodedConstructorArgsVisitor {
 
     public InsecureCryptoIvRule() {
         super(javax.crypto.spec.IvParameterSpec.class);
+    }
+
+    @Override
+    public Object visit(ASTConstructorCall node, Object data) {
+        // This superclass checks arguments only; it does not traverse children.
+        super.visit(node, data);
+        // Subclasses may transform their arguments or override getIV().
+        if (!node.isAnonymousClass() && TypeTestUtil.isExactlyA(javax.crypto.spec.IvParameterSpec.class, node)
+                && node.getArguments().size() > 0) {
+            ASTExpression argument = node.getArguments().get(0);
+            if (isDefaultArray(argument)
+                    || (argument instanceof ASTVariableAccess && isUnchangedArray((ASTVariableAccess) argument, node))) {
+                asCtx(data).addViolation(node);
+            }
+        }
+        return data;
+    }
+
+    private boolean isDefaultArray(ASTExpression expression) {
+        if (!(expression instanceof ASTArrayAllocation) || !TypeTestUtil.isExactlyA(byte[].class, expression)) {
+            return false;
+        }
+        ASTArrayAllocation array = (ASTArrayAllocation) expression;
+        JavaNode dimension = array.getTypeNode().getDimensions().get(0);
+        if (!(dimension instanceof ASTArrayDimExpr)) {
+            return false;
+        }
+        // Constant folding also resolves known lengths that getConstValue() does not expose.
+        Object length = ((ASTArrayDimExpr) dimension).getLengthExpression().getConstFoldingResult().getValue();
+        // Array dimensions promote char values to int.
+        if (length instanceof Character) {
+            length = (int) (Character) length;
+        }
+        return array.getArrayInitializer() == null && length instanceof Number && ((Number) length).intValue() > 0;
+    }
+
+    private boolean isUnchangedArray(ASTVariableAccess argument, ASTConstructorCall constructor) {
+        if (argument.getReferencedSym() == null) {
+            return false;
+        }
+        ASTVariableId variable = argument.getReferencedSym().tryGetNode();
+        ASTBlock block = constructor.ancestors(ASTBlock.class).first();
+        if (variable == null || !variable.isLocalVariable() || block == null
+                || !isStraightLineStatement(constructor, block)) {
+            return false;
+        }
+
+        ASTExpression allocation = variable.getInitializer();
+        JavaNode initialAssignment = null;
+        if (allocation == null) {
+            ASTAssignmentExpression assignment = findInitialAssignment(variable, argument, block);
+            if (assignment == null) {
+                return false;
+            }
+            allocation = assignment.getRightOperand();
+            initialAssignment = assignment.getLeftOperand();
+        }
+        if (!isDefaultArray(allocation) || !isStraightLineStatement(allocation, block)) {
+            return false;
+        }
+
+        for (JavaNode usage : variable.getLocalUsages()) {
+            if (usage == argument || usage == initialAssignment
+                    || usage.getTextRegion().getStartOffset() >= constructor.getTextRegion().getEndOffset()) {
+                continue;
+            }
+            // A nested block may run repeatedly or capture the array for execution in a different order.
+            // Do not infer execution order from source positions in that case.
+            if (!isStraightLineStatement(usage, block)) {
+                return false;
+            }
+            if (!isReadOnlyUse(usage)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private ASTAssignmentExpression findInitialAssignment(ASTVariableId variable, ASTVariableAccess argument,
+                                                          ASTBlock block) {
+        ASTAssignmentExpression result = null;
+        // Accept one unconditional assignment before the use, without following reassignment chains.
+        for (JavaNode usage : variable.getLocalUsages()) {
+            if (usage.getParent() instanceof ASTAssignmentExpression) {
+                ASTAssignmentExpression assignment = (ASTAssignmentExpression) usage.getParent();
+                if (assignment.getLeftOperand() == usage && !assignment.isCompound()
+                        && assignment.getParent() instanceof ASTExpressionStatement
+                        && assignment.getParent().getParent() == block
+                        && assignment.getTextRegion().getEndOffset() < argument.getTextRegion().getStartOffset()) {
+                    if (result != null) {
+                        return null;
+                    }
+                    result = assignment;
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean isReadOnlyUse(JavaNode usage) {
+        boolean readsLength = usage.getParent() instanceof ASTFieldAccess
+            && "length".equals(((ASTFieldAccess) usage.getParent()).getName());
+        // IvParameterSpec copies its input. A previous construction does not change the array.
+        return readsLength || usage.getParent() instanceof ASTArgumentList && usage.getIndexInParent() == 0
+            && usage.getParent().getParent() instanceof ASTConstructorCall
+            && TypeTestUtil.isExactlyA(javax.crypto.spec.IvParameterSpec.class,
+                                      (ASTConstructorCall) usage.getParent().getParent());
+    }
+
+    private boolean isStraightLineStatement(JavaNode node, ASTBlock block) {
+        JavaNode statement = node;
+        while (statement.getParent() != null && statement.getParent() != block) {
+            if (statement instanceof ASTBlock || statement instanceof ASTLambdaExpression
+                    || statement instanceof ASTTypeDeclaration) {
+                return false;
+            }
+            statement = statement.getParent();
+        }
+        return statement.getParent() == block
+            && (statement instanceof ASTExpressionStatement || statement instanceof ASTLocalVariableDeclaration
+                || statement instanceof ASTReturnStatement);
     }
 }

--- a/pmd-java/src/main/resources/category/java/security.xml
+++ b/pmd-java/src/main/resources/category/java/security.xml
@@ -41,6 +41,19 @@ public class Foo {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_security.html#insecurecryptoiv">
         <description>
 Do not use hard coded initialization vector in cryptographic operations. Please use a randomly generated IV.
+
+The rule also detects default-initialized byte arrays with a positive constant
+length, such as `new byte[16]`. For local variables, this check is limited to
+straight-line code in the same block. It does not report when the array may have
+been modified or passed elsewhere before the `IvParameterSpec` construction.
+This check applies to `IvParameterSpec` itself. Named and anonymous subclasses
+are excluded because they may transform their arguments or override `getIV()`.
+Empty arrays are excluded.
+
+Default-initialized arrays are reported at each constructor call that copies the
+unchanged array, rather than at the allocation. Put `// NOPMD` on that constructor
+call's line to suppress such a report. Existing checks for explicit hard-coded
+values continue to report at the value's source.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
@@ -202,4 +202,768 @@ public class PosCase1 {
 }
         </code>
     </test-code>
+
+
+
+    <test-code>
+        <description>7015: Inline default initialization</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte[16]); // Report: the new array contains only zeros.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Unchanged local array</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: nothing has changed the array since allocation.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Separate assignment</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        byte[] iv;
+        iv = new byte[16];
+        new IvParameterSpec(iv); // Report: the single assignment is unconditional and in this block.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Constant expression size</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        final int size = 8;
+        byte[] iv = new byte[size * 2];
+        new IvParameterSpec(iv); // Report: constant folding gives a positive length of 16.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Offset and length overload</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv, 0, iv.length); // Report: reading the length does not modify the array.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Unknown helper may initialize the array</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        load(iv); // The helper may write to the array; its body is not analyzed.
+        new IvParameterSpec(iv); // No report: the contents are no longer known.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Random generator returned by a method</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    native SecureRandom getRand();
+
+    void example() {
+        byte[] iv = new byte[16];
+        getRand().nextBytes(iv);
+        new IvParameterSpec(iv); // No report: the array was passed to a method before use.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Newly constructed SecureRandom</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        new IvParameterSpec(iv); // No report: the array has been filled with random bytes.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Array copy destination</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(byte[] source) {
+        byte[] iv = new byte[16];
+        System.arraycopy(source, 0, iv, 0, 16);
+        new IvParameterSpec(iv); // No report: input bytes were copied into the IV.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Element write before use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        iv[0] = 1;
+        new IvParameterSpec(iv); // No report: any element write ends default-array tracking.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Alias before use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        byte[] alias = iv;
+        new IvParameterSpec(iv); // No report: the check does not follow aliases, even unused ones.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Stored in a field before use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    byte[] stored;
+
+    void example() {
+        byte[] iv = new byte[16];
+        stored = iv;
+        new IvParameterSpec(iv); // No report: the array has escaped into a field.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Reassignment before use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(byte[] source) {
+        byte[] iv = new byte[16];
+        iv = source;
+        new IvParameterSpec(iv); // No report: iv now refers to the caller-provided array.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Mutation after use does not hide the violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    void example() {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: this constructor copies the zeros before the fill.
+        new SecureRandom().nextBytes(iv);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Reassignment after use does not hide the violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(byte[] source) {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: the later reassignment cannot change this IV.
+        iv = source;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Only the construction before mutation is reported</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: the array is still unchanged at this use.
+        load(iv);
+        new IvParameterSpec(iv); // No report: the helper may have changed the contents.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Conditional initialization is not a definite assignment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(byte[] source) {
+        byte[] iv = source;
+        if (source.length > 0) {
+            iv = new byte[16];
+        }
+        new IvParameterSpec(iv); // No report: the allocation does not execute on every path.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Loop mutation may affect the next iteration</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        for (int i = 0; i < 2; i++) {
+            new IvParameterSpec(iv); // No report: a previous iteration may have filled iv.
+            load(iv);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Fresh allocation inside a loop</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        for (int i = 0; i < 2; i++) {
+            byte[] iv = new byte[16];
+            new IvParameterSpec(iv); // Report: every iteration starts with a fresh zero-filled array.
+            load(iv);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Lambda capture</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        Runnable r = () -> load(iv);
+        r.run();
+        new IvParameterSpec(iv); // No report: a lambda captures the array and may modify it.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Local class capture</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        class Loader {
+            void run() {
+                load(iv);
+            }
+        }
+        new Loader().run();
+        new IvParameterSpec(iv); // No report: the local class captures the array.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Mutation in a later constructor argument</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        // All arguments are evaluated before the constructor copies the array.
+        new IvParameterSpec(iv, load(iv), 16); // No report: load may change iv during argument evaluation.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Array field is outside local analysis</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    byte[] stored = new byte[16];
+
+    void example() {
+        new IvParameterSpec(stored); // No report: field contents are outside this local check.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Runtime array size is outside the supported scope</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(byte[] source) {
+        byte[] iv = new byte[source.length];
+        new IvParameterSpec(iv); // No report: the array length is not a known positive constant.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Different scopes with the same variable name</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        {
+            byte[] iv = new byte[16];
+            load(iv);
+        }
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: the earlier use belongs to a different variable.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Each unchanged use is reported</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    IvParameterSpec example() {
+        byte[] iv = new byte[16];
+        IvParameterSpec first = new IvParameterSpec(iv); // Report: the constructor copies the zeros.
+        return new IvParameterSpec(iv); // Report: the earlier constructor did not modify iv.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Later nested mutations do not hide the earlier violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    void example(boolean refill) {
+        byte[] iv = new byte[16];
+        new IvParameterSpec(iv); // Report: neither later block has executed yet.
+        if (refill) {
+            new SecureRandom().nextBytes(iv);
+        }
+        for (int i = 0; i < iv.length; i++) {
+            iv[i] = 1;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Conditional random fill before use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    void example(boolean refill) {
+        byte[] iv = new byte[16];
+        if (refill) {
+            new SecureRandom().nextBytes(iv);
+        }
+        new IvParameterSpec(iv); // No report: the conditional fill may have changed the array.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Allocation and use inside a try block</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        try {
+            byte[] iv = new byte[16];
+            new IvParameterSpec(iv); // Report: allocation and use are in the same try block.
+        } catch (RuntimeException e) {
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Zero-length arrays are excluded</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte[0]); // No report: this check requires a positive length.
+        byte[] iv = new byte[0];
+        new IvParameterSpec(iv); // No report: the same boundary applies to local variables.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Anonymous class capture</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    native int load(byte[] iv);
+
+    void example() {
+        byte[] iv = new byte[16];
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                load(iv);
+            }
+        };
+        r.run();
+        new IvParameterSpec(iv); // No report: the anonymous class captures and may modify iv.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Declaration in a for initializer</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example(boolean repeat) {
+        for (byte[] iv = new byte[16]; repeat; repeat = false) {
+            new IvParameterSpec(iv); // No report: the allocation is outside the loop body block.
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Subclass constructors may transform their arguments</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    static class TransformingIv extends IvParameterSpec {
+        TransformingIv(byte[] iv) {
+            super(transform(iv));
+        }
+
+        static byte[] transform(byte[] iv) {
+            new SecureRandom().nextBytes(iv);
+            return iv;
+        }
+    }
+
+    void example() {
+        byte[] iv = new byte[16];
+        new TransformingIv(iv); // No report: a subclass may change iv before its super call.
+        new TransformingIv(new byte[16]); // No report: inline arrays have the same restriction.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Subclass use prevents a later report</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    static class CustomIv extends IvParameterSpec {
+        CustomIv(byte[] iv) {
+            super(iv);
+        }
+    }
+
+    void example() {
+        byte[] iv = new byte[16];
+        new CustomIv(iv); // A subclass constructor is not assumed to be a read-only use.
+        new IvParameterSpec(iv); // No report: the earlier call may have modified the array.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Anonymous subclass overrides an inline default IV</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    IvParameterSpec example() {
+        return new IvParameterSpec(new byte[16]) {
+            private final byte[] randomIv = new byte[16];
+
+            {
+                new SecureRandom().nextBytes(randomIv);
+            }
+
+            @Override
+            public byte[] getIV() {
+                return randomIv.clone();
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Anonymous subclass overrides an unchanged local IV</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+import java.security.SecureRandom;
+
+class Example {
+    IvParameterSpec example() {
+        byte[] iv = new byte[16];
+        return new IvParameterSpec(iv) {
+            private final byte[] randomIv = new byte[16];
+
+            {
+                new SecureRandom().nextBytes(randomIv);
+            }
+
+            @Override
+            public byte[] getIV() {
+                return randomIv.clone();
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Char literal array size</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte['\020']); // Report: the char literal gives a length of 16.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Char cast array size</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte[(char) 16]); // Report: the cast still gives a positive constant length.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Char constant local array size</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        final char size = '\020';
+        byte[] iv = new byte[size];
+        new IvParameterSpec(iv); // Report: the unchanged local array contains 16 zero bytes.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Zero char array sizes are excluded</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte['\0']);
+        new IvParameterSpec(new byte[(char) 0]);
+        final char size = '\0';
+        byte[] iv = new byte[size];
+        new IvParameterSpec(iv); // No report: char sizes must also be positive.
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>7015: Anonymous subclass keeps existing array initializer reporting</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import javax.crypto.spec.IvParameterSpec;
+
+class Example {
+    void example() {
+        new IvParameterSpec(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}) { };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

`InsecureCryptoIv` misses `byte[] iv = new byte[16]; new IvParameterSpec(iv);` even when the array remains unchanged. This change reports default-initialized byte arrays with a positive constant length, both inline and through a local variable.

The local-variable check is deliberately conservative. It supports an initializer or a separate unconditional assignment in the same block, and checks uses before each `IvParameterSpec` construction. Element writes, unknown calls, aliases, and storage elsewhere prevent a report. Reading `iv.length` and an earlier `IvParameterSpec` construction are allowed because they do not modify the array. Later uses do not suppress an earlier violation, and uses in subsequent constructor arguments are checked before reporting.

The check does not follow aliases, reassignment chains, or control flow between blocks. It also does not analyze method bodies reached through calls. Only direct `IvParameterSpec` constructions are checked for default arrays: a subclass may transform its arguments. Empty arrays are excluded. The existing hard-coded-source check is preserved through `super.visit`, which does not traverse children in this superclass. A class-level suppression documents this exception to `DontCallSuperVisitWhenUsingRuleChain`.

The regression tests cover the reported case, all four non-reporting examples from the discussion, separate assignments, constant expressions, the offset/length overload, mutations and escapes, ordering, nested execution contexts, zero-length arrays, and subclass constructors. Each new case explains why a report is expected or excluded. The rule documentation and release notes are updated.

Default-array violations are reported at each constructor call, so later mutation does not hide an earlier violation and unchanged uses can be reported individually. Existing hard-coded-value checks retain their source locations. The rule documentation explains where to put `// NOPMD` for the new reports. Is this per-construction reporting location acceptable?

Examples of these source patterns:

- [Hyphanet/Fred's provider probe](https://github.com/hyphanet/fred/blob/d354cfddf6a1360e746be512a82d0aa9d46db6c2/src/freenet/crypt/ciphers/Rijndael.java#L64-L78) creates an unchanged, zero-filled local IV. This is an intentional provider compatibility test.
- [PacketProxy's `CryptUtils.decryptCBC`](https://github.com/DeNA/PacketProxy/blob/c84cba88accf96208abddbe77e417ce02f2dce3f/src/main/java/core/packetproxy/common/CryptUtils.java#L207-L220) copies input into the allocated IV before constructing `IvParameterSpec`.
- [jPOS's `SensitiveString.decrypt`](https://github.com/jpos/jPOS/blob/91c3ac10d1ac3b4a4faf9c57da1ccde988721350/jpos/src/main/java/org/jpos/security/SensitiveString.java#L96-L106) fills its allocated IV buffer from the input before transforming it and constructing `IvParameterSpec`.

## Related issues

- Fix #7015

## Validation

- Review revision: `./mvnw -B -pl pmd-java -Dtest=InsecureCryptoIvTest,HardCodedCryptoKeyTest verify` passes on JDK 21: 54 tests, no failures, errors, or skips. PMD, Checkstyle, and API compatibility checks also pass.
- Before the review revision, `./mvnw -B -pl pmd-java verify` passed on JDK 21: 10,191 tests, no failures or errors, 21 skipped.
- In the original regression run, restoring the upstream IV implementation caused 12 new positive cases to fail; existing cases and negative controls passed.
- The full-repository `./mvnw clean verify` has not been completed locally; its checklist item is left unchecked for CI.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)