### PR TITLE
chore: Remove protobuf-java from <dependencyManagement>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,13 +1181,6 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- transitive dependency through org.scalameta:trees_2.13 -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>4.36.1</version>
-            </dependency>
-
             <!-- Make sure to use the correct version that JUnit6 needs.
                  Kotest might bring a different version.
                  see junit.version -->


### PR DESCRIPTION
## Describe the PR

This PR removes protobuf-java from <dependencyManagement> in the toplevel `pom.xml`.

It was added to update a transitive dependency through
* pmd-scala
* -> org.scalameta:trees_2.13
* -> com.thesamet.scalapb:scalapb-runtime_2.13
* -> com.google.protobuf:protobuf-java

The dependency on scalapb-runtime_2.13 has since been removed, making this entry unnecessary.

The output of ./mvnw dependency:tree is identical before and after this change except for timing.

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

