### PR TITLE
[java] Fix #7018: UnusedAssignment false positive for assignment in condition operand

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -578,10 +578,24 @@ public final class DataflowPass {
             ) {
                 recordReachingDefsInDeadOperand(cur, orExpr.getRightOperand());
             } else {
+                // The state that reaches the right operand is also the
+                // outcome where the left operand alone decided the condition,
+                // so the right operand may be skipped on it. The operands are
+                // evaluated in the state that may alias thenState (an if
+                // without else), in which the strong updates of the right
+                // operand destroy the reaching defs of that skip outcome.
+                Map<JVariableSymbol, VarLocalInfo> skipState =
+                        orExpr.getOperator() == BinaryOp.CONDITIONAL_OR && Boolean.FALSE.equals(leftValue)
+                        || orExpr.getOperator() == BinaryOp.CONDITIONAL_AND && Boolean.TRUE.equals(leftValue)
+                        ? null : new LinkedHashMap<>(before.symtable);
                 cur = linkConditional(cur, orExpr.getRightOperand(), thenState, elseState, false);
                 thenState.absorb(cur);
 
                 elseState.absorb(cur);
+
+                if (skipState != null && thenState == before) { // NOPMD CompareObjectsWithEqual
+                    CollectionUtil.mergeMaps(before.symtable, skipState, VarLocalInfo::merge);
+                }
             }
 
             return cur;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -4339,4 +4339,187 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a condition operand may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() && (ok = false)) {
+            return;
+        }
+        System.out.println(ok); // reads the initializer when flag() is false
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in an evaluated || operand of an abrupt branch kills the initializer #7018</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() || (ok = false)) {
+            return;
+        }
+        System.out.println(ok); // the fall-through implies ok was assigned
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a condition operand with a normally completing branch #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() && (ok = false)) {
+            System.out.println("then");
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a condition operand with an else branch #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() && (ok = false)) {
+            return;
+        } else {
+            System.out.println("else");
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a loop condition operand may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        while (flag() && (ok = false)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a ternary condition operand may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        int x = flag() && (ok = false) ? 1 : 2;
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a compound condition operand may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() && ((ok = false) == true)) {
+            return;
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Assignment in a condition operand before a throwing branch may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        boolean ok = true;
+        if (flag() && (ok = false)) {
+            throw new IllegalStateException();
+        }
+        System.out.println(ok);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] Field assignment in a condition operand may be skipped #7018</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int f;
+
+    static boolean flag() {
+        return Math.random() < 0.5;
+    }
+
+    public void process() {
+        this.f = 1;
+        if (flag() && (this.f = 2) == 2) {
+            return;
+        }
+        System.out.println(this.f);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## Describe the PR

`if (flag() && (ok = false))` reported `The initializer for variable 'ok' is never used` although the path where `flag()` returns false skips the assignment and reads the initializer.

Root cause: `makeConditional` reuses `before` as the else state when the if has no else branch. The right operand is evaluated in that shared state, so its strong update destroys the reaching defs of the outcome where the left operand alone decided the condition.

Fix: snapshot the reaching defs before evaluating the right operand and merge them back when `thenState` aliases the shared state and the left operand does not force the evaluation. Constant left operands keep the dead-operand and forced-evaluation handling of #5940.

Known boundary: with an assignment in the left subexpression of an outer `&&` and an abruptly completing then branch (`flag() && (ok = false) && (ok2 = true)`), one false positive remains; this fix reduces it from two.

## Related issues

- Fix #7018

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

