### PR TITLE
[core] Fix off-by-one error in AbstractJjtreeNode.fitTokensToChildren()

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
@@ -92,7 +92,7 @@ public abstract class AbstractJjtreeNode<B extends AbstractJjtreeNode<B, N>, N e
         if (index == 0) {
             enlargeLeft(getChild(index).getFirstToken());
         }
-        if (index == getNumChildren()) {
+        if (index == getNumChildren() - 1) {
             enlargeRight(getChild(index).getLastToken());
         }
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
@@ -18,7 +18,7 @@ class AbstractJjtreeNodeTest {
 
     @Test
     void testDummy() {
-        // only necessary because junit cannot handle classes with only nested tests.
+        // Without this, the test will fail?!
         assertTrue(true);
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
@@ -1,3 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.ast.impl.javacc;
 
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.ast.impl.javacc;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,12 +16,18 @@ import org.junit.jupiter.api.Test;
 
 class AbstractJjtreeNodeTest {
 
+    @Test
+    void testDummy() {
+        // only necessary because junit cannot handle classes with only nested tests.
+        assertTrue(true);
+    }
+
     @Nested
     class InsertChild {
 
-        FooNode subject;
-        FooNode child0;
-        FooNode child1;
+        private FooNode subject;
+        private FooNode child0;
+        private FooNode child1;
 
         @BeforeEach
         void setup() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNodeTest.java
@@ -1,0 +1,88 @@
+package net.sourceforge.pmd.lang.ast.impl.javacc;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AbstractJjtreeNodeTest {
+
+    @Nested
+    class InsertChild {
+
+        FooNode subject;
+        FooNode child0;
+        FooNode child1;
+
+        @BeforeEach
+        void setup() {
+            subject = new FooNode(0);
+
+            child0 = createChildWithTokens(1);
+            child1 = createChildWithTokens(3);
+
+            subject.addChild(child0, 0);
+            subject.addChild(child1, 1);
+
+            subject.setFirstToken(child0.getFirstToken());
+            subject.setLastToken(child1.getLastToken());
+        }
+
+        @Test
+        void insertAtBeginning() {
+            FooNode newChild = createChildWithTokens(0);
+            when(newChild.getFirstToken().compareTo(any())).thenReturn(-1);
+
+            subject.insertChild(newChild, 0);
+
+            assertSame(newChild, subject.getFirstChild());
+            assertSame(newChild.getFirstToken(), subject.getFirstToken());
+            assertSame(child1.getLastToken(), subject.getLastToken());
+        }
+
+        @Test
+        void insertInTheMiddle() {
+            FooNode newChild = createChildWithTokens(2);
+
+            subject.insertChild(newChild, 1);
+
+            assertSame(newChild, subject.getChild(1));
+            assertSame(child0.getFirstToken(), subject.getFirstToken());
+            assertSame(child1.getLastToken(), subject.getLastToken());
+        }
+
+        @Test
+        void insertAtEnd() {
+            FooNode newChild = createChildWithTokens(4);
+            when(newChild.getLastToken().compareTo(any())).thenReturn(1);
+
+            subject.insertChild(newChild, 2);
+
+            assertSame(newChild, subject.getLastChild());
+            assertSame(child0.getFirstToken(), subject.getFirstToken());
+            assertSame(newChild.getLastToken(), subject.getLastToken());
+        }
+
+        private FooNode createChildWithTokens(int id) {
+            FooNode child = new FooNode(id);
+            child.setFirstToken(mock());
+            child.setLastToken(mock());
+            return child;
+        }
+    }
+
+    private static class FooNode extends AbstractJjtreeNode<FooNode, FooNode> {
+        private FooNode(int id) {
+            super(id);
+        }
+
+        @Override
+        public String getXPathNodeName() {
+            return "";
+        }
+    }
+}


### PR DESCRIPTION
## Describe the PR

I've been browsing through sonar, and I think it has found a valid off-by-one bug [here](https://sonarcloud.io/project/issues?id=net.sourceforge.pmd%3Apmd&open=AZ-BFDGZR0eOGOK6bdWy&s=IMPACT_RANK). If `index == getNumChildren()` is `true`, `getChild(index)` will throw an `ArrayIndexOutOfBoundsException`.

This issue never shows, because `insertChild` is only ever used to insert at the front, never at the back. Still, I think this problem should be fixed. But this means there is no reproduction test case to verify.

This PR closes the bug and adds unit tests for `AbstractJjtreeNode.insertChild`. I'm not quite happy with the latter. The mocks for `compareTo` on the tokens only do enough for the code to run, But they don't follow the contract of Comparable. Improvements are welcome.

## Related issues

- None

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [n/a] Added (in-code) documentation (if needed)

