### PR TITLE
[java] Fix #3124: Deprecate statementOrderMatters property of VariableCanBeInlined

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -56,6 +56,7 @@ This is a {{ site.pmd.release_type }} release.
 * java-bestpractices
     * [#5940](https://github.com/pmd/pmd/issues/5940): \[java] False positive in UnusedAssignment when assignment is in conditional statement
 * java-codestyle
+    * [#3124](https://github.com/pmd/pmd/issues/3124): \[java] UnnecessaryLocalBeforeReturn - remove property statementOrderMatters
     * [#5732](https://github.com/pmd/pmd/issues/5732): \[java] UnnecessaryCast false positive with package private methods
 * java-design
     * [#6513](https://github.com/pmd/pmd/issues/6513): \[java] SimplifyConditional: False negative when null check and instanceof are separated by other && conditions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+import static net.sourceforge.pmd.properties.internal.PropertyParsingUtil.DEPRECATED_RULE_PROPERTY_MARKER;
 
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
@@ -25,7 +26,11 @@ public class VariableCanBeInlinedRule extends AbstractJavaRulechainRule {
 
     private static final PropertyDescriptor<Boolean> STATEMENT_ORDER_MATTERS = booleanProperty("statementOrderMatters")
             .defaultValue(true)
-            .desc("If set to false this rule no longer requires the variable declaration and return/throw statement to be on consecutive lines. Any variable that is used solely in a return/throw statement will be reported.")
+            .desc(DEPRECATED_RULE_PROPERTY_MARKER + "Setting this to false relaxes the rule to report any variable "
+                    + "that is used solely in a return/throw statement, under the assumption that the statements "
+                    + "between the declaration and the return have no side effects. That assumption is unsafe and "
+                    + "following the suggestion could introduce an application bug (#3124). The property will be "
+                    + "removed; statement order will then always be considered.")
             .build();
 
     public VariableCanBeInlinedRule() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableCanBeInlinedTest.java
@@ -4,8 +4,23 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.internal.PropertyParsingUtil.DEPRECATED_RULE_PROPERTY_MARKER;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.test.PmdRuleTst;
 
 class VariableCanBeInlinedTest extends PmdRuleTst {
-    // no additional unit tests
+
+    @Test
+    void statementOrderMattersPropertyIsMarkedDeprecated() {
+        PropertyDescriptor<?> descriptor =
+                new VariableCanBeInlinedRule().getPropertyDescriptor("statementOrderMatters");
+
+        assertNotNull(descriptor);
+        assertTrue(descriptor.description().startsWith(DEPRECATED_RULE_PROPERTY_MARKER));
+    }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## Describe the PR

`statementOrderMatters=false` relaxes `VariableCanBeInlined` to report any variable used solely in a return/throw statement, assuming the statements between the declaration and the return have no side effects. The assumption is unsafe: following the suggestion can introduce an application bug. This is what #3124 asks to remove.

The property came from the deprecated `UnnecessaryLocalBeforeReturn` rule: it was carried over when `VariableCanBeInlined` was created in #5847 and was not discussed in that review.

This PR marks it deprecated via `DEPRECATED_RULE_PROPERTY_MARKER` (same mechanism as `MethodNamingConventions`):

- configuring it logs a warning at ruleset load,
- the rule documentation displays a deprecated label.

Behavior is unchanged: the default stays `statementOrderMatters=true`. The property can be removed later.

## Related issues

- Fixes #3124
  - the property is deprecated here; removal and the smarter analysis from the issue's expected outcome stay open.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

## Regression

No rule behavior change: the property default and the rule logic are untouched, only the property description changed — expect zero new violations in the regression tester. The four `statementOrderMatters=false` test cases in the rule's test XML still pass and now log the deprecation warning on stderr, which is the intended new behavior.
